### PR TITLE
Fix reconnection cleanup timer

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -64,7 +64,10 @@ socket.on('joinRoom', ({ roomId, playerName, originalPosition, originalId }) => 
       
       if (player && player.name === playerName) {
         console.log(`Reconexão do jogador ${playerName} na posição ${position}`);
-        
+
+        // Cancelar limpeza da sala se estava agendada
+        game.clearCleanupTimer();
+
         // Atualizar o ID do socket
         player.id = socket.id;
         
@@ -107,7 +110,10 @@ socket.on('joinRoom', ({ roomId, playerName, originalPosition, originalId }) => 
   
   if (existingPlayerIndex !== -1) {
     console.log(`Reconexão do jogador ${playerName} na sala ${roomId}`);
-    
+
+    // Cancelar limpeza da sala se estava agendada
+    game.clearCleanupTimer();
+
     // Atualizar o ID do socket para o jogador existente
     const oldId = game.players[existingPlayerIndex].id;
     game.players[existingPlayerIndex].id = socket.id;
@@ -316,6 +322,9 @@ socket.on('requestGameState', ({ roomId, playerName }) => {
   const playerIndex = game.players.findIndex(p => p.name === playerName);
   
   if (playerIndex !== -1) {
+    // Cancelar limpeza da sala se estava agendada
+    game.clearCleanupTimer();
+
     // Atualizar o ID do socket para o jogador
     const oldId = game.players[playerIndex].id;
     game.players[playerIndex].id = socket.id;


### PR DESCRIPTION
## Summary
- prevent game rooms from being deleted mid-game
- clear cleanup timer when players reconnect

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f505643e8832aa4df00e78cb6b4fc