### PR TITLE
Add manual team confirmation before starting game

### DIFF
--- a/public/js/index.js
+++ b/public/js/index.js
@@ -37,6 +37,7 @@ document.addEventListener('DOMContentLoaded', () => {
         socket.on('roomJoined', handleRoomJoined);
         socket.on('updatePlayers', handleUpdatePlayers);
         socket.on('teamsSet', handleTeamsSet);
+        socket.on('teamsReady', handleTeamsReady);
         socket.on('gameStarted', handleGameStarted);
         socket.on('error', handleError);
     }
@@ -78,6 +79,14 @@ document.addEventListener('DOMContentLoaded', () => {
         
         // Mostrar configuração de times se houver 4 jogadores e o usuário é o criador
         if (players.length === 4 && isRoomCreator) {
+            teamsSetup.classList.remove('hidden');
+            waitingMessage.classList.add('hidden');
+            populateTeamLists();
+        }
+    }
+
+    function handleTeamsReady() {
+        if (isRoomCreator) {
             teamsSetup.classList.remove('hidden');
             waitingMessage.classList.add('hidden');
             populateTeamLists();

--- a/server/game.js
+++ b/server/game.js
@@ -137,11 +137,10 @@ startGame() {
   this.currentPlayerIndex = 0;
   console.log(`Primeiro jogador escolhido: índice ${this.currentPlayerIndex}`);
   
-  // Definir times: 0 e 2 vs 1 e 3
-  this.teams = [
-    [this.players[0], this.players[2]],
-    [this.players[1], this.players[3]]
-  ];
+  // Garantir que os times estejam definidos
+  if (this.teams[0].length !== 2 || this.teams[1].length !== 2) {
+    this.setupTeams();
+  }
   console.log(`Times definidos: ${this.teams[0][0].name}/${this.teams[0][1].name} vs ${this.teams[1][0].name}/${this.teams[1][1].name}`);
   
   this.isActive = true;

--- a/server/server.js
+++ b/server/server.js
@@ -16,6 +16,23 @@ app.use(express.static(path.join(__dirname, '../public')));
 // Armazenar salas e jogos ativos
 const rooms = new Map();
 
+function launchGame(game) {
+  const roomId = game.roomId;
+
+  game.startGame();
+
+  const gameState = game.getGameState();
+  io.to(roomId).emit('gameStarted', gameState);
+
+  const currentPlayer = game.getCurrentPlayer();
+  if (currentPlayer && currentPlayer.id) {
+    currentPlayer.cards.push(game.drawCard());
+    io.to(currentPlayer.id).emit('yourTurn', {
+      cards: currentPlayer.cards
+    });
+  }
+}
+
 io.on('connection', (socket) => {
   console.log('Novo usuário conectado:', socket.id);
 
@@ -180,44 +197,10 @@ socket.on('joinRoom', ({ roomId, playerName, originalPosition, originalId }) => 
   
   console.log(`${playerName} entrou na sala ${roomId}`);
   
-  // Se a sala estiver completa, iniciar o jogo
+  // Se a sala estiver completa, avisar o criador para definir os times
   if (game.players.length === 4) {
-    console.log(`Sala ${roomId} completa com 4 jogadores, iniciando jogo`);
-    
-    try {
-      game.setupTeams();
-      console.log(`Times configurados para sala ${roomId}`);
-      
-      game.startGame();
-      console.log(`Jogo iniciado para sala ${roomId}`);
-      
-      // Enviar estado inicial do jogo para todos
-      const gameState = game.getGameState();
-      console.log(`Estado do jogo gerado para sala ${roomId}`);
-      
-      io.to(roomId).emit('gameStarted', gameState);
-      console.log(`Evento 'gameStarted' enviado para sala ${roomId}`);
-      
-      // Notificar o primeiro jogador que é sua vez
-      const currentPlayer = game.getCurrentPlayer();
-      console.log(`Jogador atual: ${currentPlayer ? currentPlayer.name : 'nenhum'}`);
-      
-      if (currentPlayer && currentPlayer.id) {
-        // Comprar uma carta para o jogador atual (primeira rodada)
-        currentPlayer.cards.push(game.drawCard());
-        console.log(`Enviando cartas para ${currentPlayer.name}:`, JSON.stringify(currentPlayer.cards));
-        
-        io.to(currentPlayer.id).emit('yourTurn', {
-          cards: currentPlayer.cards
-        });
-        console.log(`Notificação 'yourTurn' enviada para jogador ${currentPlayer.id}`);
-      } else {
-        console.log(`ERRO: Não foi possível determinar o jogador atual`);
-      }
-    } catch (error) {
-      console.error(`ERRO ao iniciar o jogo: ${error.message}`);
-      console.error(error.stack);
-    }
+    const creatorId = game.players[0].id;
+    io.to(creatorId).emit('teamsReady');
   }
 });
 
@@ -436,6 +419,27 @@ socket.on('makeJokerMove', ({ roomId, pieceId, targetPieceId, cardIndex }) => {
     
     game.setCustomTeams(teams);
     io.to(roomId).emit('teamsSet', game.getTeamsInfo());
+
+    if (!game.isActive) {
+      launchGame(game);
+    }
+  });
+
+  // Iniciar jogo manualmente pelo criador
+  socket.on('startGame', ({ roomId }) => {
+    const game = rooms.get(roomId);
+
+    if (!game || game.players.length !== 4) {
+      socket.emit('error', 'Não é possível iniciar o jogo agora');
+      return;
+    }
+
+    if (game.isActive) {
+      socket.emit('error', 'Jogo já está ativo');
+      return;
+    }
+
+    launchGame(game);
   });
 
   // Jogador seleciona peça e carta


### PR DESCRIPTION
## Summary
- avoid starting the game immediately after the fourth player joins
- add helper `launchGame` to initialize and begin a game instance
- ensure `startGame` keeps custom teams if already set
- allow teams to be defined and game started through new `startGame` event or automatically after `setTeams`
- notify room creator with `teamsReady` so they can pick teams
- update lobby client to handle `teamsReady` event

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f50601868832a871f834d9d93d768