### PR TITLE
Fix player reconnection and board layout

### DIFF
--- a/public/js/game.js
+++ b/public/js/game.js
@@ -47,9 +47,10 @@ document.addEventListener('DOMContentLoaded', () => {
     // Inicializar o jogo
    // No arquivo game.js - Modifique a função init
 function init() {
-  // Obter roomId da URL
+  // Obter roomId e playerId da URL
   const urlParams = new URLSearchParams(window.location.search);
   roomId = urlParams.get('roomId');
+  playerId = urlParams.get('playerId');
   
   if (!roomId) {
     alert('Sala não especificada');
@@ -58,7 +59,7 @@ function init() {
   }
   
   // Recuperar dados do jogador do localStorage
-  const playerKey = `game_${roomId}_player`;
+  const playerKey = `game_${roomId}_player_${playerId}`;
   const playerDataString = localStorage.getItem(playerKey);
   
   if (!playerDataString) {
@@ -131,7 +132,7 @@ function handleRoomJoined(data) {
     console.log('Posição do jogador atualizada para:', playerPosition);
     
     // Atualizar o localStorage com a posição atualizada
-    const playerKey = `game_${roomId}_player`;
+    const playerKey = `game_${roomId}_player_${playerId}`;
     const playerDataString = localStorage.getItem(playerKey);
     
     if (playerDataString) {
@@ -148,7 +149,7 @@ function handleRoomJoined(data) {
   // Se for uma reconexão, solicitar o estado atual do jogo
   if (data.isReconnection) {
     console.log('Reconectado à sala, solicitando estado do jogo');
-    const playerKey = `game_${roomId}_player`;
+    const playerKey = `game_${roomId}_player_${playerId}`;
     let storedName = null;
     const stored = localStorage.getItem(playerKey);
     if (stored) {
@@ -172,7 +173,7 @@ function handlePlayerInfo(data) {
 
   if (data.playerPosition !== undefined) {
     playerPosition = data.playerPosition;
-    const playerKey = `game_${roomId}_player`;
+    const playerKey = `game_${roomId}_player_${playerId}`;
     const playerDataString = localStorage.getItem(playerKey);
     if (playerDataString) {
       try {

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -124,7 +124,7 @@ function handleGameStarted(gameState) {
   }
   
   // Criar um identificador único para este jogador
-  const playerKey = `game_${gameState.roomId}_player`;
+  const playerKey = `game_${gameState.roomId}_player_${playerId}`;
   
   // Salvar informações do jogador de forma mais segura
   const playerData = {
@@ -140,8 +140,8 @@ function handleGameStarted(gameState) {
   console.log(`Dados do jogador salvos: ${JSON.stringify(playerData)}`);
   
   // Redirecionar para a página do jogo
-  console.log(`Redirecionando para game.html?roomId=${gameState.roomId}`);
-  window.location.href = `/game.html?roomId=${gameState.roomId}`;
+  console.log(`Redirecionando para game.html?roomId=${gameState.roomId}&playerId=${playerId}`);
+  window.location.href = `/game.html?roomId=${gameState.roomId}&playerId=${playerId}`;
 }
 
 function handleError(message) {

--- a/server/utils.js
+++ b/server/utils.js
@@ -89,11 +89,11 @@ boardLayout[4][16] = 'e';
 boardLayout[4][17] = 'e';
 
 // Fundo-Direita
-boardLayout[13][15] = 'e';
-boardLayout[14][15] = 'e';
-boardLayout[15][15] = 'e';
-boardLayout[16][15] = 'e';
-boardLayout[17][15] = 'e';
+boardLayout[13][14] = 'e';
+boardLayout[14][14] = 'e';
+boardLayout[15][14] = 'e';
+boardLayout[16][14] = 'e';
+boardLayout[17][14] = 'e';
 
 // Fundo-Esquerda
 boardLayout[14][1] = 'e';


### PR DESCRIPTION
## Summary
- uniquely store player data per player ID
- pass playerId when starting game and retrieving game state
- adjust board layout so the bottom-right victory lane matches others

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f53dc088c832a95f868385bfa4bca