### PR TITLE
Fix misaligned home stretch and piece orientation

### DIFF
--- a/public/js/game.js
+++ b/public/js/game.js
@@ -403,9 +403,12 @@ function updateBoard() {
   
   // Marcar células especiais
   markSpecialCells();
-  
+
   // Posicionar peças
   positionPieces();
+
+  // Reaplicar rotação para ajustar a orientação das peças
+  rotateBoard();
   
   console.log('Tabuleiro atualizado');
 }

--- a/server/server.js
+++ b/server/server.js
@@ -521,60 +521,6 @@ socket.on('makeMove', ({ roomId, pieceId, cardIndex }) => {
   }
 });
 
-// No arquivo server.js - Adicione este evento
-socket.on('discardCard', ({ roomId, cardIndex }) => {
-  console.log(`Jogador ${socket.id} descartando carta ${cardIndex}`);
-  const game = rooms.get(roomId);
-  
-  if (!game || !game.isActive) {
-    socket.emit('error', 'Jogo não está ativo');
-    return;
-  }
-  
-  const currentPlayer = game.getCurrentPlayer();
-  if (!currentPlayer) {
-    socket.emit('error', 'Jogador atual não encontrado');
-    return;
-  }
-  
-  if (currentPlayer.id !== socket.id) {
-    socket.emit('error', 'Não é sua vez');
-    return;
-  }
-  
-  if (cardIndex < 0 || cardIndex >= currentPlayer.cards.length) {
-    socket.emit('error', 'Índice de carta inválido');
-    return;
-  }
-  
-  const card = currentPlayer.cards[cardIndex];
-  console.log(`Jogador ${currentPlayer.name} descartando carta ${card.suit}${card.value}`);
-  
-  // Descartar a carta
-  game.discardPile.push(card);
-  currentPlayer.cards.splice(cardIndex, 1);
-  
-  // Atualizar estado do jogo para todos
-  io.to(roomId).emit('gameStateUpdate', game.getGameState());
-  
-  // Enviar cartas atualizadas para o jogador
-  socket.emit('updateCards', {
-    cards: currentPlayer.cards
-  });
-  
-  // Passar para o próximo jogador
-  game.nextTurn();
-  
-  // Notificar próximo jogador
-  const nextPlayer = game.getCurrentPlayer();
-  
-  // Comprar uma carta para o próximo jogador
-  nextPlayer.cards.push(game.drawCard());
-  
-  io.to(nextPlayer.id).emit('yourTurn', {
-    cards: nextPlayer.cards
-  });
-});
 
 
 

--- a/server/utils.js
+++ b/server/utils.js
@@ -89,11 +89,12 @@ boardLayout[4][16] = 'e';
 boardLayout[4][17] = 'e';
 
 // Fundo-Direita
-boardLayout[13][14] = 'e';
-boardLayout[14][14] = 'e';
-boardLayout[15][14] = 'e';
-boardLayout[16][14] = 'e';
-boardLayout[17][14] = 'e';
+// Ajuste da coluna para alinhar com o corredor utilizado na lógica do jogo
+boardLayout[13][15] = 'e';
+boardLayout[14][15] = 'e';
+boardLayout[15][15] = 'e';
+boardLayout[16][15] = 'e';
+boardLayout[17][15] = 'e';
 
 // Fundo-Esquerda
 boardLayout[14][1] = 'e';


### PR DESCRIPTION
## Summary
- adjust green player's victory lane coordinates
- remove duplicate `discardCard` event handler
- re-apply board rotation after positioning pieces so numbers face correctly

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_683f59ff5f6c832aad07fe816efcf476