### PR TITLE
Fix player 3 victory zone position

### DIFF
--- a/public/js/game.js
+++ b/public/js/game.js
@@ -476,7 +476,7 @@ function rotateBoard() {
             // Topo-Direita
             [{row: 4, col: 13}, {row: 4, col: 14}, {row: 4, col: 15}, {row: 4, col: 16}, {row: 4, col: 17}],
             // Fundo-Direita
-            [{row: 13, col: 15}, {row: 14, col: 15}, {row: 15, col: 15}, {row: 16, col: 15}, {row: 17, col: 15}],
+            [{row: 13, col: 14}, {row: 14, col: 14}, {row: 15, col: 14}, {row: 16, col: 14}, {row: 17, col: 14}],
             // Fundo-Esquerda
             [{row: 14, col: 1}, {row: 14, col: 2}, {row: 14, col: 3}, {row: 14, col: 4}, {row: 14, col: 5}]
         ];

--- a/server/game.js
+++ b/server/game.js
@@ -527,7 +527,7 @@ discardCard(cardIndex) {
     const entrances = [
       {row: 0, col: 4},   // Jogador 0 (topo-esquerda)
       {row: 4, col: 18},  // Jogador 1 (topo-direita)
-      {row: 18, col: 15}, // Jogador 2 (fundo-direita)
+      {row: 18, col: 14}, // Jogador 2 (fundo-direita)
       {row: 14, col: 0}   // Jogador 3 (fundo-esquerda)
     ];
     
@@ -559,11 +559,11 @@ discardCard(cardIndex) {
       ],
       // Jogador 2 - fundo-direita
       [
-        {row: 17, col: 15},
-        {row: 16, col: 15},
-        {row: 15, col: 15},
-        {row: 14, col: 15},
-        {row: 13, col: 15}
+        {row: 17, col: 14},
+        {row: 16, col: 14},
+        {row: 15, col: 14},
+        {row: 14, col: 14},
+        {row: 13, col: 14}
       ],
       // Jogador 3 - fundo-esquerda
       [
@@ -627,11 +627,11 @@ discardCard(cardIndex) {
       ],
       // Jogador 2 - fundo-direita
       [
-        {row: 17, col: 15},
-        {row: 16, col: 15},
-        {row: 15, col: 15},
-        {row: 14, col: 15},
-        {row: 13, col: 15}
+        {row: 17, col: 14},
+        {row: 16, col: 14},
+        {row: 15, col: 14},
+        {row: 14, col: 14},
+        {row: 13, col: 14}
       ],
       // Jogador 3 - fundo-esquerda
       [
@@ -784,11 +784,11 @@ discardCard(cardIndex) {
       ],
       // Jogador 2 - fundo-direita
       [
-        {row: 17, col: 15},
-        {row: 16, col: 15},
-        {row: 15, col: 15},
-        {row: 14, col: 15},
-        {row: 13, col: 15}
+        {row: 17, col: 14},
+        {row: 16, col: 14},
+        {row: 15, col: 14},
+        {row: 14, col: 14},
+        {row: 13, col: 14}
       ],
       // Jogador 3 - fundo-esquerda
       [

--- a/server/utils.js
+++ b/server/utils.js
@@ -89,12 +89,11 @@ boardLayout[4][16] = 'e';
 boardLayout[4][17] = 'e';
 
 // Fundo-Direita
-// Ajuste da coluna para alinhar com o corredor utilizado na lógica do jogo
-boardLayout[13][15] = 'e';
-boardLayout[14][15] = 'e';
-boardLayout[15][15] = 'e';
-boardLayout[16][15] = 'e';
-boardLayout[17][15] = 'e';
+boardLayout[13][14] = 'e';
+boardLayout[14][14] = 'e';
+boardLayout[15][14] = 'e';
+boardLayout[16][14] = 'e';
+boardLayout[17][14] = 'e';
 
 // Fundo-Esquerda
 boardLayout[14][1] = 'e';


### PR DESCRIPTION
## Summary
- correct player 3 home stretch column index on both front-end and server
- update board layout to match
- ensure unit tests pass

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f5ec5bca4832a9a205548435c4790