### PR TITLE
Fix partner capture position

### DIFF
--- a/server/__tests__/game.test.js
+++ b/server/__tests__/game.test.js
@@ -25,4 +25,15 @@ describe('Game class', () => {
       expect(p.cards).toHaveLength(5);
     });
   });
+
+  test('handlePartnerCapture moves piece to entrance before home stretch', () => {
+    const game = new Game('room3');
+    const piece = game.pieces.find(p => p.id === 'p2_1');
+
+    const result = game.handlePartnerCapture(piece);
+
+    expect(result.position).toEqual({ row: 18, col: 14 });
+    expect(piece.position).toEqual({ row: 18, col: 14 });
+    expect(piece.inHomeStretch).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- place pieces captured by a partner on the track square before the home stretch entrance
- test partner capture placement

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f6f17bb74832a9484c9db72472ef0