### PR TITLE
Fix Ace movement causing NaN

### DIFF
--- a/server/__tests__/game.test.js
+++ b/server/__tests__/game.test.js
@@ -36,4 +36,17 @@ describe('Game class', () => {
     expect(piece.position).toEqual({ row: 18, col: 14 });
     expect(piece.inHomeStretch).toBe(false);
   });
+
+  test('executeMove interprets Ace as one step forward', () => {
+    const game = new Game('room4');
+    const piece = game.pieces.find(p => p.id === 'p0_1');
+
+    piece.inPenaltyZone = false;
+    piece.position = { row: 0, col: 8 };
+
+    const result = game.executeMove(piece, { value: 'A' });
+
+    expect(result.action).toBe('move');
+    expect(piece.position).toEqual({ row: 0, col: 9 });
+  });
 });

--- a/server/game.js
+++ b/server/game.js
@@ -329,6 +329,7 @@ discardCard(cardIndex) {
     // Peça está no tabuleiro
     switch (value) {
       case 'A':
+        return this.movePieceForward(piece, 1, enterHome);
       case '2':
       case '3':
       case '4':
@@ -336,7 +337,7 @@ discardCard(cardIndex) {
       case '6':
       case '9':
       case 'T': // 10
-        return this.movePieceForward(piece, parseInt(value === 'T' ? 10 : value), enterHome);
+        return this.movePieceForward(piece, value === 'T' ? 10 : parseInt(value), enterHome);
       case '7':
         throw new Error("Carta 7 requer movimento especial");
       case '8':


### PR DESCRIPTION
## Summary
- interpret Ace card as one step forward instead of using `parseInt`
- test Ace movement so it doesn't crash

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f7979697c832a9fe345e4929c9704