### PR TITLE
Ensure Jest is installed before tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,9 @@ The application will be available at `http://localhost:3000`.
 5. The first team to bring all their pieces home wins.
 
 ## Running Tests
-Run the automated test suite using [Jest](https://jestjs.io/):
+Run the automated test suite using [Jest](https://jestjs.io/). Jest is listed as a dev dependency and will be installed automatically on the first test run:
 
 ```bash
 npm test
 ```
-
-This will execute all tests inside the `server/__tests__` directory.
+This will install any missing packages and execute all tests inside the `server/__tests__` directory.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "node server/server.js",
     "dev": "nodemon server/server.js",
+    "pretest": "npm install",
     "test": "jest"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- run `npm install` automatically before `npm test`
- clarify test instructions in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f81ad3c4c832a9782a740be5550a0