### PR TITLE
Add no-move detection

### DIFF
--- a/public/js/game.js
+++ b/public/js/game.js
@@ -276,40 +276,40 @@ function handleYourTurn(data) {
   console.log('É sua vez de jogar!', data);
   isMyTurn = true;
   showStatusMessage('É sua vez de jogar!', 'turn');
-  
+
   // Atualizar cartas na mão
   if (data && data.cards) {
     console.log('Atualizando cartas:', data.cards);
     updateCards(data.cards);
-    
+
     // Verificar se o jogador está preso no castigo sem K, Q ou J
-    checkIfStuckInPenalty(data.cards);
+    checkIfStuckInPenalty(data.cards, data.canMove);
   } else {
     console.error('ERRO: Dados de cartas não recebidos');
   }
 }
 
 // Adicione esta função para verificar se o jogador está preso no castigo
-function checkIfStuckInPenalty(cards) {
+function checkIfStuckInPenalty(cards, canMoveFlag) {
   if (!gameState || !gameState.pieces) return;
-  
-  // Verificar se todas as peças do jogador estão no castigo
+
+  const cardElements = document.querySelectorAll('.card');
+
+  if (canMoveFlag === false) {
+    showStatusMessage('Você não tem jogadas possíveis. Selecione uma carta para descartar.', 'error');
+    cardElements.forEach(card => card.classList.add('discard-only'));
+    return;
+  }
+
   const playerPieces = gameState.pieces.filter(p => p.playerId === playerPosition);
   const allInPenalty = playerPieces.every(p => p.inPenaltyZone);
-  
-  // Verificar se o jogador não tem K, Q ou J
   const hasExitCard = cards.some(card => ['K', 'Q', 'J'].includes(card.value));
-  
+
   if (allInPenalty && !hasExitCard) {
-    // Jogador está preso no castigo sem cartas para sair
     showStatusMessage('Você não tem K, Q ou J para sair do castigo. Selecione uma carta para descartar.', 'error');
-    
-    // Adicionar classe visual para indicar que as cartas são apenas para descarte
-    const cardElements = document.querySelectorAll('.card');
-    cardElements.forEach(card => {
-      card.classList.add('discard-only');
-    });
+    cardElements.forEach(card => card.classList.add('discard-only'));
   } else {
+    cardElements.forEach(card => card.classList.remove('discard-only'));
     showStatusMessage('É sua vez de jogar!', 'turn');
   }
 }
@@ -742,17 +742,8 @@ function handleCardClick(index) {
 
 // Adicione esta função auxiliar
 function isPlayerStuckInPenalty() {
-  if (!gameState || !gameState.pieces) return false;
-  
-  // Verificar se todas as peças do jogador estão no castigo
-  const playerPieces = gameState.pieces.filter(p => p.playerId === playerPosition);
-  const allInPenalty = playerPieces.every(p => p.inPenaltyZone);
-  
-  // Obter cartas do DOM
   const cardElements = document.querySelectorAll('.card');
-  const hasDiscard = cardElements.length > 0 && cardElements[0].classList.contains('discard-only');
-  
-  return allInPenalty && hasDiscard;
+  return cardElements.length > 0 && cardElements[0].classList.contains('discard-only');
 }
 
 // Adicione esta função para descartar uma carta

--- a/server/game.js
+++ b/server/game.js
@@ -1039,6 +1039,46 @@ discardCard(cardIndex) {
     return null;
   }
 
+  cloneForSimulation() {
+    const clone = new Game(this.roomId);
+    clone.players = JSON.parse(JSON.stringify(this.players));
+    clone.teams = JSON.parse(JSON.stringify(this.teams));
+    clone.deck = JSON.parse(JSON.stringify(this.deck));
+    clone.discardPile = JSON.parse(JSON.stringify(this.discardPile));
+    clone.currentPlayerIndex = this.currentPlayerIndex;
+    clone.isActive = this.isActive;
+    clone.board = JSON.parse(JSON.stringify(this.board));
+    clone.pieces = JSON.parse(JSON.stringify(this.pieces));
+    return clone;
+  }
+
+  hasAnyValidMove(playerIndex) {
+    const player = this.players[playerIndex];
+    if (!player) return false;
+
+    const pieces = this.pieces.filter(p => p.playerId === playerIndex && !p.completed);
+
+    for (const card of player.cards) {
+      for (const piece of pieces) {
+        const tempGame = this.cloneForSimulation();
+        const tempPiece = tempGame.pieces.find(p => p.id === piece.id);
+
+        try {
+          if (card.value === '7') {
+            tempGame.movePieceForward(tempPiece, 7);
+          } else {
+            tempGame.executeMove(tempPiece, card);
+          }
+          return true;
+        } catch (e) {
+          continue;
+        }
+      }
+    }
+
+    return false;
+  }
+
   getPlayersInfo() {
     return this.players.map(p => ({
       id: p.id,

--- a/server/server.js
+++ b/server/server.js
@@ -44,7 +44,8 @@ function launchGame(game) {
     currentPlayer.cards.push(game.drawCard());
     logPiecePositions(game);
     io.to(currentPlayer.id).emit('yourTurn', {
-      cards: currentPlayer.cards
+      cards: currentPlayer.cards,
+      canMove: game.hasAnyValidMove(currentPlayer.position)
     });
   }
 }
@@ -128,7 +129,8 @@ socket.on('joinRoom', ({ roomId, playerName, originalPosition, originalId }) => 
         // Se for a vez deste jogador, notificar
         if (game.currentPlayerIndex === position) {
           socket.emit('yourTurn', {
-            cards: game.players[position].cards
+            cards: game.players[position].cards,
+            canMove: game.hasAnyValidMove(position)
           });
         }
         
@@ -175,7 +177,8 @@ socket.on('joinRoom', ({ roomId, playerName, originalPosition, originalId }) => 
     // Se for a vez deste jogador, notificar
     if (game.currentPlayerIndex === existingPlayerIndex) {
       socket.emit('yourTurn', {
-        cards: game.players[existingPlayerIndex].cards
+        cards: game.players[existingPlayerIndex].cards,
+        canMove: game.hasAnyValidMove(existingPlayerIndex)
       });
     }
     
@@ -295,7 +298,8 @@ socket.on('discardCard', ({ roomId, cardIndex }) => {
 
     logPiecePositions(game);
     io.to(nextPlayer.id).emit('yourTurn', {
-      cards: nextPlayer.cards
+      cards: nextPlayer.cards,
+      canMove: game.hasAnyValidMove(nextPlayer.position)
     });
   } catch (error) {
     console.error(`Erro ao descartar carta:`, error);
@@ -344,7 +348,8 @@ socket.on('requestGameState', ({ roomId, playerName }) => {
     // Se for a vez deste jogador, notificar
     if (game.currentPlayerIndex === playerIndex) {
       socket.emit('yourTurn', {
-        cards: game.players[playerIndex].cards
+        cards: game.players[playerIndex].cards,
+        canMove: game.hasAnyValidMove(playerIndex)
       });
     }
   } else {
@@ -423,9 +428,10 @@ socket.on('makeJokerMove', ({ roomId, pieceId, targetPieceId, cardIndex }) => {
     
     // Comprar uma carta para o próximo jogador
     nextPlayer.cards.push(game.drawCard());
-    
+
     io.to(nextPlayer.id).emit('yourTurn', {
-      cards: nextPlayer.cards
+      cards: nextPlayer.cards,
+      canMove: game.hasAnyValidMove(nextPlayer.position)
     });
     
   } catch (error) {
@@ -546,7 +552,8 @@ socket.on('makeMove', ({ roomId, pieceId, cardIndex, enterHome }) => {
 
     logPiecePositions(game);
     io.to(nextPlayer.id).emit('yourTurn', {
-      cards: nextPlayer.cards
+      cards: nextPlayer.cards,
+      canMove: game.hasAnyValidMove(nextPlayer.position)
     });
 
   } catch (error) {
@@ -596,7 +603,8 @@ socket.on('makeMove', ({ roomId, pieceId, cardIndex, enterHome }) => {
 
     logPiecePositions(game);
     io.to(nextPlayer.id).emit('yourTurn', {
-      cards: nextPlayer.cards
+      cards: nextPlayer.cards,
+      canMove: game.hasAnyValidMove(nextPlayer.position)
     });
    } catch (error) {
      console.error('Erro ao confirmar entrada na vitória:', error);
@@ -644,7 +652,8 @@ socket.on('makeMove', ({ roomId, pieceId, cardIndex, enterHome }) => {
 
       logPiecePositions(game);
       io.to(nextPlayer.id).emit('yourTurn', {
-        cards: nextPlayer.cards
+        cards: nextPlayer.cards,
+        canMove: game.hasAnyValidMove(nextPlayer.position)
       });
       
     } catch (error) {


### PR DESCRIPTION
## Summary
- detect when a player has no valid moves by trying the moves on a cloned game
- send `canMove` flag to clients when it's a player's turn
- show discard-only message when no move is possible
- simplify stuck check on the client

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f8d604748832a99eb4bb6abcb40f9