### PR TITLE
Add DEBUG mode for deterministic hands

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ or use Docker Compose:
 docker-compose up
 ```
 
+Set the `DEBUG` environment variable to `true` to start each player with a fixed
+hand (`K`, `Q`, `T`, `8` and `JOKER`) which is useful for testing. Without this
+variable or when set to `false`, the hands are dealt normally.
+
 The application will be available at `http://localhost:3000`.
 
 ## Basic Gameplay

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,5 +6,7 @@ services:
     volumes:
       - ./server:/app/server
       - ./public:/app/public
+    environment:
+      DEBUG: "false"
     restart: unless-stopped
 

--- a/server/__tests__/game.test.js
+++ b/server/__tests__/game.test.js
@@ -26,6 +26,23 @@ describe('Game class', () => {
     });
   });
 
+  test('startGame gives fixed hands when DEBUG is true', () => {
+    process.env.DEBUG = 'true';
+    const game = new Game('roomDebug');
+    game.addPlayer('1', 'Alice');
+    game.addPlayer('2', 'Bob');
+    game.addPlayer('3', 'Carol');
+    game.addPlayer('4', 'Dave');
+    game.startGame();
+    const expectedValues = ['K', 'Q', 'T', '8', 'JOKER'];
+    game.players.forEach(p => {
+      expect(p.cards.map(c => c.value)).toEqual(expectedValues);
+    });
+    const expectedDeckSize = 108 - game.players.length * 5;
+    expect(game.deck.length).toBe(expectedDeckSize);
+    process.env.DEBUG = 'false';
+  });
+
   test('handlePartnerCapture moves piece to entrance before home stretch', () => {
     const game = new Game('room3');
     const piece = game.pieces.find(p => p.id === 'p2_1');

--- a/server/game.js
+++ b/server/game.js
@@ -120,17 +120,33 @@ class Game {
 // No arquivo game.js do servidor
 startGame() {
   console.log(`Iniciando jogo. Jogadores: ${this.players.length}`);
-  
+
   // Criar e embaralhar o deck
   this.deck = shuffle(createDeck());
   console.log(`Deck criado com ${this.deck.length} cartas`);
-  
+
   this.discardPile = [];
-  
-  // Distribuir 5 cartas para cada jogador
-  for (const player of this.players) {
-    player.cards = this.deck.splice(0, 5);
-    console.log(`Distribuídas 5 cartas para ${player.name}`);
+
+  const debug = process.env.DEBUG === 'true';
+
+  if (debug) {
+    const fixedValues = ['K', 'Q', 'T', '8', 'JOKER'];
+    for (const player of this.players) {
+      player.cards = [];
+      for (const value of fixedValues) {
+        const index = this.deck.findIndex(c => c.value === value);
+        if (index !== -1) {
+          player.cards.push(this.deck.splice(index, 1)[0]);
+        }
+      }
+      console.log(`Modo debug: cartas fixas distribuídas para ${player.name}`);
+    }
+  } else {
+    // Distribuir 5 cartas para cada jogador
+    for (const player of this.players) {
+      player.cards = this.deck.splice(0, 5);
+      console.log(`Distribuídas 5 cartas para ${player.name}`);
+    }
   }
   
   // Sempre começar com o jogador 0 (p1)


### PR DESCRIPTION
## Summary
- add optional DEBUG environment variable
- set DEBUG variable in docker compose
- explain DEBUG usage in docs
- distribute fixed card hands when DEBUG is true
- test debug mode behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f8ff70c6c832a91e45e725f9f9ef3