### PR TITLE
Fix entering home stretch

### DIFF
--- a/server/__tests__/game.test.js
+++ b/server/__tests__/game.test.js
@@ -160,4 +160,23 @@ describe('Game class', () => {
     expect(partner.position).toEqual({ row: 18, col: 14 });
     expect(leaving.position).toEqual({ row: 0, col: 8 });
   });
+
+  test('landing exactly on home entrance stops on the board', () => {
+    const game = new Game('room10');
+    game.addPlayer('1', 'Alice');
+    game.addPlayer('2', 'Bob');
+    game.addPlayer('3', 'Carol');
+    game.addPlayer('4', 'Dave');
+    game.setupTeams();
+
+    const piece = game.pieces.find(p => p.id === 'p0_1');
+    piece.inPenaltyZone = false;
+    piece.position = { row: 0, col: 0 };
+
+    const result = game.movePieceForward(piece, 4);
+
+    expect(result.action).toBe('move');
+    expect(piece.inHomeStretch).toBe(false);
+    expect(piece.position).toEqual({ row: 0, col: 4 });
+  });
 });

--- a/server/game.js
+++ b/server/game.js
@@ -439,7 +439,14 @@ discardCard(cardIndex) {
 
     // Verificar se deve entrar no corredor de chegada diretamente
     if (this.shouldEnterHomeStretch(piece, newPosition)) {
-      return this.enterHomeStretch(piece, steps);
+      const stepsToEnt = this.stepsToEntrance(piece);
+      if (steps > stepsToEnt) {
+        return this.enterHomeStretch(piece, steps - stepsToEnt);
+      }
+
+      const oldPosition = { ...piece.position };
+      piece.position = newPosition;
+      return this.checkCapture(piece, oldPosition);
     }
 
     const homeOption = this.checkHomeEntryOption(piece, steps);


### PR DESCRIPTION
## Summary
- stop automatic multi-step advance when landing exactly on home entrance
- add regression test for this movement

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f9273009c832ab732893331bca487