### PR TITLE
Fix capturing in home stretch

### DIFF
--- a/server/game.js
+++ b/server/game.js
@@ -515,8 +515,13 @@ discardCard(cardIndex) {
 
   moveToSelectedPosition(piece, targetPieceId) {
     const targetPiece = this.pieces.find(p => p.id === targetPieceId);
-    
-    if (!targetPiece || targetPiece.completed || targetPiece.inPenaltyZone) {
+
+    if (
+      !targetPiece ||
+      targetPiece.completed ||
+      targetPiece.inPenaltyZone ||
+      targetPiece.inHomeStretch
+    ) {
       throw new Error("Posição inválida");
     }
     
@@ -883,12 +888,14 @@ discardCard(cardIndex) {
 
   checkCapture(piece, oldPosition) {
     // Verificar se "comeu" alguma peça
-    const capturedPieces = this.pieces.filter(p => 
-      p.id !== piece.id && 
-      !p.completed && 
-      !p.inPenaltyZone &&
-      p.position.row === piece.position.row && 
-      p.position.col === piece.position.col
+    const capturedPieces = this.pieces.filter(
+      p =>
+        p.id !== piece.id &&
+        !p.completed &&
+        !p.inPenaltyZone &&
+        !p.inHomeStretch &&
+        p.position.row === piece.position.row &&
+        p.position.col === piece.position.col
     );
     
     if (capturedPieces.length === 0) {


### PR DESCRIPTION
## Summary
- disallow selecting a target piece in the home stretch when using the Joker
- make `checkCapture` ignore pieces already in the home stretch

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f93da042c832aaae744b5f2a5bee6