### PR TITLE
Fix double-piece move selection

### DIFF
--- a/public/js/game.js
+++ b/public/js/game.js
@@ -699,15 +699,6 @@ function handlePieceClick(pieceId) {
     return;
   }
   
-  // Selecionar/desselecionar peça
-  if (selectedPieceId === pieceId) {
-    selectedPieceId = null;
-    updateSelectedPiece();
-  } else {
-    selectedPieceId = pieceId;
-    updateSelectedPiece();
-  }
-  
   if (awaitingSecondPiece) {
     if (pieceId === selectedPieceId) {
       showStatusMessage('Selecione uma peça diferente', 'error');
@@ -722,6 +713,15 @@ function handlePieceClick(pieceId) {
     awaitingSecondPiece = false;
     showSliderDialog();
     return;
+  }
+
+  // Selecionar/desselecionar peça
+  if (selectedPieceId === pieceId) {
+    selectedPieceId = null;
+    updateSelectedPiece();
+  } else {
+    selectedPieceId = pieceId;
+    updateSelectedPiece();
   }
 
   // Se já tiver uma carta selecionada, tentar fazer o movimento


### PR DESCRIPTION
## Summary
- fix logic when choosing the second piece for a split move

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f9c2fda2c832abba9dad0f4dcfe14