### PR TITLE
Enable home stretch entry during special 7 move

### DIFF
--- a/public/js/game.js
+++ b/public/js/game.js
@@ -132,6 +132,7 @@ function initSocketWithPlayerData(playerData) {
   socket.on('updateCards', handleUpdateCards);
   socket.on('choosePosition', handleChoosePosition);
   socket.on('homeEntryChoice', handleHomeEntryChoice);
+  socket.on('homeEntryChoiceSpecial', handleHomeEntryChoiceSpecial);
   socket.on('error', handleError);
 }
 
@@ -269,6 +270,17 @@ function handleHomeEntryChoice(data) {
   socket.emit('confirmHomeEntry', {
     roomId,
     pieceId: data.pieceId,
+    cardIndex: data.cardIndex,
+    enterHome: choice
+  });
+}
+
+function handleHomeEntryChoiceSpecial(data) {
+  const choice = confirm('Sua peça pode entrar na zona de vitória. Deseja entrar?');
+  socket.emit('confirmSpecialHomeEntry', {
+    roomId,
+    moves: data.moves,
+    moveIndex: data.moveIndex,
     cardIndex: data.cardIndex,
     enterHome: choice
   });

--- a/server/__tests__/game.test.js
+++ b/server/__tests__/game.test.js
@@ -196,7 +196,7 @@ describe('Game class', () => {
     const before = game.players[0].cards.length;
 
     const initial = { ...piece.position };
-    game.makeSpecialMove([{ pieceId: piece.id, steps: 7 }]);
+    game.makeSpecialMove([{ pieceId: piece.id, steps: 7, enterHome: false }]);
 
     expect(piece.position).not.toEqual(initial);
     expect(game.players[0].cards.length).toBe(before - 1);
@@ -230,6 +230,49 @@ describe('Game class', () => {
     expect(piece1.position).not.toEqual(pos1);
     expect(piece2.position).not.toEqual(pos2);
     expect(game.players[0].cards.length).toBe(before - 1);
+  });
+
+  test('makeSpecialMove offers home entry option', () => {
+    const game = new Game('room13');
+    game.addPlayer('1', 'Alice');
+    game.addPlayer('2', 'Bob');
+    game.addPlayer('3', 'Carol');
+    game.addPlayer('4', 'Dave');
+    game.startGame();
+
+    const piece = game.pieces.find(p => p.id === 'p0_1');
+    piece.inPenaltyZone = false;
+    piece.position = { row: 0, col: 0 };
+
+    game.players[0].cards.push({ suit: '♠', value: '7' });
+    const len = game.players[0].cards.length;
+
+    const result = game.makeSpecialMove([{ pieceId: piece.id, steps: 7 }]);
+
+    expect(result.action).toBe('homeEntryChoice');
+    expect(result.success).toBe(false);
+    expect(game.players[0].cards.length).toBe(len);
+  });
+
+  test('makeSpecialMove can move piece into home stretch', () => {
+    const game = new Game('room14');
+    game.addPlayer('1', 'Alice');
+    game.addPlayer('2', 'Bob');
+    game.addPlayer('3', 'Carol');
+    game.addPlayer('4', 'Dave');
+    game.startGame();
+
+    const piece = game.pieces.find(p => p.id === 'p0_1');
+    piece.inPenaltyZone = false;
+    piece.position = { row: 0, col: 0 };
+
+    game.players[0].cards.push({ suit: '♠', value: '7' });
+
+    const result = game.makeSpecialMove([{ pieceId: piece.id, steps: 7, enterHome: true }]);
+
+    expect(result.success).toBe(true);
+    expect(piece.inHomeStretch).toBe(true);
+    expect(piece.position).toEqual({ row: 3, col: 4 });
   });
 
   test('moveToSelectedPosition rejects targets in home stretch', () => {

--- a/server/game.js
+++ b/server/game.js
@@ -302,7 +302,8 @@ discardCard(cardIndex) {
     }
     
     // Executar cada movimento
-    for (const move of moves) {
+    for (let i = 0; i < moves.length; i++) {
+      const move = moves[i];
       const piece = this.pieces.find(p => p.id === move.pieceId);
       
       if (!piece) {
@@ -313,7 +314,15 @@ discardCard(cardIndex) {
         throw new Error("Esta peça não pertence a você");
       }
       
-      this.movePieceForward(piece, move.steps, false);
+      const result = this.movePieceForward(
+        piece,
+        move.steps,
+        Object.prototype.hasOwnProperty.call(move, 'enterHome') ? move.enterHome : null
+      );
+
+      if (result && result.action === 'homeEntryChoice') {
+        return { ...result, moveIndex: i };
+      }
     }
     
     // Remover a carta 7 da mão do jogador


### PR DESCRIPTION
## Summary
- let `makeSpecialMove` handle entering home stretch and propagate choices
- notify clients when a special 7 move can enter home stretch
- allow client to confirm entering home stretch during special moves
- add tests for new behaviour

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_683fa01d9304832ab0efb3e67c9b824b