### PR TITLE
Fix move validation in penalty zone

### DIFF
--- a/server/__tests__/game.test.js
+++ b/server/__tests__/game.test.js
@@ -289,4 +289,21 @@ describe('Game class', () => {
 
     expect(() => game.moveToSelectedPosition(mover, target.id)).toThrow();
   });
+
+  test('movePieceForward cannot move piece in penalty zone', () => {
+    const game = new Game('penaltyMove');
+    const piece = game.pieces.find(p => p.id === 'p0_1');
+    expect(() => game.movePieceForward(piece, 3)).toThrow();
+  });
+
+  test('hasAnyValidMove is false with 7 when all pieces penalized', () => {
+    const game = new Game('penaltyHand');
+    game.addPlayer('1', 'A');
+    game.addPlayer('2', 'B');
+    game.addPlayer('3', 'C');
+    game.addPlayer('4', 'D');
+    const player = game.players[0];
+    player.cards = [{ suit: '♠', value: '7' }];
+    expect(game.hasAnyValidMove(player.position)).toBe(false);
+  });
 });

--- a/server/game.js
+++ b/server/game.js
@@ -432,6 +432,10 @@ discardCard(cardIndex) {
     if (piece.completed) {
       throw new Error("Esta peça já completou o percurso");
     }
+
+    if (piece.inPenaltyZone) {
+      throw new Error('Peça está na zona de castigo');
+    }
     
     // Se a peça está no corredor de chegada
     if (piece.inHomeStretch) {


### PR DESCRIPTION
## Summary
- disallow moving pieces that are still in the penalty zone
- test penalty zone movement and valid-move detection

## Testing
- `npx jest --silent`

------
https://chatgpt.com/codex/tasks/task_e_683fa2a02af8832aba884009719b1da0