### PR TITLE
Fix entry check and allow home entry choice

### DIFF
--- a/server/game.js
+++ b/server/game.js
@@ -432,6 +432,10 @@ discardCard(cardIndex) {
     if (piece.completed) {
       throw new Error("Esta peça já completou o percurso");
     }
+
+    if (piece.inPenaltyZone) {
+      throw new Error('Peça está na zona de castigo');
+    }
     
     // Se a peça está no corredor de chegada
     if (piece.inHomeStretch) {
@@ -446,25 +450,27 @@ discardCard(cardIndex) {
       throw new Error("Não pode ultrapassar sua própria peça");
     }
 
-    // Verificar se deve entrar no corredor de chegada diretamente
-    if (this.shouldEnterHomeStretch(piece, newPosition)) {
-      const stepsToEnt = this.stepsToEntrance(piece);
-      if (steps > stepsToEnt) {
-        return this.enterHomeStretch(piece, steps - stepsToEnt);
-      }
-
-      const oldPosition = { ...piece.position };
-      piece.position = newPosition;
-      return this.checkCapture(piece, oldPosition);
-    }
-
     const homeOption = this.checkHomeEntryOption(piece, steps);
     if (homeOption && enterHome === null) {
-      return { success: false, action: 'homeEntryChoice', pieceId: piece.id, cardSteps: steps, boardPosition: homeOption.boardPosition, homePosition: homeOption.homePosition };
+      return {
+        success: false,
+        action: 'homeEntryChoice',
+        pieceId: piece.id,
+        cardSteps: steps,
+        boardPosition: homeOption.boardPosition,
+        homePosition: homeOption.homePosition
+      };
     }
 
     if (homeOption && enterHome) {
       return this.enterHomeStretch(piece, homeOption.remainingSteps);
+    }
+
+    // Verificar se deve entrar no corredor de chegada diretamente
+    if (this.shouldEnterHomeStretch(piece, newPosition)) {
+      const oldPosition = { ...piece.position };
+      piece.position = newPosition;
+      return this.checkCapture(piece, oldPosition);
     }
     
     // Mover para a nova posição
@@ -875,9 +881,9 @@ discardCard(cardIndex) {
   checkHomeEntryOption(piece, steps) {
     const stepsToEnt = this.stepsToEntrance(piece);
     if (stepsToEnt === null) return null;
+    const stretch = this.homeStretchForPlayer(piece.playerId);
     if (steps > stepsToEnt) {
       const remaining = steps - stepsToEnt;
-      const stretch = this.homeStretchForPlayer(piece.playerId);
       if (remaining <= stretch.length) {
         const boardPos = this.calculateNewPosition(piece.position, steps, true);
         const target = stretch[remaining - 1];
@@ -890,6 +896,17 @@ discardCard(cardIndex) {
         if (!occupyingPiece && pathClear) {
           return { remainingSteps: remaining, boardPosition: boardPos, homePosition: target };
         }
+      }
+    } else if (steps === stepsToEnt) {
+      const boardPos = this.calculateNewPosition(piece.position, steps, true);
+      const target = stretch[0];
+      const occupyingPiece = this.pieces.find(p =>
+        p.id !== piece.id &&
+        p.position.row === target.row &&
+        p.position.col === target.col
+      );
+      if (!occupyingPiece) {
+        return { remainingSteps: 1, boardPosition: boardPos, homePosition: target };
       }
     }
     return null;


### PR DESCRIPTION
## Summary
- let pieces enter the home stretch when landing exactly on the entrance
- return a `homeEntryChoice` response in that situation
- update `makeSpecialMove` test to avoid new option
- add unit tests covering the new behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fa2a02af8832aba884009719b1da0