### PR TITLE
Enable partner piece control after home stretch

### DIFF
--- a/server/__tests__/game.test.js
+++ b/server/__tests__/game.test.js
@@ -324,4 +324,29 @@ describe('Game class', () => {
     player.cards = [{ suit: '♠', value: '7' }];
     expect(game.hasAnyValidMove(player.position)).toBe(false);
   });
+
+  test('player can control partner pieces after all in home stretch', () => {
+    const game = new Game('partnerPlay');
+    game.addPlayer('1', 'A');
+    game.addPlayer('2', 'B');
+    game.addPlayer('3', 'C');
+    game.addPlayer('4', 'D');
+    game.setupTeams();
+    const p0Pieces = game.pieces.filter(p => p.playerId === 0);
+    p0Pieces.forEach((p, idx) => {
+      p.inPenaltyZone = false;
+      p.inHomeStretch = true;
+      p.position = { row: 1 + idx, col: 4 };
+    });
+    const partnerPiece = game.pieces.find(p => p.id === 'p2_1');
+    partnerPiece.inPenaltyZone = false;
+    partnerPiece.position = { row: 0, col: 0 };
+
+    game.players[0].cards = [{ suit: '♠', value: 'A' }];
+    game.currentPlayerIndex = 0;
+
+    expect(game.hasAnyValidMove(0)).toBe(true);
+    game.makeMove(partnerPiece.id, 0);
+    expect(partnerPiece.position).toEqual({ row: 0, col: 1 });
+  });
 });

--- a/server/server.js
+++ b/server/server.js
@@ -395,7 +395,7 @@ socket.on('makeJokerMove', ({ roomId, pieceId, targetPieceId, cardIndex }) => {
       return;
     }
 
-    if (piece.playerId !== currentPlayer.position) {
+    if (!game.canControlPiece(currentPlayer.position, piece.playerId)) {
       socket.emit('error', 'Esta peça não pertence a você');
       return;
     }


### PR DESCRIPTION
## Summary
- add helper methods to detect partner piece control eligibility
- allow moving partner pieces when all own pieces are in the home stretch
- extend valid move detection to include partner pieces
- adjust server Joker handler for new rule
- test playing with partner pieces when eligible

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683faa77ae74832a8e2cd5dbff819266