### PR TITLE
Fix partner capture edge case

### DIFF
--- a/server/__tests__/game.test.js
+++ b/server/__tests__/game.test.js
@@ -161,6 +161,57 @@ describe('Game class', () => {
     expect(leaving.position).toEqual({ row: 0, col: 8 });
   });
 
+  test('leavePenaltyZone cannot capture partner when entrance is blocked', () => {
+    const game = new Game('room9b');
+    game.addPlayer('1', 'Alice');
+    game.addPlayer('2', 'Bob');
+    game.addPlayer('3', 'Carol');
+    game.addPlayer('4', 'Dave');
+    game.setupTeams();
+
+    const leaving = game.pieces.find(p => p.id === 'p3_1');
+    const partner = game.pieces.find(p => p.id === 'p1_1');
+    const blocker = game.pieces.find(p => p.id === 'p1_2');
+
+    partner.inPenaltyZone = false;
+    partner.position = { row: 10, col: 0 };
+
+    blocker.inPenaltyZone = false;
+    blocker.position = { row: 4, col: 18 };
+
+    expect(() => game.leavePenaltyZone(leaving)).toThrow();
+  });
+
+  test('leavePenaltyZone allows chain capture to own entrance', () => {
+    const game = new Game('chain1');
+    game.addPlayer('1', 'Alice');
+    game.addPlayer('2', 'Bob');
+    game.addPlayer('3', 'Carol');
+    game.addPlayer('4', 'Dave');
+    game.setupTeams();
+
+    const leaving = game.pieces.find(p => p.id === 'p3_1');
+    const partner = game.pieces.find(p => p.id === 'p1_1');
+    const captPiece = game.pieces.find(p => p.id === 'p3_2');
+    const opponent = game.pieces.find(p => p.id === 'p0_1');
+
+    partner.inPenaltyZone = false;
+    partner.position = { row: 10, col: 0 };
+
+    captPiece.inPenaltyZone = false;
+    captPiece.position = { row: 4, col: 18 };
+
+    opponent.inPenaltyZone = false;
+    opponent.position = { row: 14, col: 0 };
+
+    const result = game.leavePenaltyZone(leaving);
+
+    expect(result.success).toBe(true);
+    expect(partner.position).toEqual({ row: 4, col: 18 });
+    expect(captPiece.position).toEqual({ row: 14, col: 0 });
+    expect(opponent.inPenaltyZone).toBe(true);
+  });
+
   test('landing exactly on home entrance offers entry option', () => {
     const game = new Game('room10');
     game.addPlayer('1', 'Alice');

--- a/server/game.js
+++ b/server/game.js
@@ -409,7 +409,7 @@ discardCard(cardIndex) {
       const isPartner = this.isPartner(piece.playerId, occupyingPiece.playerId);
 
       if (isPartner) {
-        const result = this.handlePartnerCapture(occupyingPiece);
+        const result = this.handlePartnerCapture(occupyingPiece, piece.playerId);
         captures.push({ pieceId: occupyingPiece.id, action: 'partnerCapture', result });
       } else {
         this.sendToPenaltyZone(occupyingPiece);
@@ -936,7 +936,7 @@ discardCard(cardIndex) {
       
       if (isPartner) {
         // Captura de parceiro - mover para corredor de chegada
-        const result = this.handlePartnerCapture(capturedPiece);
+        const result = this.handlePartnerCapture(capturedPiece, piece.playerId);
         captures.push({
           pieceId: capturedPiece.id,
           action: 'partnerCapture',
@@ -959,7 +959,7 @@ discardCard(cardIndex) {
     };
   }
 
-  handlePartnerCapture(piece) {
+  handlePartnerCapture(piece, capturingPlayerId = null) {
     // Regra de captura de parceiro: a peça deve ir para a casa
     // imediatamente antes da entrada do seu corredor de chegada.
 
@@ -980,13 +980,29 @@ discardCard(cardIndex) {
       p.position.col === target.col
     );
 
+    if (occupyingPiece) {
+      if (piece.playerId === capturingPlayerId) {
+        const partner = this.partnerIdFor(capturingPlayerId);
+        if (
+          occupyingPiece.playerId === capturingPlayerId ||
+          occupyingPiece.playerId === partner
+        ) {
+          throw new Error('Não é possível capturar sua própria peça.');
+        }
+      } else {
+        if (occupyingPiece.playerId === piece.playerId) {
+          throw new Error('Não é possível capturar sua própria peça.');
+        }
+      }
+    }
+
     let captures;
     if (occupyingPiece) {
       captures = [];
       const isPartner = this.isPartner(piece.playerId, occupyingPiece.playerId);
 
       if (isPartner) {
-        const result = this.handlePartnerCapture(occupyingPiece);
+        const result = this.handlePartnerCapture(occupyingPiece, capturingPlayerId);
         captures.push({ pieceId: occupyingPiece.id, action: 'partnerCapture', result });
       } else {
         this.sendToPenaltyZone(occupyingPiece);


### PR DESCRIPTION
## Summary
- refine partner capture chain logic to allow chain captures while preventing self captures
- add regression tests for complex partner capture scenarios

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_683fac42e838832a8298c73c03b1b707