### PR TITLE
Improve mobile card layout

### DIFF
--- a/public/css/game.css
+++ b/public/css/game.css
@@ -157,6 +157,11 @@
     margin-top: 1rem;
 }
 
+/* Usado quando a mão precisa encolher para caber em telas menores */
+#cards-container.compact {
+    gap: 0.5rem;
+}
+
 .card {
     width: 80px;
     height: 120px;
@@ -168,9 +173,23 @@
     justify-content: space-between;
     padding: 0.5rem;
     cursor: pointer;
-    transition: transform 0.2s;
+    transition: transform 0.2s, width 0.2s, height 0.2s, margin 0.2s;
     box-shadow: 0 2px 5px rgba(0,0,0,0.1);
     margin: 0.5rem;
+}
+
+#cards-container.compact .card {
+    width: 55px;
+    height: 85px;
+    margin: 0.25rem;
+}
+
+#cards-container.compact .card-value {
+    font-size: 1.2rem;
+}
+
+#cards-container.compact .card-suit {
+    font-size: 1.6rem;
 }
 
 .card:hover {
@@ -321,6 +340,17 @@
     .card {
         width: 60px;
         height: 90px;
+    }
+
+    #cards-container.compact .card {
+        width: 55px;
+        height: 85px;
+    }
+    #cards-container.compact .card-value {
+        font-size: 1.2rem;
+    }
+    #cards-container.compact .card-suit {
+        font-size: 1.6rem;
     }
     
     .card-back {

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -650,9 +650,10 @@ function updateCards(cards) {
     cardElement.dataset.index = index;
     
     const isRed = card.suit === '♥' || card.suit === '♦';
-    
+    const displayValue = card.value === 'JOKER' ? 'C' : card.value;
+
     cardElement.innerHTML = `
-      <div class="card-value">${card.value}</div>
+      <div class="card-value">${displayValue}</div>
       <div class="card-suit ${isRed ? 'red' : 'black'}">${card.suit}</div>
     `;
     
@@ -660,15 +661,23 @@ function updateCards(cards) {
     
     cardsContainer.appendChild(cardElement);
   });
-  
+
+  // Ajusta o tamanho das cartas caso a mão tenha mais de cinco
+  if (cards.length > 5) {
+    cardsContainer.classList.add('compact');
+  } else {
+    cardsContainer.classList.remove('compact');
+  }
+
   console.log('Cartas atualizadas no DOM:', cardsContainer.children.length);
 }
    
 
     function createCardHTML(card) {
         const isRed = card.suit === '♥' || card.suit === '♦';
+        const displayValue = card.value === 'JOKER' ? 'C' : card.value;
         return `
-            <div class="card-value">${card.value}</div>
+            <div class="card-value">${displayValue}</div>
             <div class="card-suit ${isRed ? 'red' : 'black'}">${card.suit}</div>
         `;
     }


### PR DESCRIPTION
## Summary
- enlarge compact hand cards and scale fonts
- show JOKER as `C` on the front-end only

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68403d4e4688832a9d6750bab069c7b3