### PR TITLE
Add colored player names and board labels

### DIFF
--- a/public/css/game.css
+++ b/public/css/game.css
@@ -411,3 +411,23 @@
   text-align: center;
   font-weight: bold;
 }
+
+/* Área para exibir os nomes dos jogadores ao redor do tabuleiro */
+#player-labels {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
+.player-label {
+  position: absolute;
+  font-weight: bold;
+  background-color: rgba(255,255,255,0.8);
+  padding: 2px 4px;
+  border-radius: 4px;
+  white-space: nowrap;
+  pointer-events: none;
+}

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -161,3 +161,8 @@ input[type="text"] {
     color: #7f8c8d;
 }
 
+/* Cores dos jogadores, usadas para nomes e indicadores */
+.player-color-0 { color: #3498db; }
+.player-color-1 { color: #e74c3c; }
+.player-color-2 { color: #2ecc71; }
+.player-color-3 { color: #f39c12; }

--- a/public/game.html
+++ b/public/game.html
@@ -32,6 +32,7 @@
         
         <div class="board-container">
             <div id="board"></div>
+            <div id="player-labels"></div>
             
             <div class="deck-area">
                 <div class="deck">

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -48,6 +48,7 @@ document.addEventListener('DOMContentLoaded', () => {
     let playerCards = [];
     let secondPieceId = null;
     let awaitingSecondPiece = false;
+    const playerColors = ['#3498db', '#e74c3c', '#2ecc71', '#f39c12'];
 
     function getDisplayValue(card) {
       return card.value === 'JOKER' ? 'C' : card.value;
@@ -403,7 +404,9 @@ function updateBoard() {
 
   // Reaplicar rotação para ajustar a orientação das peças
   rotateBoard();
-  
+
+  updatePlayerLabels();
+
   console.log('Tabuleiro atualizado');
 }
 
@@ -423,6 +426,63 @@ function rotateBoard() {
   const pieces = document.querySelectorAll('.piece');
   pieces.forEach(piece => {
     piece.style.transform = `rotate(${-rotation}deg)`;
+  });
+}
+
+function updatePlayerLabels() {
+  const container = document.getElementById('player-labels');
+  if (!container || !gameState || !gameState.players) return;
+
+  container.innerHTML = '';
+
+  const rotationMap = [180, 90, 0, 270];
+  const rotation = rotationMap[playerPosition];
+
+  const orientations = ['top-left', 'top-right', 'bottom-right', 'bottom-left'];
+
+  gameState.players.forEach(p => {
+    const label = document.createElement('div');
+    label.className = 'player-label';
+    label.textContent = p.name;
+    if (p.id === playerId) {
+      label.textContent += ' (você)';
+    }
+    if (p.position !== undefined) {
+      label.style.color = playerColors[p.position];
+    }
+
+    const oriIndex = (p.position + rotation / 90) % 4;
+    const orientation = orientations[oriIndex];
+
+    label.style.top = '';
+    label.style.bottom = '';
+    label.style.left = '';
+    label.style.right = '';
+
+    switch (orientation) {
+      case 'top-left':
+        label.style.top = '6%';
+        label.style.left = '6%';
+        label.style.transform = `translate(-100%, -100%) rotate(${-rotation}deg)`;
+        break;
+      case 'top-right':
+        label.style.top = '6%';
+        label.style.right = '6%';
+        label.style.transform = `translate(100%, -100%) rotate(${-rotation}deg)`;
+        break;
+      case 'bottom-right':
+        label.style.bottom = '6%';
+        label.style.right = '6%';
+        label.style.transform = `translate(100%, 100%) rotate(${-rotation}deg)`;
+        break;
+      case 'bottom-left':
+        label.style.bottom = '6%';
+        label.style.left = '6%';
+        label.style.transform = `translate(-100%, 100%) rotate(${-rotation}deg)`;
+        break;
+    }
+
+    container.appendChild(label);
   });
 }
 
@@ -566,6 +626,9 @@ function rotateBoard() {
         gameState.teams[0].forEach(player => {
             const playerElement = document.createElement('div');
             playerElement.textContent = player.name;
+            if (player.position !== undefined) {
+                playerElement.style.color = playerColors[player.position];
+            }
             if (player.id === playerId) {
                 playerElement.style.fontWeight = 'bold';
                 playerElement.textContent += ' (você)';
@@ -577,6 +640,9 @@ function rotateBoard() {
         gameState.teams[1].forEach(player => {
             const playerElement = document.createElement('div');
             playerElement.textContent = player.name;
+            if (player.position !== undefined) {
+                playerElement.style.color = playerColors[player.position];
+            }
             if (player.id === playerId) {
                 playerElement.style.fontWeight = 'bold';
                 playerElement.textContent += ' (você)';

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -27,6 +27,7 @@ document.addEventListener('DOMContentLoaded', () => {
     let players = [];
     let teams = [[], []];
     let isRoomCreator = false;
+    const playerColors = ['#3498db', '#e74c3c', '#2ecc71', '#f39c12'];
     
     // Inicializar Socket.io
     function initSocket() {
@@ -172,6 +173,9 @@ function handleError(message) {
         players.forEach(player => {
             const li = document.createElement('li');
             li.textContent = player.name;
+            if (player.position !== undefined) {
+                li.style.color = playerColors[player.position];
+            }
             if (player.id === playerId) {
                 li.textContent += ' (você)';
                 li.style.fontWeight = 'bold';
@@ -188,6 +192,9 @@ function handleError(message) {
             const li = document.createElement('li');
             li.textContent = player.name;
             li.dataset.id = player.id;
+            if (player.position !== undefined) {
+                li.style.color = playerColors[player.position];
+            }
             
             // Verificar se o jogador já está em algum time
             const team1 = teams[0].find(p => p.id === player.id);


### PR DESCRIPTION
## Summary
- color player names using piece colors
- show player names around board with rotation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684053a80bfc832a91d9d628246adabf