### PR TITLE
Fix player label grid alignment

### DIFF
--- a/public/css/game.css
+++ b/public/css/game.css
@@ -66,6 +66,9 @@
     justify-content: center;
     align-items: center;
     position: relative;
+    width: fit-content;
+    height: fit-content;
+    margin: 0 auto;
 }
 
 #board {


### PR DESCRIPTION
## Summary
- ensure the board container shrinks to the board size to align overlays

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68406397af40832aa9a569f16f5e274f