### PR TITLE
Fix player label orientation

### DIFF
--- a/public/js/game.js
+++ b/public/js/game.js
@@ -458,7 +458,9 @@ function updatePlayerLabels() {
     right: { row: 10, startCol: 15, endCol: 17 }
   };
 
-  const orientationOrder = ['bottom', 'left', 'top', 'right'];
+  // Ordem das posições relativas considerando a orientação do jogador
+  // Mantém a sequência em sentido horário para evitar inversões
+  const orientationOrder = ['bottom', 'right', 'top', 'left'];
 
   // Mesma convenção de rotação usada em rotateBoard
   const rotationMap = [180, 270, 0, 90];


### PR DESCRIPTION
## Summary
- adjust orientation order so name labels stay consistent for all player slots

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684067fdc49c832a829be16251694e47