### PR TITLE
Fix scoreboard orientation for all players

### DIFF
--- a/public/js/game.js
+++ b/public/js/game.js
@@ -459,8 +459,9 @@ function updatePlayerLabels() {
   };
 
   // Ordem das posições relativas considerando a orientação do jogador
-  // Mantém a sequência em sentido horário para evitar inversões
-  const orientationOrder = ['bottom', 'right', 'top', 'left'];
+  // Mantém a sequência em sentido horário para que cada jogador
+  // visualize seus adversários nos lados corretos
+  const orientationOrder = ['bottom', 'left', 'top', 'right'];
 
   // Mesma convenção de rotação usada em rotateBoard
   const rotationMap = [180, 270, 0, 90];


### PR DESCRIPTION
## Summary
- fix orientation order in player labels to line up opponents
- all tests pass

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68406cff41dc832ab7d123db4e812f5e