### PR TITLE
Fix mobile hand layout and label sizing

### DIFF
--- a/public/css/game.css
+++ b/public/css/game.css
@@ -148,13 +148,15 @@
     background-color: white;
     border-radius: 4px;
     box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+    overflow-x: auto;
 }
 
 #cards-container {
     display: flex;
     justify-content: center;
     gap: 1rem;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
+    overflow-x: auto;
     margin-top: 1rem;
 }
 
@@ -452,4 +454,5 @@
   pointer-events: none;
   align-self: center;
   justify-self: center;
+  font-size: clamp(0.6rem, 2vw, 1rem);
 }

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -768,11 +768,10 @@ function updateCards(cards) {
     cardsContainer.appendChild(cardElement);
   });
 
-  // Ajusta o tamanho das cartas caso a mão tenha mais de cinco
-  if (cards.length > 5) {
+  // Ajusta o tamanho das cartas conforme o espaço disponível
+  cardsContainer.classList.remove('compact');
+  if (cardsContainer.scrollWidth > cardsContainer.clientWidth) {
     cardsContainer.classList.add('compact');
-  } else {
-    cardsContainer.classList.remove('compact');
   }
 
   console.log('Cartas atualizadas no DOM:', cardsContainer.children.length);


### PR DESCRIPTION
## Summary
- keep cards on one line with overflow scrolling
- shrink labels on small screens
- dynamically compact cards when the hand overflows

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68407ab13f14832a95add63bb505ef2d