### PR TITLE
Fix reference error in makeSpecialMove handler

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -664,12 +664,8 @@ socket.on('confirmHomeEntry', ({ roomId, pieceId, cardIndex, enterHome }) => {
     }
     
     try {
+      const currentPlayer = game.getCurrentPlayer();
       const moveResult = game.makeSpecialMove(moves);
-      if (moveResult.moves) {
-        moveResult.moves.forEach(m => {
-          logMoveDetails(currentPlayer, m.pieceId, m.oldPosition, m.result, game);
-        });
-      }
       if (moveResult.moves) {
         moveResult.moves.forEach(m => {
           logMoveDetails(currentPlayer, m.pieceId, m.oldPosition, m.result, game);


### PR DESCRIPTION
## Summary
- define `currentPlayer` before logging moves in the `makeSpecialMove` event
- remove duplicated log loop

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840949f6028832a9c8437c8a149b37e