### PR TITLE
Adjust game page header layout

### DIFF
--- a/public/css/game.css
+++ b/public/css/game.css
@@ -13,8 +13,8 @@
 .game-info {
     display: flex;
     justify-content: space-between;
-    align-items: flex-start;
-    padding: 0.5rem;
+    align-items: center;
+    padding: 0.3rem;
     background-color: white;
     border-radius: 4px;
     box-shadow: 0 2px 5px rgba(0,0,0,0.1);
@@ -22,11 +22,13 @@
 
 .teams-info {
     display: flex;
-    gap: 1rem;
+    flex-direction: column;
+    gap: 0.2rem;
 }
 
-.team {
-    padding: 0.5rem;
+.team-line {
+    font-size: 0.9rem;
+    padding: 0.1rem 0.3rem;
     border-radius: 4px;
 }
 
@@ -40,6 +42,16 @@
 
 .turn-info {
     text-align: right;
+}
+
+.turn-info h3 {
+    font-size: 1rem;
+    margin: 0;
+}
+
+.room-code {
+    font-size: 0.9rem;
+    margin-bottom: 0.2rem;
 }
 
 #turn-message {

--- a/public/game.html
+++ b/public/game.html
@@ -11,16 +11,10 @@
     <div class="game-container">
         <div class="game-info">
             <div class="room-info">
-                <h2>Sala: <span id="room-code"></span></h2>
+                <div class="room-code">Sala: <span id="room-code"></span></div>
                 <div class="teams-info">
-                    <div class="team team1">
-                        <h3>Equipe 1</h3>
-                        <div id="team1-players"></div>
-                    </div>
-                    <div class="team team2">
-                        <h3>Equipe 2</h3>
-                        <div id="team2-players"></div>
-                    </div>
+                    <div class="team-line team1">Time 1: <span id="team1-players"></span></div>
+                    <div class="team-line team2">Time 2: <span id="team2-players"></span></div>
                 </div>
             </div>
             

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -670,38 +670,28 @@ function updatePlayerLabels() {
 
     function updateTeams() {
         if (!gameState || !gameState.teams) return;
-        
-        // Limpar listas de times
-        team1Players.innerHTML = '';
-        team2Players.innerHTML = '';
-        
-        // Preencher time 1
-        gameState.teams[0].forEach(player => {
-            const playerElement = document.createElement('div');
-            playerElement.textContent = player.name;
-            if (player.position !== undefined) {
-                playerElement.style.color = playerColors[player.position];
-            }
-            if (player.id === playerId) {
-                playerElement.style.fontWeight = 'bold';
-                playerElement.textContent += ' (você)';
-            }
-            team1Players.appendChild(playerElement);
-        });
-        
-        // Preencher time 2
-        gameState.teams[1].forEach(player => {
-            const playerElement = document.createElement('div');
-            playerElement.textContent = player.name;
-            if (player.position !== undefined) {
-                playerElement.style.color = playerColors[player.position];
-            }
-            if (player.id === playerId) {
-                playerElement.style.fontWeight = 'bold';
-                playerElement.textContent += ' (você)';
-            }
-            team2Players.appendChild(playerElement);
-        });
+
+        const fillTeam = (container, players) => {
+            container.innerHTML = '';
+            players.forEach((player, index) => {
+                const span = document.createElement('span');
+                span.textContent = player.name;
+                if (player.position !== undefined) {
+                    span.style.color = playerColors[player.position];
+                }
+                if (player.id === playerId) {
+                    span.style.fontWeight = 'bold';
+                    span.textContent += ' (você)';
+                }
+                container.appendChild(span);
+                if (index < players.length - 1) {
+                    container.appendChild(document.createTextNode(' e '));
+                }
+            });
+        };
+
+        fillTeam(team1Players, gameState.teams[0]);
+        fillTeam(team2Players, gameState.teams[1]);
     }
     
 // No arquivo game.js do cliente


### PR DESCRIPTION
## Summary
- shrink the game page header
- display teams on two compact lines
- reduce room code emphasis

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684096063948832a880b09522d5d9281