### PR TITLE
Ensure team layout reflects partners

### DIFF
--- a/server/__tests__/game.test.js
+++ b/server/__tests__/game.test.js
@@ -43,6 +43,26 @@ describe('Game class', () => {
     process.env.DEBUG = 'false';
   });
 
+  test('setCustomTeams reorders players across from partners', () => {
+    const game = new Game('customTeams');
+    game.addPlayer('1', 'A');
+    game.addPlayer('2', 'B');
+    game.addPlayer('3', 'C');
+    game.addPlayer('4', 'D');
+
+    const teams = [
+      [game.players[0].id, game.players[1].id],
+      [game.players[2].id, game.players[3].id]
+    ];
+
+    game.setCustomTeams(teams);
+
+    expect(game.players.map(p => p.name)).toEqual(['A', 'C', 'B', 'D']);
+    game.players.forEach((p, idx) => {
+      expect(p.position).toBe(idx);
+    });
+  });
+
   test('handlePartnerCapture moves piece to entrance before home stretch', () => {
     const game = new Game('room3');
     const piece = game.pieces.find(p => p.id === 'p2_1');

--- a/server/game.js
+++ b/server/game.js
@@ -104,8 +104,16 @@ class Game {
     // teamConfig deve ser um array com dois arrays, cada um contendo os IDs dos jogadores em cada equipe
     const team0 = teamConfig[0].map(id => this.players.find(p => p.id === id));
     const team1 = teamConfig[1].map(id => this.players.find(p => p.id === id));
-    
+
     if (team0.length === 2 && team1.length === 2) {
+      // Reorganizar jogadores para que parceiros fiquem frente a frente
+      const ordered = [team0[0], team1[0], team0[1], team1[1]];
+      ordered.forEach((p, idx) => {
+        p.position = idx;
+      });
+
+      this.players = ordered;
+      this.pieces = this.initializePieces();
       this.teams = [team0, team1];
       return true;
     }

--- a/server/server.js
+++ b/server/server.js
@@ -489,6 +489,7 @@ socket.on('makeJokerMove', ({ roomId, pieceId, targetPieceId, cardIndex }) => {
     }
     
     game.setCustomTeams(teams);
+    io.to(roomId).emit('updatePlayers', game.getPlayersInfo());
     io.to(roomId).emit('teamsSet', game.getTeamsInfo());
 
     if (!game.isActive) {


### PR DESCRIPTION
## Summary
- keep partners facing each other when teams are chosen
- broadcast player positions after team setup
- test custom team arrangement for correct ordering

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68409b5bae2c832a8cb5d808b3d733bc