### PR TITLE
Fix partner piece control when player position mismatches

### DIFF
--- a/server/__tests__/game.test.js
+++ b/server/__tests__/game.test.js
@@ -439,3 +439,25 @@ describe('Game class', () => {
     expect(partnerPiece.position).toEqual({ row: 0, col: 1 });
   });
 });
+  test('control uses currentPlayerIndex when player position is incorrect', () => {
+    const game = new Game('positionMismatch');
+    game.addPlayer('1', 'A');
+    game.addPlayer('2', 'B');
+    game.addPlayer('3', 'C');
+    game.addPlayer('4', 'D');
+    game.setupTeams();
+    const pieces = game.pieces.filter(p => p.playerId === 0);
+    pieces.forEach((p, idx) => {
+      p.inPenaltyZone = false;
+      p.inHomeStretch = true;
+      p.position = { row: 1 + idx, col: 4 };
+    });
+    const partnerPiece = game.pieces.find(p => p.id === 'p2_1');
+    partnerPiece.inPenaltyZone = false;
+    partnerPiece.position = { row: 0, col: 0 };
+    game.players[0].position = 3; // wrong position
+    game.players[0].cards = [{ suit: '♠', value: 'A' }];
+    game.currentPlayerIndex = 0;
+    expect(() => game.makeMove(partnerPiece.id, 0)).not.toThrow();
+    expect(partnerPiece.position).toEqual({ row: 0, col: 1 });
+  });

--- a/server/game.js
+++ b/server/game.js
@@ -262,7 +262,7 @@ discardCard(cardIndex) {
       throw new Error("Peça inválida");
     }
     
-    if (!this.canControlPiece(player.position, piece.playerId)) {
+    if (!this.canControlPiece(this.currentPlayerIndex, piece.playerId)) {
       throw new Error("Esta peça não pertence a você");
     }
     
@@ -317,7 +317,7 @@ discardCard(cardIndex) {
         throw new Error("Peça inválida");
       }
       
-      if (!this.canControlPiece(player.position, piece.playerId)) {
+      if (!this.canControlPiece(this.currentPlayerIndex, piece.playerId)) {
         throw new Error("Esta peça não pertence a você");
       }
       
@@ -1069,11 +1069,12 @@ discardCard(cardIndex) {
   }
 
   isPartner(playerId1, playerId2) {
-    // Verificar se os jogadores são parceiros
-    return this.teams.some(team =>
-      team.some(p => p.position === playerId1) &&
-      team.some(p => p.position === playerId2)
-    );
+    // Verificar se os jogadores são parceiros usando
+    // os índices atuais na lista de jogadores
+    const playerObj1 = this.players[playerId1];
+    const playerObj2 = this.players[playerId2];
+    if (!playerObj1 || !playerObj2) return false;
+    return this.teams.some(team => team.includes(playerObj1) && team.includes(playerObj2));
   }
 
   hasAllPiecesInHomeStretch(playerId) {


### PR DESCRIPTION
## Summary
- ensure piece control logic uses `currentPlayerIndex`
- determine partners by player list indexes
- test controlling partner pieces if a player's position is wrong

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840a77a5ef4832a850b932b129513e7