### PR TITLE
Fix special move cleanup

### DIFF
--- a/public/js/game.js
+++ b/public/js/game.js
@@ -306,6 +306,7 @@ function handleHomeEntryChoiceSpecial(data) {
     cardIndex: data.cardIndex,
     enterHome: choice
   });
+  finalizeSpecialMove();
 }
    
 
@@ -978,6 +979,7 @@ function makeMove() {
         specialMoveDialog.classList.add('hidden');
         awaitingSecondPiece = false;
         secondPieceId = null;
+        specialMoveCard = null;
         selectedPieceId = null;
         selectedCardIndex = null;
         updateSelectedPiece();


### PR DESCRIPTION
## Summary
- reset special move selection on home entry confirmation
- clear tracked card index when finishing a special move

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840ca1341cc832ab31929623f005bc2