### PR TITLE
Fix double-move bug for 7 card

### DIFF
--- a/public/js/game.js
+++ b/public/js/game.js
@@ -320,9 +320,6 @@ function handleHomeEntryChoiceSpecial(data) {
   const choice = confirm('Sua peça pode entrar na zona de vitória. Deseja entrar?');
   socket.emit('confirmSpecialHomeEntry', {
     roomId,
-    moves: data.moves,
-    moveIndex: data.moveIndex,
-    cardIndex: data.cardIndex,
     enterHome: choice
   });
   finalizeSpecialMove();

--- a/server/__tests__/game.test.js
+++ b/server/__tests__/game.test.js
@@ -449,6 +449,41 @@ describe('Game class', () => {
     game.makeMove(partnerPiece.id, 0);
     expect(partnerPiece.position).toEqual({ row: 0, col: 1 });
   });
+
+  test('resumeSpecialMove does not repeat executed moves', () => {
+    const game = new Game('resume7');
+    game.addPlayer('1', 'A');
+    game.addPlayer('2', 'B');
+    game.addPlayer('3', 'C');
+    game.addPlayer('4', 'D');
+    game.startGame();
+
+    game.currentPlayerIndex = 3;
+    const p32 = game.pieces.find(p => p.id === 'p3_2');
+    const p33 = game.pieces.find(p => p.id === 'p3_3');
+    p32.inPenaltyZone = false;
+    p33.inPenaltyZone = false;
+    p32.position = { row: 10, col: 0 };
+    p33.position = { row: 14, col: 0 };
+
+    game.players[3].cards.push({ suit: '♠', value: '7' });
+
+    let result = game.makeSpecialMove([
+      { pieceId: p32.id, steps: 5 },
+      { pieceId: p33.id, steps: 2 }
+    ]);
+
+    expect(result.action).toBe('homeEntryChoice');
+    expect(p32.position).toEqual({ row: 5, col: 0 });
+    expect(p33.position).toEqual({ row: 14, col: 0 });
+
+    result = game.resumeSpecialMove(false);
+
+    expect(result.success).toBe(true);
+    expect(p32.position).toEqual({ row: 5, col: 0 });
+    expect(p33.position).toEqual({ row: 12, col: 0 });
+    expect(game.pendingSpecialMove).toBe(null);
+  });
 });
   test('control uses currentPlayerIndex when player position is incorrect', () => {
     const game = new Game('positionMismatch');

--- a/server/server.js
+++ b/server/server.js
@@ -654,7 +654,7 @@ socket.on('confirmHomeEntry', ({ roomId, pieceId, cardIndex, enterHome }) => {
 
 
   // Movimento especial para carta 7
-  socket.on('makeSpecialMove', ({ roomId, moves, cardIndex }) => {
+  socket.on('makeSpecialMove', ({ roomId, moves }) => {
     const game = rooms.get(roomId);
     
     if (!game || !game.isActive) {
@@ -682,8 +682,7 @@ socket.on('confirmHomeEntry', ({ roomId, pieceId, cardIndex, enterHome }) => {
           moveIndex: moveResult.moveIndex,
           boardPosition: moveResult.boardPosition,
           homePosition: moveResult.homePosition,
-          cardIndex,
-          moves
+          moves: moveResult.moves
         });
         return;
       }
@@ -717,7 +716,7 @@ socket.on('confirmHomeEntry', ({ roomId, pieceId, cardIndex, enterHome }) => {
     }
   });
 
-  socket.on('confirmSpecialHomeEntry', ({ roomId, moves, moveIndex, cardIndex, enterHome }) => {
+  socket.on('confirmSpecialHomeEntry', ({ roomId, enterHome }) => {
     const game = rooms.get(roomId);
 
     if (!game || !game.isActive) {
@@ -732,11 +731,7 @@ socket.on('confirmHomeEntry', ({ roomId, pieceId, cardIndex, enterHome }) => {
     }
 
     try {
-      if (moves[moveIndex]) {
-        moves[moveIndex].enterHome = enterHome;
-      }
-
-      const moveResult = game.makeSpecialMove(moves);
+      const moveResult = game.resumeSpecialMove(enterHome);
 
       if (moveResult && moveResult.action === 'homeEntryChoice') {
         socket.emit('homeEntryChoiceSpecial', {
@@ -744,8 +739,7 @@ socket.on('confirmHomeEntry', ({ roomId, pieceId, cardIndex, enterHome }) => {
           moveIndex: moveResult.moveIndex,
           boardPosition: moveResult.boardPosition,
           homePosition: moveResult.homePosition,
-          cardIndex,
-          moves
+          moves: moveResult.moves
         });
         return;
       }


### PR DESCRIPTION
## Summary
- store pending state when a special move (card 7) awaits confirmation
- resume special moves without repeating earlier steps
- update server events and client handler
- add regression test for special move continuation

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6840d0ac3ef8832a9233139ae4ac5359