### PR TITLE
Add rematch and winner dialog

### DIFF
--- a/public/game.html
+++ b/public/game.html
@@ -73,7 +73,10 @@
         <div id="game-over" class="dialog hidden">
             <h2>Fim de Jogo!</h2>
             <div id="winners"></div>
-            <button id="new-game-btn" class="btn primary">Novo Jogo</button>
+            <div class="button-group">
+                <button id="rematch-btn" class="btn primary">Revanche</button>
+                <button id="exit-btn" class="btn secondary">Sair</button>
+            </div>
         </div>
     </div>
     

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -31,8 +31,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const jokerPositions = document.getElementById('joker-positions');
     const cancelJokerMoveBtn = document.getElementById('cancel-joker-move');
     
-    // Botão de novo jogo
-    const newGameBtn = document.getElementById('new-game-btn');
+    // Botões do diálogo de fim de jogo
+    const rematchBtn = document.getElementById('rematch-btn');
+    const exitBtn = document.getElementById('exit-btn');
     
     // Estado do jogo
     let socket;
@@ -165,6 +166,7 @@ function initSocketWithPlayerData(playerData) {
   
   // Eventos do socket
   socket.on('roomJoined', handleRoomJoined);
+  socket.on('gameStarted', handleGameStarted);
   socket.on('gameStateUpdate', handleGameStateUpdate);
   socket.on('playerInfo', handlePlayerInfo);
   socket.on('yourTurn', handleYourTurn);
@@ -221,6 +223,16 @@ function handleRoomJoined(data) {
       playerPosition: playerPosition
     });
   }
+}
+
+function handleGameStarted(state) {
+  console.log('Novo jogo iniciado:', state);
+  gameState = state;
+  updateBoard();
+  updateTeams();
+  updateTurnInfo();
+  updateDeckInfo();
+  gameOverDialog.classList.add('hidden');
 }
 
 // Adicione esta função
@@ -1148,7 +1160,12 @@ function makeMove() {
             jokerDialog.classList.add('hidden');
         });
 
-        newGameBtn.addEventListener('click', () => {
+        rematchBtn.addEventListener('click', () => {
+            socket.emit('rematch', { roomId });
+            gameOverDialog.classList.add('hidden');
+        });
+
+        exitBtn.addEventListener('click', () => {
             window.location.href = '/';
         });
 

--- a/server/game.js
+++ b/server/game.js
@@ -167,6 +167,20 @@ startGame() {
   console.log(`Jogo marcado como ativo`);
 }
 
+  resetForNewGame() {
+    // Reconfigurar tabuleiro e peças para uma nova partida mantendo os mesmos jogadores
+    this.board = this.createBoard();
+    this.pieces = this.initializePieces();
+    this.discardPile = [];
+    this.deck = [];
+    this.currentPlayerIndex = 0;
+    this.isActive = false;
+    this.pendingSpecialMove = null;
+    for (const player of this.players) {
+      player.cards = [];
+    }
+  }
+
   getCurrentPlayer() {
     console.log(`Obtendo jogador atual. Índice: ${this.currentPlayerIndex}, Total de jogadores: ${this.players.length}`);
     
@@ -1167,17 +1181,18 @@ discardCard(cardIndex) {
     for (let teamIndex = 0; teamIndex < 2; teamIndex++) {
       const team = this.teams[teamIndex];
       const playerIds = team.map(p => p.position);
-      
-      // Verificar se todas as peças dos dois jogadores estão completas
-      const allCompleted = this.pieces
+
+      // Considerar vitória quando todas as peças estão pelo menos no corredor
+      // de chegada (inHomeStretch) ou finalizadas (completed)
+      const allHome = this.pieces
         .filter(p => playerIds.includes(p.playerId))
-        .every(p => p.completed);
-      
-      if (allCompleted) {
+        .every(p => p.completed || p.inHomeStretch);
+
+      if (allHome) {
         return true;
       }
     }
-    
+
     return false;
   }
 
@@ -1186,17 +1201,16 @@ discardCard(cardIndex) {
     for (let teamIndex = 0; teamIndex < 2; teamIndex++) {
       const team = this.teams[teamIndex];
       const playerIds = team.map(p => p.position);
-      
-      // Verificar se todas as peças dos dois jogadores estão completas
-      const allCompleted = this.pieces
+
+      const allHome = this.pieces
         .filter(p => playerIds.includes(p.playerId))
-        .every(p => p.completed);
-      
-      if (allCompleted) {
+        .every(p => p.completed || p.inHomeStretch);
+
+      if (allHome) {
         return team;
       }
     }
-    
+
     return null;
   }
 

--- a/server/server.js
+++ b/server/server.js
@@ -517,6 +517,18 @@ socket.on('makeJokerMove', ({ roomId, pieceId, targetPieceId, cardIndex }) => {
     launchGame(game);
   });
 
+  socket.on('rematch', ({ roomId }) => {
+    const game = rooms.get(roomId);
+
+    if (!game || game.players.length !== 4) {
+      socket.emit('error', 'Não é possível reiniciar o jogo agora');
+      return;
+    }
+
+    game.resetForNewGame();
+    launchGame(game);
+  });
+
   // Jogador seleciona peça e carta
 // No arquivo server.js - Modifique o evento makeMove
 socket.on('makeMove', ({ roomId, pieceId, cardIndex, enterHome }) => {


### PR DESCRIPTION
## Summary
- declare winners when all team pieces are in the home stretch
- allow starting a new match via a 'revanche' button
- handle `gameStarted` event on the client for rematches

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840d2c23fd4832a8126371c5f49ce00