### PR TITLE
Fix home entry path check

### DIFF
--- a/server/__tests__/game.test.js
+++ b/server/__tests__/game.test.js
@@ -282,6 +282,52 @@ describe('Game class', () => {
     expect(piece.position).toEqual({ row: 1, col: 4 });
   });
 
+  test('can enter home stretch even if own piece is ahead on track', () => {
+    const game = new Game('pathClear');
+    game.addPlayer('1', 'A');
+    game.addPlayer('2', 'B');
+    game.addPlayer('3', 'C');
+    game.addPlayer('4', 'D');
+    game.setupTeams();
+
+    const mover = game.pieces.find(p => p.id === 'p2_1');
+    const blocker = game.pieces.find(p => p.id === 'p2_3');
+
+    mover.inPenaltyZone = false;
+    mover.position = { row: 18, col: 14 };
+
+    blocker.inPenaltyZone = false;
+    blocker.position = { row: 18, col: 10 };
+
+    const result = game.movePieceForward(mover, 5, true);
+
+    expect(result.success).toBe(true);
+    expect(mover.inHomeStretch).toBe(true);
+    expect(mover.position).toEqual({ row: 13, col: 14 });
+  });
+
+  test('movePieceForward cannot overpass inside home stretch', () => {
+    const game = new Game('noOverpass');
+    game.addPlayer('1', 'A');
+    game.addPlayer('2', 'B');
+    game.addPlayer('3', 'C');
+    game.addPlayer('4', 'D');
+    game.setupTeams();
+
+    const mover = game.pieces.find(p => p.id === 'p0_1');
+    const blocker = game.pieces.find(p => p.id === 'p0_2');
+
+    mover.inPenaltyZone = false;
+    mover.inHomeStretch = true;
+    mover.position = { row: 1, col: 4 };
+
+    blocker.inPenaltyZone = false;
+    blocker.inHomeStretch = true;
+    blocker.position = { row: 2, col: 4 };
+
+    expect(() => game.movePieceForward(mover, 2)).toThrow();
+  });
+
   test('makeSpecialMove moves one piece seven steps', () => {
     const game = new Game('room11');
     game.addPlayer('1', 'Alice');

--- a/server/game.js
+++ b/server/game.js
@@ -529,6 +529,11 @@ discardCard(cardIndex) {
       return this.moveInHomeStretch(piece, steps);
     }
     
+    const homeOption = this.checkHomeEntryOption(piece, steps);
+    if (homeOption && enterHome === true) {
+      return this.enterHomeStretch(piece, homeOption.remainingSteps);
+    }
+
     // Calcular nova posição na pista principal
     const newPosition = this.calculateNewPosition(piece.position, steps, true);
 
@@ -537,7 +542,6 @@ discardCard(cardIndex) {
       throw new Error("Não pode ultrapassar sua própria peça");
     }
 
-    const homeOption = this.checkHomeEntryOption(piece, steps);
     if (homeOption && enterHome === null) {
       return {
         success: false,
@@ -549,9 +553,6 @@ discardCard(cardIndex) {
       };
     }
 
-    if (homeOption && enterHome) {
-      return this.enterHomeStretch(piece, homeOption.remainingSteps);
-    }
 
     // Verificar se deve entrar no corredor de chegada diretamente
     if (this.shouldEnterHomeStretch(piece, newPosition)) {
@@ -976,7 +977,7 @@ discardCard(cardIndex) {
     const stretch = this.homeStretchForPlayer(piece.playerId);
     if (steps > stepsToEnt) {
       const remaining = steps - stepsToEnt;
-      if (remaining <= stretch.length) {
+      if (remaining <= stretch.length && !this.wouldOverpassOwnPiece(piece, stepsToEnt + 1, true)) {
         const boardPos = this.calculateNewPosition(piece.position, steps, true);
         const target = stretch[remaining - 1];
         const occupyingPiece = this.pieces.find(p =>


### PR DESCRIPTION
## Summary
- prevent false overpass error when moving into home stretch
- ensure entry path is clear of own pieces
- test entering home stretch with piece ahead
- test blocking overpass inside home stretch

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6840d7986cfc832ab83cd8145eabfc4f