### PR TITLE
Fix special move choice logic

### DIFF
--- a/public/js/game.js
+++ b/public/js/game.js
@@ -1027,7 +1027,9 @@ function makeMove() {
             canControlPiece(playerPosition, p.playerId) && !p.inPenaltyZone && !p.completed
         );
 
-        if (movable.length <= 1) {
+        const movableOnTrack = movable.filter(p => !p.inHomeStretch);
+
+        if (movableOnTrack.length <= 1) {
             socket.emit('makeSpecialMove', {
                 roomId,
                 moves: [{ pieceId: selectedPieceId, steps: 7 }],


### PR DESCRIPTION
## Summary
- avoid showing the second piece option when only one piece is on track during a special move

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840dd98aa74832a96d067ba3723f633