### PR TITLE
Adjust last move display

### DIFF
--- a/public/css/game.css
+++ b/public/css/game.css
@@ -88,9 +88,10 @@
 /* Mensagem da última jogada */
 #last-move {
     position: absolute;
-    top: 10%;
-    left: 10%;
-    transform: translate(-50%, -50%);
+    /* posiciona abaixo da pilha de descarte, centralizado */
+    top: calc(50% + 6rem);
+    left: 50%;
+    transform: translate(-50%, 0);
     background-color: rgba(255, 255, 255, 0.9);
     padding: 2px 4px;
     border-radius: 4px;


### PR DESCRIPTION
## Summary
- place `#last-move` directly below the discard area and centered

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68420f0d4b40832ab5b9b9917fd0628c