### PR TITLE
Fix home stretch entry check

### DIFF
--- a/server/__tests__/game.test.js
+++ b/server/__tests__/game.test.js
@@ -306,6 +306,32 @@ describe('Game class', () => {
     expect(mover.position).toEqual({ row: 13, col: 14 });
   });
 
+  test('home entry check happens before overpass check', () => {
+    const game = new Game('entryFirst');
+    game.addPlayer('1', 'A');
+    game.addPlayer('2', 'B');
+    game.addPlayer('3', 'C');
+    game.addPlayer('4', 'D');
+    game.setupTeams();
+
+    const mover = game.pieces.find(p => p.id === 'p0_1');
+    const blocker = game.pieces.find(p => p.id === 'p0_2');
+
+    mover.inPenaltyZone = false;
+    mover.position = { row: 0, col: 4 };
+
+    blocker.inPenaltyZone = false;
+    blocker.position = { row: 0, col: 8 };
+
+    const result = game.movePieceForward(mover, 5);
+
+    expect(result.action).toBe('homeEntryChoice');
+    const finish = game.movePieceForward(mover, 5, true);
+
+    expect(finish.success).toBe(true);
+    expect(mover.inHomeStretch).toBe(true);
+  });
+
   test('movePieceForward cannot overpass inside home stretch', () => {
     const game = new Game('noOverpass');
     game.addPlayer('1', 'A');

--- a/server/game.js
+++ b/server/game.js
@@ -531,8 +531,22 @@ discardCard(cardIndex) {
     }
     
     const homeOption = this.checkHomeEntryOption(piece, steps);
-    if (homeOption && enterHome === true) {
-      return this.enterHomeStretch(piece, homeOption.remainingSteps);
+    if (homeOption) {
+      if (enterHome === true) {
+        return this.enterHomeStretch(piece, homeOption.remainingSteps);
+      }
+
+      if (enterHome === null) {
+        return {
+          success: false,
+          action: 'homeEntryChoice',
+          pieceId: piece.id,
+          cardSteps: steps,
+          boardPosition: homeOption.boardPosition,
+          homePosition: homeOption.homePosition
+        };
+      }
+      // Se enterHome for false, continua movimentação normal
     }
 
     // Calcular nova posição na pista principal
@@ -541,17 +555,6 @@ discardCard(cardIndex) {
     // Verificar se vai ultrapassar peça do mesmo jogador
     if (this.wouldOverpassOwnPiece(piece, steps, true)) {
       throw new Error("Não pode ultrapassar sua própria peça");
-    }
-
-    if (homeOption && enterHome === null) {
-      return {
-        success: false,
-        action: 'homeEntryChoice',
-        pieceId: piece.id,
-        cardSteps: steps,
-        boardPosition: homeOption.boardPosition,
-        homePosition: homeOption.homePosition
-      };
     }
 
 


### PR DESCRIPTION
## Summary
- prioritize home stretch entry before overpass check
- add regression test for home entry with own piece ahead

## Testing
- `npm test --silent`
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_684210baf448832a8850cad47bf9e60f