### PR TITLE
Fix special move 7 when only one track piece

### DIFF
--- a/public/js/game.js
+++ b/public/js/game.js
@@ -1053,7 +1053,7 @@ function makeMove() {
 
         const movableOnTrack = movable.filter(p => !p.inHomeStretch);
 
-        if (movableOnTrack.length <= 1) {
+        if (movable.length <= 1) {
             socket.emit('makeSpecialMove', {
                 roomId,
                 moves: [{ pieceId: selectedPieceId, steps: 7 }],


### PR DESCRIPTION
## Summary
- fix 7-card special move selection logic when only one piece is on the track

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842151fcf04832a81bb3871eb9f3156