### PR TITLE
Fix training resets by isolating JSON output

### DIFF
--- a/game-ai-training/game/game_wrapper.js
+++ b/game-ai-training/game/game_wrapper.js
@@ -14,8 +14,14 @@ try {
     process.exit(1);
 }
 
-// Restore console.log
-console.log = originalConsoleLog;
+// Restore console.log and redirect all further output to stderr so that
+// stdout remains reserved for JSON communication with the Python side.
+console.log = (...args) => {
+    process.stderr.write(args.join(' ') + '\n');
+};
+console.error = (...args) => {
+    process.stderr.write(args.join(' ') + '\n');
+};
 
 class GameWrapper {
     constructor() {


### PR DESCRIPTION
## Summary
- redirect console output from `game_wrapper.js` to stderr
- keep stdout solely for JSON messages

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_684343438738832aa9149266727ba51f