### PR TITLE
Fix Python training start by printing JSON to stdout

### DIFF
--- a/game-ai-training/game/game_wrapper.js
+++ b/game-ai-training/game/game_wrapper.js
@@ -39,7 +39,8 @@ class GameWrapper {
     }
     
     sendResponse(response) {
-        console.log(JSON.stringify(response));
+        // Write JSON to stdout so the Python side can read it
+        process.stdout.write(JSON.stringify(response) + '\n');
     }
     
     setupGame() {


### PR DESCRIPTION
## Summary
- fix ready signal by writing game responses to stdout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68434d050a3c832a8ce5725920284fa6