### PR TITLE
Fix win tracking

### DIFF
--- a/game-ai-training/ai/environment.py
+++ b/game-ai-training/ai/environment.py
@@ -138,6 +138,9 @@ class GameEnvironment:
         response = self.send_command({"action": "reset"})
         if response.get('success'):
             self.game_state = response.get("gameState", {})
+            # Ensure win information fields exist for trainer
+            self.game_state['gameEnded'] = False
+            self.game_state['winningTeam'] = response.get('winningTeam')
             info("Game reset successful")
         else:
             error("Game reset failed", response=response)
@@ -221,9 +224,12 @@ class GameEnvironment:
         # Calculate reward
         reward = 0.1 if response.get('success') else -0.1
         done = response.get('gameEnded', False)
-        
+
         if response.get('success'):
             self.game_state = response.get("gameState", self.game_state)
+            # Preserve win information returned by the Node process
+            self.game_state['gameEnded'] = done
+            self.game_state['winningTeam'] = response.get('winningTeam')
         
         next_state = self.get_state(player_id)
         return next_state, reward, done

--- a/game-ai-training/tests/test_environment.py
+++ b/game-ai-training/tests/test_environment.py
@@ -21,10 +21,10 @@ def test_get_valid_actions_limits_to_ten():
 
 def test_step_updates_game_state_and_returns_rewards():
     env = GameEnvironment()
-    with patch.object(env, 'send_command', return_value={'success': True, 'gameState': {'foo': 'bar'}, 'gameEnded': False}):
+    with patch.object(env, 'send_command', return_value={'success': True, 'gameState': {'foo': 'bar'}, 'gameEnded': False, 'winningTeam': None}):
         with patch.object(env, 'get_state', return_value=np.zeros(env.state_size)):
             next_state, reward, done = env.step(1, 0)
     assert reward == 0.1
     assert done is False
-    assert env.game_state == {'foo': 'bar'}
+    assert env.game_state == {'foo': 'bar', 'gameEnded': False, 'winningTeam': None}
     assert isinstance(next_state, np.ndarray)


### PR DESCRIPTION
## Summary
- include `gameEnded` and `winningTeam` in game state
- update unit tests for new fields

## Testing
- `pip install -r game-ai-training/requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68435056bacc832ab192206323a5dd83