### PR TITLE
Add new env reset win test

### DIFF
--- a/game-ai-training/tests/test_environment.py
+++ b/game-ai-training/tests/test_environment.py
@@ -28,3 +28,11 @@ def test_step_updates_game_state_and_returns_rewards():
     assert done is False
     assert env.game_state == {'foo': 'bar', 'gameEnded': False, 'winningTeam': None}
     assert isinstance(next_state, np.ndarray)
+
+
+def test_reset_initializes_win_fields():
+    env = GameEnvironment()
+    with patch.object(env, 'start_node_game', return_value=True):
+        with patch.object(env, 'send_command', return_value={'success': True, 'gameState': {}, 'winningTeam': None}):
+            env.reset()
+    assert env.game_state == {'gameEnded': False, 'winningTeam': None}


### PR DESCRIPTION
## Summary
- improve GameEnvironment tests
- ensure win state fields are properly initialised by `reset`

## Testing
- `pip install numpy`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684354cbd558832a83a3a33eccf65286