### PR TITLE
Add game-ai-training test instructions

### DIFF
--- a/game-ai-training/README.md
+++ b/game-ai-training/README.md
@@ -5,3 +5,14 @@ This directory contains the Python training scripts and utilities used to train 
 ## JSON Logging
 
 Set the environment variable `JSON_LOGGING=1` before running the training scripts to output logs in machine readable JSON format. When enabled, each log message is emitted as a single JSON object on a separate line. Without this variable the logs remain human friendly text.
+
+## Running Tests
+
+Install the required Python packages and run the PyTest suite:
+
+```bash
+pip install -r game-ai-training/requirements.txt
+pytest
+```
+
+This installs all dependencies listed in `requirements.txt` and executes the tests located in `game-ai-training/tests`.


### PR DESCRIPTION
## Summary
- document how to install Python deps and run tests for the training code

## Testing
- `pip install -r game-ai-training/requirements.txt` *(fails: large downloads)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684354d603cc832a9490f94ff9a5ac7d