### PR TITLE
Remove reset call from start_node_game

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 package-lock.json
 replays/
 
+__pycache__/

--- a/game-ai-training/ai/environment.py
+++ b/game-ai-training/ai/environment.py
@@ -77,17 +77,9 @@ class GameEnvironment:
             if not ready:
                 error("No ready signal received")
                 return False
-            
-            # Test communication
-            info("Testing reset command")
-            test_response = self.send_command({"action": "reset"})
-            
-            if test_response.get('success'):
-                info("Node.js game process started successfully")
-                return True
-            else:
-                error("Communication test failed", response=test_response)
-                return False
+
+            info("Node.js game process started successfully")
+            return True
                 
         except Exception as e:
             error("Error starting Node.js game", exception=str(e))


### PR DESCRIPTION
## Summary
- avoid sending a reset command when starting the Node game
- ignore Python bytecode directories

## Testing
- `npm test`
- `python3 -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684354d83650832aa0f4543255637ba9