### PR TITLE
Print board state on reset

### DIFF
--- a/game-ai-training/ai/environment.py
+++ b/game-ai-training/ai/environment.py
@@ -134,6 +134,9 @@ class GameEnvironment:
             self.game_state['gameEnded'] = False
             self.game_state['winningTeam'] = response.get('winningTeam')
             info("Game reset successful")
+            board = response.get('board')
+            if board is not None:
+                info("Board state after reset", board=board)
         else:
             error("Game reset failed", response=response)
         

--- a/game-ai-training/game/game_wrapper.js
+++ b/game-ai-training/game/game_wrapper.js
@@ -94,7 +94,8 @@ class GameWrapper {
                     if (this.setupGame()) {
                         return {
                             success: true,
-                            gameState: this.getGameState()
+                            gameState: this.getGameState(),
+                            board: this.game.board
                         };
                     } else {
                         return { error: "Failed to setup game" };


### PR DESCRIPTION
## Summary
- expose board data in game_wrapper reset response
- log board state after each reset in the Python environment

## Testing
- `npm test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6843b95b0404832a8284ad15a90603a3