### PR TITLE
Add num_envs CLI option

### DIFF
--- a/game-ai-training/README.md
+++ b/game-ai-training/README.md
@@ -39,12 +39,16 @@ and start training as usual.
 
 The training manager can also run multiple game environments in parallel to
 speed up experience collection. Pass the `num_envs` argument to the `train`
-method to enable this:
+method or specify it on the command line:
 
 ```python
 manager = TrainingManager(num_envs=2)
 manager.create_bots()
 manager.train(num_envs=2)
+```
+
+```bash
+python3 game-ai-training/main.py --num_envs 2
 ```
 
 Each environment runs in its own thread with a separate Node.js game process.

--- a/game-ai-training/main.py
+++ b/game-ai-training/main.py
@@ -1,21 +1,36 @@
 #!/usr/bin/env python3
-import sys
 import os
+import argparse
 from ai.trainer import TrainingManager
 from json_logger import info, error
 
 def main():
+    parser = argparse.ArgumentParser(description="Game AI Training System")
+    parser.add_argument(
+        "--continue",
+        dest="resume",
+        action="store_true",
+        help="Resume training from saved models",
+    )
+    parser.add_argument(
+        "--num_envs",
+        type=int,
+        default=1,
+        help="Number of parallel environments to run",
+    )
+    args = parser.parse_args()
+
     info("Game AI Training System starting")
     info("Initializing training environment")
-    
+
     # Create training manager
-    trainer = TrainingManager()
+    trainer = TrainingManager(num_envs=args.num_envs)
     
     # Create bots
     trainer.create_bots(num_bots=4)
     
     # Check if we should load existing models
-    if len(sys.argv) > 1 and sys.argv[1] == "--continue":
+    if args.resume:
         model_path = "models/final"
         if os.path.exists(model_path):
             info(f"Loading existing models from {model_path}")
@@ -26,7 +41,7 @@ def main():
     # Start training
     info("Starting training process")
     try:
-        trainer.train()
+        trainer.train(num_envs=args.num_envs)
     except KeyboardInterrupt:
         info("Training interrupted by user")
         trainer.save_models("models/interrupted")


### PR DESCRIPTION
## Summary
- use `argparse` in game-ai-training launcher
- allow setting `--num_envs` on command line
- document the option in README

## Testing
- `pip install -r game-ai-training/requirements.txt` *(fails: torch install requires network)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6843ba9a0148832a8207e50711c23139