### PR TITLE
Add training move history logging

### DIFF
--- a/game-ai-training/tests/test_trainer.py
+++ b/game-ai-training/tests/test_trainer.py
@@ -8,6 +8,7 @@ class MockGameEnvironment:
         self.state_size = 1
         self.action_space_size = 1
         self.game_state = {'currentPlayerIndex': 0, 'gameEnded': False, 'winningTeam': None}
+        self.saved_file = None
 
     def reset(self):
         self.game_state = {'currentPlayerIndex': 0, 'gameEnded': False, 'winningTeam': None}
@@ -29,6 +30,9 @@ class MockGameEnvironment:
 
     def close(self):
         pass
+
+    def save_history(self, filepath):
+        self.saved_file = filepath
 
 
 class DummyGameBot:


### PR DESCRIPTION
## Summary
- add env_id and move history tracking in `GameEnvironment`
- persist move history for each training episode in `TrainingManager`
- update unit tests for new method

## Testing
- `npm test --silent`
- `pytest -q` *(fails: ModuleNotFoundError for numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68443094f198832a99f7bef2b099dfa8