### PR TITLE
Fix training crash when using parallel environments

### DIFF
--- a/game-ai-training/ai/environment.py
+++ b/game-ai-training/ai/environment.py
@@ -25,11 +25,6 @@ class GameEnvironment:
     def start_node_game(self):
         """Start the Node.js game process"""
         try:
-            # Kill any existing processes
-            subprocess.run(['pkill', '-f', 'game_wrapper.js'], 
-                          capture_output=True, check=False)
-            time.sleep(1)
-            
             info("Starting Node.js game process")
             
             # Start process with unbuffered I/O

--- a/game-ai-training/tests/test_trainer.py
+++ b/game-ai-training/tests/test_trainer.py
@@ -8,6 +8,8 @@ class MockGameEnvironment:
         self.state_size = 1
         self.action_space_size = 1
         self.game_state = {'currentPlayerIndex': 0, 'gameEnded': False, 'winningTeam': None}
+        # provide env_id attribute expected by TrainingManager
+        self.env_id = 0
         self.saved_file = None
 
     def reset(self):


### PR DESCRIPTION
## Summary
- prevent node process killing when starting multiple environments
- fix trainer unit test by adding env_id attribute

## Testing
- `pip install -r game-ai-training/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844341d5b84832a98bb6f734152c3bc