### PR TITLE
Fix move logging and training scripts

### DIFF
--- a/game-ai-training/ai/trainer.py
+++ b/game-ai-training/ai/trainer.py
@@ -141,12 +141,6 @@ class TrainingManager:
         
         self.training_stats['games_played'] += 1
         self.training_stats['episode_rewards'].append(sum(episode_rewards))
-        # Persist move log for analysis
-        log_file = os.path.join(
-            LOG_DIR,
-            f"episode_{self.training_stats['games_played']}_env_{env.env_id}.log"
-        )
-        env.save_history(log_file)
 
         return episode_rewards
     
@@ -168,12 +162,17 @@ class TrainingManager:
                 for episode in range(num_episodes):
                     self.train_episode(self.env)
 
-                    if episode % stats_freq == 0:
-                        self.print_statistics(episode)
+                    if (episode + 1) % stats_freq == 0:
+                        self.print_statistics(episode + 1)
                         self.plot_training_progress()
 
-                    if episode % save_freq == 0:
-                        self.save_models(f"{MODEL_DIR}/episode_{episode}")
+                    if (episode + 1) % save_freq == 0:
+                        self.save_models(f"{MODEL_DIR}/episode_{episode + 1}")
+                        log_file = os.path.join(
+                            LOG_DIR,
+                            f"episode_{episode + 1}_env_{self.env.env_id}.log"
+                        )
+                        self.env.save_history(log_file)
 
                 info("Training completed")
                 self.save_models(f"{MODEL_DIR}/final")
@@ -194,12 +193,20 @@ class TrainingManager:
                     with ThreadPoolExecutor(max_workers=num_envs) as executor:
                         list(executor.map(self.train_episode, self.envs))
 
-                    if episode % stats_freq == 0:
-                        self.print_statistics(episode * num_envs)
+                    if (episode + 1) % stats_freq == 0:
+                        self.print_statistics((episode + 1) * num_envs)
                         self.plot_training_progress()
 
-                    if episode % save_freq == 0:
-                        self.save_models(f"{MODEL_DIR}/episode_{episode * num_envs}")
+                    if (episode + 1) % save_freq == 0:
+                        self.save_models(
+                            f"{MODEL_DIR}/episode_{(episode + 1) * num_envs}"
+                        )
+                        for env in self.envs:
+                            log_file = os.path.join(
+                                LOG_DIR,
+                                f"episode_{(episode + 1) * num_envs}_env_{env.env_id}.log"
+                            )
+                            env.save_history(log_file)
 
                 info("Training completed")
                 self.save_models(f"{MODEL_DIR}/final")

--- a/game-ai-training/simple_start.sh
+++ b/game-ai-training/simple_start.sh
@@ -18,6 +18,9 @@ echo -e "${BLUE}=== Simple Game AI Training Launcher ===${NC}"
 # Create logs directory
 mkdir -p "$LOG_DIR"
 
+# Ensure we run from the script directory so relative paths resolve
+cd "$SCRIPT_DIR"
+
 # Function to cleanup any leftover processes
 cleanup() {
     echo -e "${BLUE}Cleaning up...${NC}"

--- a/game-ai-training/start_training.sh
+++ b/game-ai-training/start_training.sh
@@ -21,6 +21,9 @@ NC='\033[0m' # No Color
 # Create logs directory
 mkdir -p "$LOG_DIR"
 
+# Always operate from the script directory so relative paths work
+cd "$SCRIPT_DIR"
+
 # Function to print colored output
 print_status() {
     echo -e "${BLUE}[INFO]${NC} $1"


### PR DESCRIPTION
## Summary
- log move history only on save checkpoints
- ensure training scripts run from their directory

## Testing
- `npm test`
- `pytest game-ai-training/tests` *(fails: ModuleNotFoundError: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_e_684438664574832a9affd0d8a50ec539