### PR TITLE
Fix move history logs

### DIFF
--- a/game-ai-training/game/game_wrapper.js
+++ b/game-ai-training/game/game_wrapper.js
@@ -125,7 +125,12 @@ class GameWrapper {
                 isActive: false
             };
         }
-        
+
+        // Prefer the game's own helper so fields like `lastMove` are included
+        if (typeof this.game.getGameState === 'function') {
+            return this.game.getGameState();
+        }
+
         return {
             players: this.game.players || [],
             pieces: this.game.pieces || [],


### PR DESCRIPTION
## Summary
- ensure `GameWrapper` delegates state retrieval to the underlying game

## Testing
- `npm test`
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684447d3f9c0832a8eecc236b90f38a9