### PR TITLE
Fix history reset between games

### DIFF
--- a/server/game.js
+++ b/server/game.js
@@ -177,6 +177,7 @@ startGame() {
     this.currentPlayerIndex = 0;
     this.isActive = false;
     this.pendingSpecialMove = null;
+    this.history = [];
     for (const player of this.players) {
       player.cards = [];
     }


### PR DESCRIPTION
## Summary
- clear history when a new match starts

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68445649b86483298dcc311816923151