### PR TITLE
Add save-match-log option

### DIFF
--- a/game-ai-training/README.md
+++ b/game-ai-training/README.md
@@ -28,6 +28,14 @@ python3 game-ai-training/main.py --continue
 
 The trainer will load the models from `models/final` if they exist.
 
+## Match Logging
+
+Passing the `--save-match-log` flag to `main.py` writes the move history of
+every game played at each save interval to the `logs/` directory. The log files
+follow the pattern `episode_<N>_env_<ID>.log` where `<N>` is the episode number
+and `<ID>` identifies the environment when multiple environments run in
+parallel.
+
 ## Multi-GPU Support
 
 When multiple CUDA devices are available, the training manager will now

--- a/game-ai-training/ai/trainer.py
+++ b/game-ai-training/ai/trainer.py
@@ -144,7 +144,7 @@ class TrainingManager:
 
         return episode_rewards
     
-    def train(self, num_episodes=None, save_freq=None, stats_freq=None, num_envs: int = 1):
+    def train(self, num_episodes=None, save_freq=None, stats_freq=None, num_envs: int = 1, save_match_log: bool = False):
         """Train using one or more environments in parallel."""
         num_episodes = num_episodes or TRAINING_CONFIG['num_episodes']
         save_freq = save_freq or TRAINING_CONFIG['save_frequency']
@@ -168,11 +168,12 @@ class TrainingManager:
 
                     if (episode + 1) % save_freq == 0:
                         self.save_models(f"{MODEL_DIR}/episode_{episode + 1}")
-                        log_file = os.path.join(
-                            LOG_DIR,
-                            f"episode_{episode + 1}_env_{self.env.env_id}.log"
-                        )
-                        self.env.save_history(log_file)
+                        if save_match_log:
+                            log_file = os.path.join(
+                                LOG_DIR,
+                                f"episode_{episode + 1}_env_{self.env.env_id}.log"
+                            )
+                            self.env.save_history(log_file)
 
                 info("Training completed")
                 self.save_models(f"{MODEL_DIR}/final")
@@ -201,12 +202,13 @@ class TrainingManager:
                         self.save_models(
                             f"{MODEL_DIR}/episode_{(episode + 1) * num_envs}"
                         )
-                        for env in self.envs:
-                            log_file = os.path.join(
-                                LOG_DIR,
-                                f"episode_{(episode + 1) * num_envs}_env_{env.env_id}.log"
-                            )
-                            env.save_history(log_file)
+                        if save_match_log:
+                            for env in self.envs:
+                                log_file = os.path.join(
+                                    LOG_DIR,
+                                    f"episode_{(episode + 1) * num_envs}_env_{env.env_id}.log"
+                                )
+                                env.save_history(log_file)
 
                 info("Training completed")
                 self.save_models(f"{MODEL_DIR}/final")

--- a/game-ai-training/main.py
+++ b/game-ai-training/main.py
@@ -18,6 +18,12 @@ def main():
         default=1,
         help="Number of parallel environments to run",
     )
+    parser.add_argument(
+        "--save-match-log",
+        dest="save_match_log",
+        action="store_true",
+        help="Save move history every save_frequency episodes",
+    )
     args = parser.parse_args()
 
     info("Game AI Training System starting")
@@ -41,7 +47,7 @@ def main():
     # Start training
     info("Starting training process")
     try:
-        trainer.train(num_envs=args.num_envs)
+        trainer.train(num_envs=args.num_envs, save_match_log=args.save_match_log)
     except KeyboardInterrupt:
         info("Training interrupted by user")
         trainer.save_models("models/interrupted")


### PR DESCRIPTION
## Summary
- add `--save-match-log` flag to training CLI
- support `save_match_log` parameter in trainer so that move history is written on save intervals
- document match logging feature

## Testing
- `pip install -r game-ai-training/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68445714b970832a8b45ac24e8c955b8