### PR TITLE
Fix discardCard not advancing turn

### DIFF
--- a/game-ai-training/game/game.js
+++ b/game-ai-training/game/game.js
@@ -285,6 +285,10 @@ discardCard(cardIndex) {
       this.logMoveDetails(player, firstPenaltyPiece.id, oldPos, result, card);
       const discardMsg = `${player.name} descartou um ${card.value === 'JOKER' ? 'C' : card.value}`;
       this.history.push(discardMsg);
+
+      // Passar a vez para o próximo jogador
+      this.nextTurn();
+
       return result;
     }
   }

--- a/server/__tests__/game.test.js
+++ b/server/__tests__/game.test.js
@@ -629,4 +629,20 @@ describe('Game class', () => {
     expect(partnerPiece.position).toEqual({ row: 0, col: 1 });
   });
 
+  test('discardCard advances turn when leaving penalty zone', () => {
+    const game = new Game('discardTurn');
+    game.addPlayer('1', 'A');
+    game.addPlayer('2', 'B');
+    game.addPlayer('3', 'C');
+    game.addPlayer('4', 'D');
+    game.startGame();
+
+    const player = game.getCurrentPlayer();
+    player.cards = [{ suit: '♠', value: 'A' }];
+
+    const result = game.discardCard(0);
+    expect(result.action).toBe('leavePenalty');
+    expect(game.currentPlayerIndex).toBe(1);
+  });
+
 });

--- a/server/game.js
+++ b/server/game.js
@@ -237,9 +237,13 @@ discardCard(cardIndex) {
       // Descartar a carta
       this.discardPile.push(card);
       player.cards.splice(cardIndex, 1);
-      
       // Sair do castigo com esta peça
-      return this.leavePenaltyZone(firstPenaltyPiece);
+      const result = this.leavePenaltyZone(firstPenaltyPiece);
+
+      // Passar a vez para o próximo jogador
+      this.nextTurn();
+
+      return result;
     }
   }
   


### PR DESCRIPTION
## Summary
- advance turn when leaving the penalty zone in `discardCard`
- update training game's version of `discardCard`
- test that `discardCard` advances the turn

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844736d5038832abc4e4910e057811f