### PR TITLE
Sync discard guard and lock across training

### DIFF
--- a/game-ai-training/game/game.js
+++ b/game-ai-training/game/game.js
@@ -225,6 +225,10 @@ startGame() {
     }
   }
 
+  endGame() {
+    this.isActive = false;
+  }
+
   getCurrentPlayer() {
     console.log(`Obtendo jogador atual. Índice: ${this.currentPlayerIndex}, Total de jogadores: ${this.players.length}`);
     
@@ -266,10 +270,11 @@ discardCard(cardIndex) {
   }
   
   const card = player.cards[cardIndex];
-  
+
   // Verificar se todas as peças estão no castigo
   const playerPieces = this.pieces.filter(p => p.playerId === player.position);
   const allInPenalty = playerPieces.every(p => p.inPenaltyZone);
+  const hasMove = this.hasAnyValidMove(player.position);
   
   // Se todas as peças estão no castigo e a carta é A, K, Q ou J, tentar sair do castigo
   if (allInPenalty && ['A', 'K', 'Q', 'J'].includes(card.value)) {
@@ -309,7 +314,16 @@ discardCard(cardIndex) {
   
   // Se nem todas as peças estão no castigo, verificar se o jogador tem peças fora
   if (!allInPenalty) {
-    throw new Error("Você deve mover uma peça fora do castigo");
+    if (hasMove) {
+      throw new Error("Você ainda tem jogadas disponíveis");
+    }
+    // Não possui movimentos válidos, permitir descarte
+    this.discardPile.push(card);
+    player.cards.splice(cardIndex, 1);
+
+    this.nextTurn();
+
+    return { success: true, action: 'discard' };
   }
   
   throw new Error("Você deve usar A, K, Q ou J para sair do castigo ou ter peças fora do castigo para usar outras cartas");

--- a/game-ai-training/game/server.js
+++ b/game-ai-training/game/server.js
@@ -374,7 +374,13 @@ socket.on('discardCard', ({ roomId, cardIndex }) => {
     // Verificar se todas as peças estão no castigo
     const playerPieces = game.pieces.filter(p => p.playerId === currentPlayer.position);
     const allInPenalty = playerPieces.every(p => p.inPenaltyZone);
-    
+    const hasMove = game.hasAnyValidMove(currentPlayer.position);
+
+    if (!allInPenalty && hasMove) {
+      socket.emit('error', 'Você ainda tem jogadas disponíveis');
+      return;
+    }
+
     // Se todas as peças estão no castigo e a carta é A, K, Q ou J, permitir sair do castigo
     if (allInPenalty && ['A', 'K', 'Q', 'J'].includes(card.value)) {
       // Encontrar a primeira peça no castigo
@@ -539,6 +545,7 @@ socket.on('makeJokerMove', ({ roomId, pieceId, targetPieceId, cardIndex }) => {
       io.to(roomId).emit('gameOver', {
         winners: game.getWinningTeam()
       });
+      game.endGame();
       return;
     }
 
@@ -670,6 +677,7 @@ socket.on('makeMove', ({ roomId, pieceId, cardIndex, enterHome }) => {
       io.to(roomId).emit('gameOver', {
         winners: game.getWinningTeam()
       });
+      game.endGame();
       return;
     }
 
@@ -725,6 +733,7 @@ socket.on('confirmHomeEntry', ({ roomId, pieceId, cardIndex, enterHome }) => {
       io.to(roomId).emit('gameOver', {
         winners: game.getWinningTeam()
       });
+      game.endGame();
       return;
     }
 
@@ -792,6 +801,7 @@ socket.on('confirmHomeEntry', ({ roomId, pieceId, cardIndex, enterHome }) => {
         io.to(roomId).emit('gameOver', {
           winners: game.getWinningTeam()
         });
+        game.endGame();
         return;
       }
       
@@ -857,6 +867,7 @@ socket.on('confirmHomeEntry', ({ roomId, pieceId, cardIndex, enterHome }) => {
         io.to(roomId).emit('gameOver', {
           winners: game.getWinningTeam()
         });
+        game.endGame();
         return;
       }
 

--- a/server/__tests__/game.test.js
+++ b/server/__tests__/game.test.js
@@ -645,4 +645,28 @@ describe('Game class', () => {
     expect(game.currentPlayerIndex).toBe(3);
   });
 
+  test('discardCard cannot discard when a move exists', () => {
+    const game = new Game('discardGuard');
+    game.addPlayer('1', 'A');
+    game.addPlayer('2', 'B');
+    game.addPlayer('3', 'C');
+    game.addPlayer('4', 'D');
+    game.startGame();
+
+    const player = game.getCurrentPlayer();
+    player.cards = [{ suit: '♠', value: 'A' }];
+    const piece = game.pieces.find(p => p.playerId === player.position);
+    piece.inPenaltyZone = false;
+    piece.position = { row: 0, col: 0 };
+
+    expect(() => game.discardCard(0)).toThrow();
+  });
+
+  test('endGame sets game inactive', () => {
+    const game = new Game('lock');
+    game.isActive = true;
+    game.endGame();
+    expect(game.isActive).toBe(false);
+  });
+
 });

--- a/server/game.js
+++ b/server/game.js
@@ -183,6 +183,10 @@ startGame() {
     }
   }
 
+  endGame() {
+    this.isActive = false;
+  }
+
   getCurrentPlayer() {
     console.log(`Obtendo jogador atual. Índice: ${this.currentPlayerIndex}, Total de jogadores: ${this.players.length}`);
     
@@ -224,11 +228,13 @@ discardCard(cardIndex) {
   }
   
   const card = player.cards[cardIndex];
-  
+
   // Verificar se todas as peças estão no castigo
   const playerPieces = this.pieces.filter(p => p.playerId === player.position);
   const allInPenalty = playerPieces.every(p => p.inPenaltyZone);
-  
+
+  const hasMove = this.hasAnyValidMove(player.position);
+
   // Se todas as peças estão no castigo e a carta é A, K, Q ou J, tentar sair do castigo
   if (allInPenalty && ['A', 'K', 'Q', 'J'].includes(card.value)) {
     // Encontrar a primeira peça no castigo
@@ -246,7 +252,7 @@ discardCard(cardIndex) {
       return result;
     }
   }
-  
+
   // Se todas as peças estão no castigo e a carta não é A, K, Q ou J, permitir descarte
   if (allInPenalty && !['A', 'K', 'Q', 'J'].includes(card.value)) {
     // Descartar a carta
@@ -258,12 +264,21 @@ discardCard(cardIndex) {
     
     return { success: true, action: 'discard' };
   }
-  
+
   // Se nem todas as peças estão no castigo, verificar se o jogador tem peças fora
   if (!allInPenalty) {
-    throw new Error("Você deve mover uma peça fora do castigo");
+    if (hasMove) {
+      throw new Error("Você ainda tem jogadas disponíveis");
+    }
+    // Não possui movimentos válidos, permitir descarte
+    this.discardPile.push(card);
+    player.cards.splice(cardIndex, 1);
+
+    this.nextTurn();
+
+    return { success: true, action: 'discard' };
   }
-  
+
   throw new Error("Você deve usar A, K, Q ou J para sair do castigo ou ter peças fora do castigo para usar outras cartas");
 }
 

--- a/server/server.js
+++ b/server/server.js
@@ -372,11 +372,17 @@ socket.on('discardCard', ({ roomId, cardIndex }) => {
   
   const card = currentPlayer.cards[cardIndex];
   console.log(`Jogador ${currentPlayer.name} descartando carta ${card.suit}${card.value}`);
-  
+
   try {
     // Verificar se todas as peças estão no castigo
     const playerPieces = game.pieces.filter(p => p.playerId === currentPlayer.position);
     const allInPenalty = playerPieces.every(p => p.inPenaltyZone);
+    const hasMove = game.hasAnyValidMove(currentPlayer.position);
+
+    if (!allInPenalty && hasMove) {
+      socket.emit('error', 'Você ainda tem jogadas disponíveis');
+      return;
+    }
     
     // Se todas as peças estão no castigo e a carta é A, K, Q ou J, permitir sair do castigo
     if (allInPenalty && ['A', 'K', 'Q', 'J'].includes(card.value)) {
@@ -542,6 +548,7 @@ socket.on('makeJokerMove', ({ roomId, pieceId, targetPieceId, cardIndex }) => {
       io.to(roomId).emit('gameOver', {
         winners: game.getWinningTeam()
       });
+      game.endGame();
       return;
     }
 
@@ -673,6 +680,7 @@ socket.on('makeMove', ({ roomId, pieceId, cardIndex, enterHome }) => {
       io.to(roomId).emit('gameOver', {
         winners: game.getWinningTeam()
       });
+      game.endGame();
       return;
     }
 
@@ -728,6 +736,7 @@ socket.on('confirmHomeEntry', ({ roomId, pieceId, cardIndex, enterHome }) => {
       io.to(roomId).emit('gameOver', {
         winners: game.getWinningTeam()
       });
+      game.endGame();
       return;
     }
 
@@ -795,6 +804,7 @@ socket.on('confirmHomeEntry', ({ roomId, pieceId, cardIndex, enterHome }) => {
         io.to(roomId).emit('gameOver', {
           winners: game.getWinningTeam()
         });
+        game.endGame();
         return;
       }
       
@@ -860,6 +870,7 @@ socket.on('confirmHomeEntry', ({ roomId, pieceId, cardIndex, enterHome }) => {
         io.to(roomId).emit('gameOver', {
           winners: game.getWinningTeam()
         });
+        game.endGame();
         return;
       }
 


### PR DESCRIPTION
## Summary
- add `endGame` helper to training `Game`
- tighten discard rules in training logic
- lock the game on victory in training server

## Testing
- `npm test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6845a2abe484832a82db7a3fc9f87ab4