### PR TITLE
Fix discard availability based on valid moves

### DIFF
--- a/game-ai-training/game/game_wrapper.js
+++ b/game-ai-training/game/game_wrapper.js
@@ -156,9 +156,11 @@ class GameWrapper {
                 }
             }
             
-            // Add discard actions
-            for (let cardIdx = 0; cardIdx < 5; cardIdx++) {
-                validActions.push(40 + cardIdx);
+            // Add discard actions only when the player has no valid moves
+            if (!this.game.hasAnyValidMove(playerId)) {
+                for (let cardIdx = 0; cardIdx < 5; cardIdx++) {
+                    validActions.push(40 + cardIdx);
+                }
             }
             
             return validActions.length > 0 ? validActions.slice(0, 10) : [0]; // Limit to 10 actions


### PR DESCRIPTION
## Summary
- add condition to only offer discard actions when no moves are available
- test Node wrapper behaviour through environment tests

## Testing
- `npm install`
- `pip install -r game-ai-training/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845e7ae1804832a9c255dcb917e3e0c