### PR TITLE
Fix CUDA assertion by clamping action ids

### DIFF
--- a/game-ai-training/ai/environment.py
+++ b/game-ai-training/ai/environment.py
@@ -207,7 +207,14 @@ class GameEnvironment:
         })
         
         actions = response.get("validActions", [0])
-        return actions[:10] if len(actions) > 10 else actions  # Limit actions
+        # Ensure actions are within the defined action space. The Node.js
+        # wrapper should already enforce this, but extra validation guards
+        # against out-of-range values that would crash the PyTorch training.
+        filtered = [a for a in actions if 0 <= a < self.action_space_size]
+        if not filtered:
+            filtered = [0]
+
+        return filtered[:10] if len(filtered) > 10 else filtered  # Limit actions
     
     def step(self, action: int, player_id: int) -> Tuple[np.ndarray, float, bool]:
         """Execute action and return next_state, reward, done"""

--- a/game-ai-training/game/game_wrapper.js
+++ b/game-ai-training/game/game_wrapper.js
@@ -148,7 +148,12 @@ class GameWrapper {
             const validActions = [];
             const player = this.game.players[playerId];
 
-            for (let cardIdx = 0; cardIdx < player.cards.length; cardIdx++) {
+            // Limit to the first 5 cards so that generated action IDs never
+            // exceed the Python trainer's action space of 50. Each card index
+            // contributes at most five piece moves (cardIdx * 10 + pieceNum) and
+            // cardIdx >= 5 would produce IDs >= 50.
+            const maxMoveCards = Math.min(player.cards.length, 5);
+            for (let cardIdx = 0; cardIdx < maxMoveCards; cardIdx++) {
                 for (let pieceNum = 1; pieceNum <= 5; pieceNum++) {
                     const pieceId = `p${playerId}_${pieceNum}`;
                     const piece = this.game.pieces.find(p => p.id === pieceId);
@@ -166,8 +171,11 @@ class GameWrapper {
                 }
             }
 
-            if (validActions.length === 0 && !this.game.hasAnyValidMove(playerId)) {
-                for (let cardIdx = 0; cardIdx < player.cards.length; cardIdx++) {
+            if (!this.game.hasAnyValidMove(playerId)) {
+                // Discard actions use IDs 40-49 (10 possible discards). Constrain
+                // the number of cards considered so action IDs remain < 50.
+                const maxDiscardCards = Math.min(player.cards.length, 10);
+                for (let cardIdx = 0; cardIdx < maxDiscardCards; cardIdx++) {
                     validActions.push(40 + cardIdx);
                 }
             }


### PR DESCRIPTION
## Summary
- ensure valid action ids returned by Node wrapper stay below 50
- validate action ids in Python environment

## Testing
- `pip install -r game-ai-training/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68462cc8b394832a8992b21e1fbe33f3