### PR TITLE
Fix piece position revert on invalid capture

### DIFF
--- a/server/__tests__/game.test.js
+++ b/server/__tests__/game.test.js
@@ -262,6 +262,31 @@ describe('Game class', () => {
     expect(() => game.movePieceForward(mover, 3)).toThrow();
   });
 
+  test('movePieceBackward reverts position on invalid partner capture', () => {
+    const game = new Game('revertBack');
+    game.addPlayer('1', 'Alice');
+    game.addPlayer('2', 'Bob');
+    game.addPlayer('3', 'Carol');
+    game.addPlayer('4', 'Dave');
+    game.setupTeams();
+
+    const mover = game.pieces.find(p => p.id === 'p1_4');
+    const partner = game.pieces.find(p => p.id === 'p3_4');
+    const blocker = game.pieces.find(p => p.id === 'p3_3');
+
+    mover.inPenaltyZone = false;
+    mover.position = { row: 4, col: 18 };
+
+    partner.inPenaltyZone = false;
+    partner.position = { row: 0, col: 14 };
+
+    blocker.inPenaltyZone = false;
+    blocker.position = { row: 14, col: 0 };
+
+    expect(() => game.movePieceBackward(mover, 8)).toThrow();
+    expect(mover.position).toEqual({ row: 4, col: 18 });
+  });
+
   test('landing exactly on home entrance does not offer entry option', () => {
     const game = new Game('room10');
     game.addPlayer('1', 'Alice');

--- a/server/game.js
+++ b/server/game.js
@@ -586,11 +586,16 @@ discardCard(cardIndex) {
     }
     
     // Mover para a nova posição
-    const oldPosition = {...piece.position};
+    const oldPosition = { ...piece.position };
     piece.position = newPosition;
-    
-    // Verificar se "comeu" alguma peça
-    return this.checkCapture(piece, oldPosition);
+
+    try {
+      // Verificar se "comeu" alguma peça
+      return this.checkCapture(piece, oldPosition);
+    } catch (err) {
+      piece.position = oldPosition;
+      throw err;
+    }
   }
 
   movePieceBackward(piece, steps) {
@@ -607,11 +612,16 @@ discardCard(cardIndex) {
     }
     
     // Mover para a nova posição
-    const oldPosition = {...piece.position};
+    const oldPosition = { ...piece.position };
     piece.position = newPosition;
-    
-    // Verificar se "comeu" alguma peça
-    return this.checkCapture(piece, oldPosition);
+
+    try {
+      // Verificar se "comeu" alguma peça
+      return this.checkCapture(piece, oldPosition);
+    } catch (err) {
+      piece.position = oldPosition;
+      throw err;
+    }
   }
 
   moveToOccupiedSpace(piece) {
@@ -657,10 +667,15 @@ discardCard(cardIndex) {
       throw new Error("Posição inválida");
     }
     
-    const oldPosition = {...piece.position};
-    piece.position = {...targetPiece.position};
-    
-    return this.checkCapture(piece, oldPosition);
+    const oldPosition = { ...piece.position };
+    piece.position = { ...targetPiece.position };
+
+    try {
+      return this.checkCapture(piece, oldPosition);
+    } catch (err) {
+      piece.position = oldPosition;
+      throw err;
+    }
   }
 
   calculateNewPosition(currentPos, steps, isForward) {


### PR DESCRIPTION
## Summary
- keep piece position unchanged when partner capture is invalid
- add regression test for movePieceBackward

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684706cb7574832a92bd95c00c0f43f9