### PR TITLE
Fix seven-card modal logic

### DIFF
--- a/public/game.html
+++ b/public/game.html
@@ -48,9 +48,9 @@
         
         <div id="special-move-dialog" class="dialog hidden">
             <div id="special-move-choice" class="hidden">
-                <p>Usar mesma peça ou escolher outra?</p>
-                <button id="same-piece-btn">Mesma peça</button>
-                <button id="other-piece-btn">Outra peça</button>
+                <p>Usar uma peça ou dividir entre duas?</p>
+                <button id="same-piece-btn">Uma peça</button>
+                <button id="other-piece-btn">Duas peças</button>
             </div>
             <div id="special-move-slider" class="hidden">
                 <div class="slider-labels">

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -1083,7 +1083,7 @@ function makeMove() {
 
         const movableOnTrack = movable.filter(p => !p.inHomeStretch);
 
-        if (movable.length <= 1) {
+        if (movableOnTrack.length <= 1) {
             socket.emit('makeSpecialMove', {
                 roomId,
                 moves: [{ pieceId: selectedPieceId, steps: 7 }],


### PR DESCRIPTION
## Summary
- only show special move dialog for the 7 card when more than one piece on the track can move
- update modal labels to "Uma peça" and "Duas peças"

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684721a2ca74832a921467166b37a55a