### PR TITLE
Add in-game stats tracking

### DIFF
--- a/public/css/game.css
+++ b/public/css/game.css
@@ -79,6 +79,7 @@
     display: flex;
     justify-content: center;
     align-items: center;
+    gap: 1rem;
     position: relative;
     width: fit-content;
     height: fit-content;
@@ -361,6 +362,11 @@
     font-size: 1.2rem;
 }
 
+#final-stats {
+    margin-top: 1rem;
+    text-align: left;
+}
+
 @media (max-width: 768px) {
     .game-info {
         flex-direction: column;
@@ -434,6 +440,20 @@
 }
 .card.discard-only:hover {
   background-color: #fadbd8;
+}
+
+.stats-panel {
+  background: #ffffff;
+  padding: 0.5rem;
+  border-radius: 4px;
+  box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+  min-width: 150px;
+}
+
+@media (max-width: 1000px) {
+  .stats-panel {
+    display: none;
+  }
 }
 /* Adicione ao arquivo game.css */
 .joker-mode .piece {

--- a/public/game.html
+++ b/public/game.html
@@ -40,6 +40,7 @@
                     <span id="discard-count">0</span>
                 </div>
             </div>
+            <div id="stats-panel" class="stats-panel hidden"></div>
         </div>
         
         <div class="player-hand">
@@ -74,6 +75,7 @@
         <div id="game-over" class="dialog hidden">
             <h2>Fim de Jogo!</h2>
             <div id="winners"></div>
+            <div id="final-stats"></div>
             <div class="button-group">
                 <button id="rematch-btn" class="btn primary">Revanche</button>
                 <button id="exit-btn" class="btn secondary">Sair</button>

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -15,6 +15,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const jokerDialog = document.getElementById('joker-dialog');
     const gameOverDialog = document.getElementById('game-over');
     const winnersDiv = document.getElementById('winners');
+    const finalStatsDiv = document.getElementById('final-stats');
     const lastMoveDiv = document.getElementById('last-move');
     
     // Elementos do diálogo de movimento especial (carta 7)
@@ -31,6 +32,8 @@ document.addEventListener('DOMContentLoaded', () => {
     // Elementos do diálogo de movimento com Joker
     const jokerPositions = document.getElementById('joker-positions');
     const cancelJokerMoveBtn = document.getElementById('cancel-joker-move');
+
+    const statsPanel = document.getElementById('stats-panel');
     
     // Botões do diálogo de fim de jogo
     const rematchBtn = document.getElementById('rematch-btn');
@@ -246,6 +249,7 @@ function handleGameStarted(state) {
   updateTeams();
   updateTurnInfo();
   updateDeckInfo();
+  updateStats(state.stats);
   if (state.lastMove) {
     showLastMove(state.lastMove);
   }
@@ -296,6 +300,7 @@ function handlePlayerInfo(data) {
         updateTeams();
         updateTurnInfo();
         updateDeckInfo();
+        updateStats(state.stats);
         if (state.lastMove) {
             showLastMove(state.lastMove);
         }
@@ -407,10 +412,18 @@ function checkIfStuckInPenalty(cards, canMoveFlag) {
 
     function handleGameOver(data) {
         isMyTurn = false;
-        
+
         // Mostrar diálogo de fim de jogo
         const winners = data.winners.map(player => player.name).join(' e ');
         winnersDiv.textContent = `Parabéns! ${winners} venceram o jogo!`;
+        if (data.stats && finalStatsDiv) {
+            finalStatsDiv.innerHTML = `
+                <p>Maior número de capturas: <strong>${data.stats.mostCaptures.name || 'N/A'}</strong> (${data.stats.mostCaptures.count})</p>
+                <p>Mais rodadas preso: <strong>${data.stats.mostRoundsStuck.name || 'N/A'}</strong> (${data.stats.mostRoundsStuck.count})</p>
+                <p>Mais Jokers jogados: <strong>${data.stats.mostJokers.name || 'N/A'}</strong> (${data.stats.mostJokers.count})</p>
+                <p>Jogador mais capturado: <strong>${data.stats.mostCaptured.name || 'N/A'}</strong> (${data.stats.mostCaptured.count})</p>
+            `;
+        }
         gameOverDialog.classList.remove('hidden');
     }
     
@@ -845,6 +858,17 @@ function updateTurnInfo() {
             topDiscard.innerHTML = '';
             topDiscard.classList.add('hidden');
         }
+    }
+
+    function updateStats(stats) {
+        if (!stats || !statsPanel) return;
+        statsPanel.innerHTML = `
+            <p>Capturas: <strong>${stats.captures.map((c, i) => `${i+1}:${c}`).join(' ')}</strong></p>
+            <p>Preso: <strong>${stats.roundsWithoutPlay.map((c,i)=>`${i+1}:${c}`).join(' ')}</strong></p>
+            <p>Jokers: <strong>${stats.jokersPlayed.map((c,i)=>`${i+1}:${c}`).join(' ')}</strong></p>
+            <p>Capturado: <strong>${stats.timesCaptured.map((c,i)=>`${i+1}:${c}`).join(' ')}</strong></p>
+        `;
+        statsPanel.classList.remove('hidden');
     }
     
 function updateCards(cards) {

--- a/server/server.js
+++ b/server/server.js
@@ -549,6 +549,7 @@ socket.on('makeJokerMove', ({ roomId, pieceId, targetPieceId, cardIndex }) => {
     // Descartar a carta Joker
     game.discardPile.push(card);
     currentPlayer.cards.splice(cardIndex, 1);
+    game.stats.jokersPlayed[currentPlayer.position]++;
 
     // Avançar o turno antes de enviar o novo estado
     game.nextTurn();
@@ -564,7 +565,8 @@ socket.on('makeJokerMove', ({ roomId, pieceId, targetPieceId, cardIndex }) => {
     if (game.checkWinCondition()) {
       saveReplay(game);
       io.to(roomId).emit('gameOver', {
-        winners: game.getWinningTeam()
+        winners: game.getWinningTeam(),
+        stats: game.getStatisticsSummary()
       });
       game.endGame();
       return;
@@ -697,7 +699,8 @@ socket.on('makeMove', ({ roomId, pieceId, cardIndex, enterHome }) => {
     if (game.checkWinCondition()) {
       saveReplay(game);
       io.to(roomId).emit('gameOver', {
-        winners: game.getWinningTeam()
+        winners: game.getWinningTeam(),
+        stats: game.getStatisticsSummary()
       });
       game.endGame();
       return;
@@ -754,7 +757,8 @@ socket.on('confirmHomeEntry', ({ roomId, pieceId, cardIndex, enterHome }) => {
     if (game.checkWinCondition()) {
       saveReplay(game);
       io.to(roomId).emit('gameOver', {
-        winners: game.getWinningTeam()
+        winners: game.getWinningTeam(),
+        stats: game.getStatisticsSummary()
       });
       game.endGame();
       return;
@@ -823,7 +827,8 @@ socket.on('confirmHomeEntry', ({ roomId, pieceId, cardIndex, enterHome }) => {
       if (game.checkWinCondition()) {
         saveReplay(game);
         io.to(roomId).emit('gameOver', {
-          winners: game.getWinningTeam()
+          winners: game.getWinningTeam(),
+          stats: game.getStatisticsSummary()
         });
         game.endGame();
         return;
@@ -890,7 +895,8 @@ socket.on('confirmHomeEntry', ({ roomId, pieceId, cardIndex, enterHome }) => {
       if (game.checkWinCondition()) {
         saveReplay(game);
         io.to(roomId).emit('gameOver', {
-          winners: game.getWinningTeam()
+          winners: game.getWinningTeam(),
+          stats: game.getStatisticsSummary()
         });
         game.endGame();
         return;


### PR DESCRIPTION
## Summary
- track player stats in `Game` and expose them in game state
- send statistics on game over
- display stats during the game on wide screens
- show detailed stats in the end game dialog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847273644f8832a9f1f5e5c0a13c38a