### PR TITLE
Fix no-play stat

### DIFF
--- a/server/game.js
+++ b/server/game.js
@@ -292,6 +292,9 @@ discardCard(cardIndex) {
     this.discardPile.push(card);
     player.cards.splice(cardIndex, 1);
 
+    // Contabilizar rodada sem jogada efetiva
+    this.stats.roundsWithoutPlay[player.position]++;
+
     this.nextTurn();
 
     return { success: true, action: 'discard' };


### PR DESCRIPTION
## Summary
- increment `roundsWithoutPlay` when discarding because no valid moves

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68472c728d08832a9ca462cd29abe93f