### PR TITLE
Improve joker log and relocate last move

### DIFF
--- a/public/css/game.css
+++ b/public/css/game.css
@@ -88,17 +88,26 @@
 
 /* Mensagem da última jogada */
 #last-move {
-    position: absolute;
-    /* posiciona abaixo da pilha de descarte, centralizado */
-    top: calc(50% + 6rem);
-    left: 50%;
-    transform: translate(-50%, 0);
     background-color: rgba(255, 255, 255, 0.9);
     padding: 2px 4px;
     border-radius: 4px;
     font-size: 0.7rem;
-    z-index: 20;
+    text-align: center;
+    margin-bottom: 0.3rem;
     pointer-events: none;
+}
+
+.game-info {
+    position: relative;
+}
+
+@media (min-width: 769px) {
+    #last-move {
+        position: absolute;
+        top: -1.4rem;
+        left: 50%;
+        transform: translateX(-50%);
+    }
 }
 
 .hidden {

--- a/public/game.html
+++ b/public/game.html
@@ -17,7 +17,9 @@
                     <div class="team-line team2">Time 2: <span id="team2-players"></span></div>
                 </div>
             </div>
-            
+
+            <div id="last-move" class="last-move-message hidden"></div>
+
             <div class="turn-info">
                 <h3>Turno: <span id="current-player"></span></h3>
                 <div id="turn-message"></div>
@@ -27,7 +29,6 @@
         <div class="board-container">
             <div id="board"></div>
             <div id="player-labels"></div>
-            <div id="last-move" class="last-move-message hidden"></div>
             
             <div class="deck-area">
                 <div class="deck">

--- a/server/server.js
+++ b/server/server.js
@@ -543,8 +543,19 @@ socket.on('makeJokerMove', ({ roomId, pieceId, targetPieceId, cardIndex }) => {
       return;
     }
 
-    // Utilizar regra centralizada do jogo para mover a peça
-    game.moveToSelectedPosition(piece, targetPieceId);
+    // Utilizar regra centralizada do jogo para mover a peça e obter resultado
+    const oldPos = { ...piece.position };
+    const moveResult = game.moveToSelectedPosition(piece, targetPieceId);
+
+    const msg = logMoveDetails(
+      currentPlayer,
+      piece.id,
+      oldPos,
+      moveResult,
+      game,
+      { value: 'JOKER' }
+    );
+    io.to(roomId).emit('lastMove', { message: msg });
 
     // Descartar a carta Joker
     game.discardPile.push(card);


### PR DESCRIPTION
## Summary
- update Joker move handling to send a detailed log message
- move last move banner inside the header
- restyle banner for desktop and mobile layouts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68472e297818832aa6f117c82987f96e