### PR TITLE
Update stats display

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -577,7 +577,10 @@ socket.on('makeJokerMove', ({ roomId, pieceId, targetPieceId, cardIndex }) => {
       saveReplay(game);
       io.to(roomId).emit('gameOver', {
         winners: game.getWinningTeam(),
-        stats: game.getStatisticsSummary()
+        stats: {
+          summary: game.getStatisticsSummary(),
+          full: game.stats
+        }
       });
       game.endGame();
       return;
@@ -711,7 +714,10 @@ socket.on('makeMove', ({ roomId, pieceId, cardIndex, enterHome }) => {
       saveReplay(game);
       io.to(roomId).emit('gameOver', {
         winners: game.getWinningTeam(),
-        stats: game.getStatisticsSummary()
+        stats: {
+          summary: game.getStatisticsSummary(),
+          full: game.stats
+        }
       });
       game.endGame();
       return;
@@ -769,7 +775,10 @@ socket.on('confirmHomeEntry', ({ roomId, pieceId, cardIndex, enterHome }) => {
       saveReplay(game);
       io.to(roomId).emit('gameOver', {
         winners: game.getWinningTeam(),
-        stats: game.getStatisticsSummary()
+        stats: {
+          summary: game.getStatisticsSummary(),
+          full: game.stats
+        }
       });
       game.endGame();
       return;
@@ -839,7 +848,10 @@ socket.on('confirmHomeEntry', ({ roomId, pieceId, cardIndex, enterHome }) => {
         saveReplay(game);
         io.to(roomId).emit('gameOver', {
           winners: game.getWinningTeam(),
-          stats: game.getStatisticsSummary()
+          stats: {
+            summary: game.getStatisticsSummary(),
+            full: game.stats
+          }
         });
         game.endGame();
         return;
@@ -907,7 +919,10 @@ socket.on('confirmHomeEntry', ({ roomId, pieceId, cardIndex, enterHome }) => {
         saveReplay(game);
         io.to(roomId).emit('gameOver', {
           winners: game.getWinningTeam(),
-          stats: game.getStatisticsSummary()
+          stats: {
+            summary: game.getStatisticsSummary(),
+            full: game.stats
+          }
         });
         game.endGame();
         return;


### PR DESCRIPTION
## Summary
- calculate stat champions client-side
- only display champion stats during the game
- send detailed stats on `gameOver` events
- show full statistics in the end-game modal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847316de10c832a8b0590049d976510