### PR TITLE
Allow splitting 7 card with home stretch pieces

### DIFF
--- a/public/js/game.js
+++ b/public/js/game.js
@@ -1170,9 +1170,7 @@ function makeMove() {
             canControlPiece(playerPosition, p.playerId) && !p.inPenaltyZone && !p.completed
         );
 
-        const movableOnTrack = movable.filter(p => !p.inHomeStretch);
-
-        if (movableOnTrack.length <= 1) {
+        if (movable.length <= 1) {
             socket.emit('makeSpecialMove', {
                 roomId,
                 moves: [{ pieceId: selectedPieceId, steps: 7 }],


### PR DESCRIPTION
## Summary
- fix condition that skipped split dialog when only one piece on track

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684734c13938832a95e2afd33b522452