### PR TITLE
Add training stats tracking

### DIFF
--- a/game-ai-training/ai/environment.py
+++ b/game-ai-training/ai/environment.py
@@ -233,6 +233,9 @@ class GameEnvironment:
             # Preserve win information returned by the Node process
             self.game_state['gameEnded'] = done
             self.game_state['winningTeam'] = response.get('winningTeam')
+            if 'stats' in response:
+                self.game_state['stats'] = response['stats'].get('full', {})
+                self.game_state['statsSummary'] = response['stats'].get('summary')
             last_move = self.game_state.get('lastMove')
             if last_move is not None:
                 # store both the move description and a snapshot of the state

--- a/game-ai-training/ai/trainer.py
+++ b/game-ai-training/ai/trainer.py
@@ -138,7 +138,11 @@ class TrainingManager:
                 player_pos = player.get('position', -1)
                 if 0 <= player_pos < len(self.bots):
                     self.bots[player_pos].wins += 1
-        
+
+        summary = env.game_state.get('statsSummary')
+        if summary:
+            info("Game summary", summary=summary)
+
         self.training_stats['games_played'] += 1
         self.training_stats['episode_rewards'].append(sum(episode_rewards))
 

--- a/game-ai-training/game/game_wrapper.js
+++ b/game-ai-training/game/game_wrapper.js
@@ -197,14 +197,21 @@ class GameWrapper {
             }
 
             let result;
+            let playedCard;
             if (actionId >= 40) {
                 const cardIndex = actionId - 40;
+                playedCard = this.game.players[playerId].cards[cardIndex];
                 result = this.game.discardCard(cardIndex);
             } else {
                 const cardIndex = Math.floor(actionId / 10);
                 const pieceNumber = actionId % 10;
                 const pieceId = `p${playerId}_${pieceNumber}`;
+                playedCard = this.game.players[playerId].cards[cardIndex];
                 result = this.game.makeMove(pieceId, cardIndex);
+            }
+
+            if (playedCard && playedCard.value === 'JOKER') {
+                this.game.stats.jokersPlayed[playerId]++;
             }
 
             // After the move/discard the turn has advanced inside the game
@@ -221,7 +228,7 @@ class GameWrapper {
             const gameEnded = this.game.checkWinCondition();
             const winningTeam = gameEnded ? this.game.getWinningTeam() : null;
 
-            return {
+            const response = {
                 success: true,
                 action: result && result.action ? result.action : 'move',
                 captures: result && result.captures ? result.captures : [],
@@ -229,6 +236,15 @@ class GameWrapper {
                 gameEnded,
                 winningTeam
             };
+
+            if (gameEnded) {
+                response.stats = {
+                    summary: this.game.getStatisticsSummary(),
+                    full: this.game.stats
+                };
+            }
+
+            return response;
         } catch (error) {
             return {
                 success: false,


### PR DESCRIPTION
## Summary
- copy updated game implementation to training
- track Joker plays and expose statistics summary in the Node wrapper
- pass statistics from the environment to Python trainer
- log statistics summary after every training episode

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847396056b8832a847c1e51ad3af90c