### PR TITLE
Add replay viewer

### DIFF
--- a/public/js/replay.js
+++ b/public/js/replay.js
@@ -1,0 +1,229 @@
+// file: public/js/replay.js
+
+document.addEventListener('DOMContentLoaded', () => {
+  const inputBlock = document.getElementById('replay-input');
+  const textarea = document.getElementById('replay-data');
+  const loadBtn = document.getElementById('load-replay');
+
+  const gameContainer = document.querySelector('.game-container');
+  const board = document.getElementById('board');
+  const team1Span = document.getElementById('team1-players');
+  const team2Span = document.getElementById('team2-players');
+  const currentPlayerSpan = document.getElementById('current-player');
+  const deckCountSpan = document.getElementById('deck-count');
+  const discardCountSpan = document.getElementById('discard-count');
+  const topDiscard = document.getElementById('top-discard');
+  const lastMoveDiv = document.getElementById('last-move');
+  const moveIndexSpan = document.getElementById('move-index');
+  const prevBtn = document.getElementById('prev-move');
+  const nextBtn = document.getElementById('next-move');
+
+  const playerColors = ['#3498db', '#000000', '#e74c3c', '#2ecc71'];
+  let replayData = [];
+  let idx = 0;
+  let pieceElements = {};
+
+  loadBtn.addEventListener('click', () => {
+    const parsed = parseInput(textarea.value);
+    if (parsed && parsed.length > 0) {
+      replayData = parsed;
+      idx = 0;
+      inputBlock.classList.add('hidden');
+      gameContainer.classList.remove('hidden');
+      createBoard();
+      markSpecialCells();
+      renderCurrent();
+      adjustBoardSize();
+    }
+  });
+
+  prevBtn.addEventListener('click', () => {
+    if (idx > 0) {
+      idx--;
+      renderCurrent();
+    }
+  });
+
+  nextBtn.addEventListener('click', () => {
+    if (idx < replayData.length - 1) {
+      idx++;
+      renderCurrent();
+    }
+  });
+
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'ArrowLeft') prevBtn.click();
+    if (e.key === 'ArrowRight') nextBtn.click();
+  });
+
+  function parseInput(text) {
+    if (!text) return null;
+    text = text.trim();
+    if (!text) return null;
+    try {
+      if (text.startsWith('[')) {
+        return JSON.parse(text);
+      }
+    } catch (err) {}
+    const lines = text.split(/\n/).filter(l => l.trim());
+    const arr = [];
+    for (const line of lines) {
+      try {
+        arr.push(JSON.parse(line));
+      } catch (err) {
+        alert('Linha inválida: ' + line);
+        return null;
+      }
+    }
+    return arr;
+  }
+
+  function renderCurrent() {
+    const item = replayData[idx];
+    if (!item || !item.state) return;
+    const state = item.state;
+    moveIndexSpan.textContent = `${idx + 1}/${replayData.length}`;
+    lastMoveDiv.textContent = item.move || '';
+    updateInfo(state);
+    updateBoard(state);
+  }
+
+  function updateInfo(state) {
+    const players = state.players;
+    team1Span.textContent = `${players[0].name} e ${players[2].name}`;
+    team2Span.textContent = `${players[1].name} e ${players[3].name}`;
+    currentPlayerSpan.textContent = players[state.currentPlayerIndex].name;
+    deckCountSpan.textContent = state.deckCount;
+    discardCountSpan.textContent = state.discardCount;
+    if (state.discardPile && state.discardPile.length > 0) {
+      topDiscard.innerHTML = createCardHTML(state.discardPile[0]);
+      topDiscard.classList.remove('hidden');
+    } else {
+      topDiscard.innerHTML = '';
+      topDiscard.classList.add('hidden');
+    }
+  }
+
+  function updateBoard(state) {
+    const cells = board.querySelectorAll('.cell');
+    cells.forEach(cell => {
+      const p = cell.querySelector('.piece');
+      if (p) cell.removeChild(p);
+    });
+
+    state.pieces.forEach(piece => {
+      const cell = getCell(piece.position.row, piece.position.col);
+      if (!cell) return;
+      let el = pieceElements[piece.id];
+      if (!el) {
+        el = document.createElement('div');
+        el.className = `piece player${piece.playerId}`;
+        el.textContent = piece.pieceId;
+        pieceElements[piece.id] = el;
+      }
+      cell.appendChild(el);
+    });
+  }
+
+  function createBoard() {
+    for (let row = 0; row < 19; row++) {
+      for (let col = 0; col < 19; col++) {
+        const cell = document.createElement('div');
+        cell.className = 'cell';
+        cell.dataset.row = row;
+        cell.dataset.col = col;
+        board.appendChild(cell);
+      }
+    }
+  }
+
+  function getCell(row, col) {
+    return board.querySelector(`.cell[data-row="${row}"][data-col="${col}"]`);
+  }
+
+  function markCellIfExists(row, col, className) {
+    const cell = getCell(row, col);
+    if (cell) cell.classList.add(className);
+  }
+
+  function outlineZone(zone, className, playerId, fillAll = false) {
+    zone.forEach(pos => {
+      const cell = getCell(pos.row, pos.col);
+      if (!cell) return;
+      cell.classList.add(className, `player${playerId}`);
+      const color = playerColors[playerId];
+      if (fillAll) {
+        cell.style.borderColor = color;
+      } else {
+        const neighbors = {
+          Top: { row: pos.row - 1, col: pos.col },
+          Bottom: { row: pos.row + 1, col: pos.col },
+          Left: { row: pos.row, col: pos.col - 1 },
+          Right: { row: pos.row, col: pos.col + 1 }
+        };
+        for (const [edge, n] of Object.entries(neighbors)) {
+          const exists = zone.some(p => p.row === n.row && p.col === n.col);
+          if (!exists) cell.style[`border${edge}Color`] = color;
+        }
+      }
+    });
+  }
+
+  function markSpecialCells() {
+    for (let i = 0; i < 19; i++) {
+      markCellIfExists(0, i, 'track');
+      markCellIfExists(18, i, 'track');
+      markCellIfExists(i, 0, 'track');
+      markCellIfExists(i, 18, 'track');
+    }
+
+    const penaltyZones = [
+      [{row:2,col:8},{row:1,col:8},{row:3,col:8},{row:2,col:7},{row:2,col:9}],
+      [{row:8,col:16},{row:7,col:16},{row:9,col:16},{row:8,col:15},{row:8,col:17}],
+      [{row:16,col:10},{row:15,col:10},{row:17,col:10},{row:16,col:9},{row:16,col:11}],
+      [{row:10,col:2},{row:9,col:2},{row:11,col:2},{row:10,col:1},{row:10,col:3}]
+    ];
+    penaltyZones.forEach((z,idx)=>outlineZone(z,'penalty',idx));
+
+    const homeStretches = [
+      [{row:1,col:4},{row:2,col:4},{row:3,col:4},{row:4,col:4},{row:5,col:4}],
+      [{row:4,col:13},{row:4,col:14},{row:4,col:15},{row:4,col:16},{row:4,col:17}],
+      [{row:13,col:14},{row:14,col:14},{row:15,col:14},{row:16,col:14},{row:17,col:14}],
+      [{row:14,col:1},{row:14,col:2},{row:14,col:3},{row:14,col:4},{row:14,col:5}]
+    ];
+    homeStretches.forEach((s,idx)=>outlineZone(s,'home-stretch',idx,true));
+
+    for (let r=6;r<=12;r++) {
+      for (let c=7;c<=11;c++) {
+        markCellIfExists(r,c,'discard-area');
+      }
+    }
+  }
+
+  function getDisplayValue(card) {
+    return card.value === 'JOKER' ? 'C' : card.value;
+  }
+
+  function createCardHTML(card) {
+    const isRed = card.suit === '\u2665' || card.suit === '\u2666';
+    const val = getDisplayValue(card);
+    return `
+      <div class="card-value">${val}</div>
+      <div class="card-suit ${isRed ? 'red' : 'black'}">${card.suit}</div>
+    `;
+  }
+
+  function adjustBoardSize() {
+    const info = document.querySelector('.game-info');
+    const cssMax = Math.min(window.innerWidth * 0.8, window.innerHeight * 0.8);
+    let size = cssMax;
+    if (info) {
+      const available = window.innerHeight - info.offsetHeight - 32;
+      size = Math.min(cssMax, available);
+    }
+    board.style.width = `${size}px`;
+    board.style.height = `${size}px`;
+  }
+
+  window.addEventListener('resize', adjustBoardSize);
+});

--- a/public/replay.html
+++ b/public/replay.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Replay Viewer</title>
+  <link rel="stylesheet" href="css/style.css">
+  <link rel="stylesheet" href="css/game.css">
+  <style>
+    #replay-input { margin: 1rem auto; max-width: 800px; }
+    #replay-input textarea { width: 100%; height: 150px; }
+    #nav-controls { display: flex; justify-content: center; gap: 0.5rem; margin-bottom: 0.5rem; }
+    #nav-controls button { padding: 0.3rem 0.6rem; cursor: pointer; }
+  </style>
+</head>
+<body>
+  <div id="replay-input" class="container">
+    <h2>Insira o código do replay</h2>
+    <textarea id="replay-data"></textarea>
+    <button id="load-replay" class="btn primary">Carregar</button>
+  </div>
+
+  <div class="game-container hidden">
+    <div class="game-info">
+      <div class="room-info">
+        <div class="room-code">Sala: <span id="room-code">REPLAY</span></div>
+        <div class="teams-info">
+          <div class="team-line team1">Time 1: <span id="team1-players"></span></div>
+          <div class="team-line team2">Time 2: <span id="team2-players"></span></div>
+        </div>
+      </div>
+      <div id="last-move" class="last-move-message"></div>
+      <div class="turn-info">
+        <h3>Turno: <span id="current-player"></span></h3>
+      </div>
+    </div>
+
+    <div id="nav-controls">
+      <button id="prev-move">&#8592;</button>
+      <span id="move-index">0/0</span>
+      <button id="next-move">&#8594;</button>
+    </div>
+
+    <div class="board-container">
+      <div id="board"></div>
+      <div id="player-labels"></div>
+      <div class="deck-area">
+        <div class="deck">
+          <div class="card-back"><span id="deck-count">0</span></div>
+        </div>
+        <div class="discard-pile">
+          <div id="top-discard" class="card"></div>
+          <span id="discard-count">0</span>
+        </div>
+      </div>
+      <div id="stats-panel" class="stats-panel hidden"></div>
+    </div>
+  </div>
+
+  <script src="js/replay.js"></script>
+</body>
+</html>

--- a/server/server.js
+++ b/server/server.js
@@ -60,6 +60,10 @@ app.get('/replays/:file', (req, res) => {
 app.get('/debug', (req, res) => {
   res.sendFile(path.join(__dirname, '../public/debug.html'));
 });
+app.get('/replay', (req, res) => {
+  res.sendFile(path.join(__dirname, '../public/replay.html'));
+});
+
 
 function logTurnState(game) {
   const player = game.getCurrentPlayer();


### PR DESCRIPTION
## Summary
- add `/replay` endpoint for navigating stored game states
- implement replay viewer page with board and arrow navigation
- implement client script to load replay data and step through moves

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684866aaecc4832ab828f1893095d550