### PR TITLE
Add replay loader

### DIFF
--- a/game-ai-training/game/server.js
+++ b/game-ai-training/game/server.js
@@ -141,7 +141,8 @@ function logMoveDetails(player, pieceId, oldPos, result, game, card) {
     message += ' e avançou para o corredor de chegada';
   }
 
-  game.history.push(message);
+  const snapshot = JSON.parse(JSON.stringify(game.getGameState()));
+  game.history.push({ move: message, state: snapshot });
   return message;
 }
 
@@ -413,7 +414,8 @@ socket.on('discardCard', ({ roomId, cardIndex }) => {
     });
 
     const discardMsg = `${currentPlayer.name} descartou um ${card.value === 'JOKER' ? 'C' : card.value}`;
-    game.history.push(discardMsg);
+    const snap = JSON.parse(JSON.stringify(game.getGameState()));
+    game.history.push({ move: discardMsg, state: snap });
     io.to(roomId).emit('lastMove', { message: discardMsg });
     
     // Notificar próximo jogador

--- a/public/js/replay.js
+++ b/public/js/replay.js
@@ -23,6 +23,22 @@ document.addEventListener('DOMContentLoaded', () => {
   let idx = 0;
   let pieceElements = {};
 
+  const params = new URLSearchParams(window.location.search);
+  const fileParam = params.get('file');
+  if (fileParam) {
+    fetch(`/replays/${encodeURIComponent(fileParam)}`)
+      .then(res => res.json())
+      .then(data => {
+        if (Array.isArray(data)) {
+          textarea.value = JSON.stringify(data);
+        } else if (Array.isArray(data.history)) {
+          textarea.value = JSON.stringify(data.history);
+        }
+        loadBtn.click();
+      })
+      .catch(err => console.error('Failed to load replay', err));
+  }
+
   loadBtn.addEventListener('click', () => {
     const parsed = parseInput(textarea.value);
     if (parsed && parsed.length > 0) {

--- a/public/js/replays.js
+++ b/public/js/replays.js
@@ -4,7 +4,7 @@ function renderReplays(listEl, replays) {
   replays.forEach(r => {
     const li = document.createElement('li');
     const link = document.createElement('a');
-    link.href = `/replays/${encodeURIComponent(r.file)}`;
+    link.href = `/replay?file=${encodeURIComponent(r.file)}`;
     link.textContent = r.file;
     li.appendChild(link);
     if (r.players) {

--- a/server/server.js
+++ b/server/server.js
@@ -150,7 +150,8 @@ function logMoveDetails(player, pieceId, oldPos, result, game, card) {
     message += ' e avançou para o corredor de chegada';
   }
 
-  game.history.push(message);
+  const snapshot = JSON.parse(JSON.stringify(game.getGameState()));
+  game.history.push({ move: message, state: snapshot });
   return message;
 }
 
@@ -162,7 +163,8 @@ function announceHomeStretch(game, roomId) {
         const playerName = game.players[i].name;
         const partnerName = game.players[partnerId].name;
         const msg = `${playerName} agora pode jogar com as peças de ${partnerName}`;
-        game.history.push(msg);
+        const snap = JSON.parse(JSON.stringify(game.getGameState()));
+        game.history.push({ move: msg, state: snap });
         io.to(roomId).emit('lastMove', { message: msg });
         game.homeStretchAnnounced[i] = true;
       }
@@ -450,7 +452,8 @@ socket.on('discardCard', ({ roomId, cardIndex }) => {
     });
 
     const discardMsg = `${currentPlayer.name} descartou um ${card.value === 'JOKER' ? 'C' : card.value}`;
-    game.history.push(discardMsg);
+    const snap = JSON.parse(JSON.stringify(game.getGameState()));
+    game.history.push({ move: discardMsg, state: snap });
     io.to(roomId).emit('lastMove', { message: discardMsg });
     
     // Notificar próximo jogador


### PR DESCRIPTION
## Summary
- save a full game state snapshot with every history entry so replays have board data
- allow `replay.html` to autoload a replay file via `?file=`
- link the replays list to the viewer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68487cf9409c832aacf6ef6e107992b7