### PR TITLE
Fix replay load and spacing

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -146,6 +146,10 @@ input[type="text"] {
     font-weight: bold;
 }
 
+#replay-files {
+    margin-top: 0.5rem;
+}
+
 #room-code {
     font-weight: bold;
     color: #e74c3c;

--- a/public/js/replay.js
+++ b/public/js/replay.js
@@ -24,18 +24,28 @@ document.addEventListener('DOMContentLoaded', () => {
   let idx = 0;
   let pieceElements = {};
 
+  function startReplay(dataArr) {
+    if (!Array.isArray(dataArr) || dataArr.length === 0) return;
+    replayData = dataArr;
+    idx = 0;
+    inputBlock.classList.add('hidden');
+    gameContainer.classList.remove('hidden');
+    createBoard();
+    markSpecialCells();
+    renderCurrent();
+    adjustBoardSize();
+  }
+
   const params = new URLSearchParams(window.location.search);
   const fileParam = params.get('file');
   if (fileParam) {
     fetch(`/replays/${encodeURIComponent(fileParam)}`)
       .then(res => res.json())
       .then(data => {
-        if (Array.isArray(data)) {
-          textarea.value = JSON.stringify(data);
-        } else if (Array.isArray(data.history)) {
-          textarea.value = JSON.stringify(data.history);
-        }
-        loadBtn.click();
+        let arr = null;
+        if (Array.isArray(data)) arr = data;
+        else if (Array.isArray(data.history)) arr = data.history;
+        if (arr) startReplay(arr);
       })
       .catch(err => console.error('Failed to load replay', err));
   }
@@ -61,14 +71,7 @@ document.addEventListener('DOMContentLoaded', () => {
   loadBtn.addEventListener('click', () => {
     const parsed = parseInput(textarea.value);
     if (parsed && parsed.length > 0) {
-      replayData = parsed;
-      idx = 0;
-      inputBlock.classList.add('hidden');
-      gameContainer.classList.remove('hidden');
-      createBoard();
-      markSpecialCells();
-      renderCurrent();
-      adjustBoardSize();
+      startReplay(parsed);
     }
   });
 


### PR DESCRIPTION
## Summary
- ensure /replay auto-loads selected replay instead of triggering a button click
- add top margin to the list of saved replays

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684881f0e584832a9543faa99f5a6c60