### PR TITLE
Fix replay loading for NDJSON files

### DIFF
--- a/public/js/replay.js
+++ b/public/js/replay.js
@@ -40,12 +40,10 @@ document.addEventListener('DOMContentLoaded', () => {
   const fileParam = params.get('file');
   if (fileParam) {
     fetch(`/replays/${encodeURIComponent(fileParam)}`)
-      .then(res => res.json())
-      .then(data => {
-        let arr = null;
-        if (Array.isArray(data)) arr = data;
-        else if (Array.isArray(data.history)) arr = data.history;
-        if (arr) startReplay(arr);
+      .then(res => res.text())
+      .then(text => {
+        const arr = parseInput(text);
+        if (arr && arr.length > 0) startReplay(arr);
       })
       .catch(err => console.error('Failed to load replay', err));
   }


### PR DESCRIPTION
## Summary
- parse replay files as text to support line-delimited JSON

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684884407600832ab884df7b6f3b7b76