### PR TITLE
Fix runaway replay size

### DIFF
--- a/game-ai-training/game/server.js
+++ b/game-ai-training/game/server.js
@@ -141,7 +141,9 @@ function logMoveDetails(player, pieceId, oldPos, result, game, card) {
     message += ' e avançou para o corredor de chegada';
   }
 
-  const snapshot = JSON.parse(JSON.stringify(game.getGameState()));
+  const snapState = game.getGameState();
+  delete snapState.lastMove;
+  const snapshot = JSON.parse(JSON.stringify(snapState));
   game.history.push({ move: message, state: snapshot });
   return message;
 }
@@ -414,7 +416,9 @@ socket.on('discardCard', ({ roomId, cardIndex }) => {
     });
 
     const discardMsg = `${currentPlayer.name} descartou um ${card.value === 'JOKER' ? 'C' : card.value}`;
-    const snap = JSON.parse(JSON.stringify(game.getGameState()));
+    const snapState = game.getGameState();
+    delete snapState.lastMove;
+    const snap = JSON.parse(JSON.stringify(snapState));
     game.history.push({ move: discardMsg, state: snap });
     io.to(roomId).emit('lastMove', { message: discardMsg });
     

--- a/server/server.js
+++ b/server/server.js
@@ -150,7 +150,9 @@ function logMoveDetails(player, pieceId, oldPos, result, game, card) {
     message += ' e avançou para o corredor de chegada';
   }
 
-  const snapshot = JSON.parse(JSON.stringify(game.getGameState()));
+  const snapState = game.getGameState();
+  delete snapState.lastMove;
+  const snapshot = JSON.parse(JSON.stringify(snapState));
   game.history.push({ move: message, state: snapshot });
   return message;
 }
@@ -163,7 +165,9 @@ function announceHomeStretch(game, roomId) {
         const playerName = game.players[i].name;
         const partnerName = game.players[partnerId].name;
         const msg = `${playerName} agora pode jogar com as peças de ${partnerName}`;
-        const snap = JSON.parse(JSON.stringify(game.getGameState()));
+        const snapState = game.getGameState();
+        delete snapState.lastMove;
+        const snap = JSON.parse(JSON.stringify(snapState));
         game.history.push({ move: msg, state: snap });
         io.to(roomId).emit('lastMove', { message: msg });
         game.homeStretchAnnounced[i] = true;
@@ -452,7 +456,9 @@ socket.on('discardCard', ({ roomId, cardIndex }) => {
     });
 
     const discardMsg = `${currentPlayer.name} descartou um ${card.value === 'JOKER' ? 'C' : card.value}`;
-    const snap = JSON.parse(JSON.stringify(game.getGameState()));
+    const snapState = game.getGameState();
+    delete snapState.lastMove;
+    const snap = JSON.parse(JSON.stringify(snapState));
     game.history.push({ move: discardMsg, state: snap });
     io.to(roomId).emit('lastMove', { message: discardMsg });
     


### PR DESCRIPTION
## Summary
- prevent infinite nesting in saved replay snapshots
- update training server with the same fix

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68488fd9f1b4832a832e7bb66d915cd1