### PR TITLE
Improve replay nav buttons on mobile

### DIFF
--- a/public/replay.html
+++ b/public/replay.html
@@ -10,7 +10,17 @@
     #replay-input { margin: 1rem auto; max-width: 800px; }
     #replay-input textarea { width: 100%; height: 150px; }
     #nav-controls { display: flex; justify-content: center; gap: 0.5rem; margin-bottom: 0.5rem; }
-    #nav-controls button { padding: 0.3rem 0.6rem; cursor: pointer; }
+    #nav-controls button {
+      padding: 0.3rem;
+      cursor: pointer;
+      width: 2rem;
+      height: 2rem;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 1.2rem;
+      line-height: 1;
+    }
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- tweak nav button styles to prevent tall, thin layout on small screens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6848ab6badb8832a9d2dac7c9b50db37