### PR TITLE
Add card 7 split move handling

### DIFF
--- a/game-ai-training/ai/environment.py
+++ b/game-ai-training/ai/environment.py
@@ -14,7 +14,7 @@ class GameEnvironment:
     def __init__(self, env_id: int = 0):
         self.node_process = None
         self.game_state = None
-        self.action_space_size = 50
+        self.action_space_size = 60
         self.state_size = 200
 
         # identifier for logging when multiple environments are used
@@ -235,11 +235,20 @@ class GameEnvironment:
     
     def step(self, action: int, player_id: int) -> Tuple[np.ndarray, float, bool]:
         """Execute action and return next_state, reward, done"""
-        response = self.send_command({
-            "action": "makeMove",
-            "playerId": player_id,
-            "actionId": action
-        })
+        if action >= 50:
+            cmd = {
+                "action": "makeSpecialMove",
+                "playerId": player_id,
+                "actionId": action
+            }
+        else:
+            cmd = {
+                "action": "makeMove",
+                "playerId": player_id,
+                "actionId": action
+            }
+
+        response = self.send_command(cmd)
         
         # Calculate reward
         reward = 0.1 if response.get('success') else -0.1


### PR DESCRIPTION
## Summary
- expose `makeSpecialMove` in the Node wrapper
- generate split-move actions for card 7
- dispatch special moves from the Python environment
- test card 7 handling and new actions

## Testing
- `pip install numpy`
- `pip install matplotlib`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848bc973130832aadc77564b49a3665