### PR TITLE
Document split move actions

### DIFF
--- a/game-ai-training/README.md
+++ b/game-ai-training/README.md
@@ -70,6 +70,7 @@ without manual intervention. Specifically, when a piece can enter the
 home-stretch or when a Joker move requires choosing a target position, the
 wrapper automatically selects the first valid option.
 
-Support for splitting the movement of a seven card is **not** implemented in
-the wrapper yet. If a bot attempts an unsupported action, no valid moves remain
-and the episode may finish very quickly as the agent runs out of legal actions.
+When a seven card can be split across multiple pieces, `getValidActions` may
+include special actions with IDs of 50 or higher to represent the available
+split moves. If a bot attempts an unsupported action, no valid moves remain and
+the episode may finish very quickly as the agent runs out of legal actions.


### PR DESCRIPTION
## Summary
- update the Game Wrapper Behavior section of the training README
  - mention special action IDs >= 50 for split sevens
  - remove outdated statement that seven splitting is unimplemented

## Testing
- `pip install -r game-ai-training/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848c9349a40832abb9f5ebb237d3a8d