### PR TITLE
Handle error responses during action lookup

### DIFF
--- a/game-ai-training/ai/environment.py
+++ b/game-ai-training/ai/environment.py
@@ -223,6 +223,9 @@ class GameEnvironment:
             "playerId": player_id
         })
         
+        if 'error' in response:
+            return []
+
         actions = response.get("validActions", [0])
         # Ensure actions are within the defined action space. The Node.js
         # wrapper should already enforce this, but extra validation guards

--- a/game-ai-training/ai/trainer.py
+++ b/game-ai-training/ai/trainer.py
@@ -89,7 +89,7 @@ class TrainingManager:
             state = env.get_state(current_player)
             valid_actions = env.get_valid_actions(current_player)
             
-            if not valid_actions:
+            if valid_actions == []:
                 break
             
             # Bot chooses action

--- a/game-ai-training/tests/test_environment.py
+++ b/game-ai-training/tests/test_environment.py
@@ -23,6 +23,13 @@ def test_get_valid_actions_limits_to_ten():
     assert actions == list(range(10))
 
 
+def test_get_valid_actions_returns_empty_on_error():
+    env = GameEnvironment()
+    with patch.object(env, 'send_command', return_value={'error': 'fail'}):
+        actions = env.get_valid_actions(0)
+    assert actions == []
+
+
 def test_step_updates_game_state_and_returns_rewards():
     env = GameEnvironment()
     with patch.object(env, 'send_command', return_value={'success': True, 'gameState': {'foo': 'bar'}, 'gameEnded': False, 'winningTeam': None}):

--- a/game-ai-training/tests/test_trainer.py
+++ b/game-ai-training/tests/test_trainer.py
@@ -80,3 +80,23 @@ def test_train_episode_increments_wins():
         initial_wins = manager.bots[0].wins
         manager.train_episode()
         assert manager.bots[0].wins == initial_wins + 1
+
+
+def test_train_episode_breaks_on_no_actions():
+    torch_mock = MagicMock()
+    sys.modules['torch'] = torch_mock
+    sys.modules['torch.nn'] = MagicMock()
+    sys.modules['torch.optim'] = MagicMock()
+
+    from ai.trainer import TrainingManager
+
+    with patch('ai.trainer.GameBot', DummyGameBot):
+        manager = TrainingManager()
+        env = MockGameEnvironment()
+        env.get_valid_actions = lambda pid: []
+        env.step = MagicMock()
+        manager.env = env
+        manager.create_bots(num_bots=4)
+
+        manager.train_episode()
+        env.step.assert_not_called()


### PR DESCRIPTION
## Summary
- treat error replies from Node game as no available actions
- halt training episode when no actions are returned
- test environment error handling
- test trainer stops when action list is empty

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848c94b52f0832ab61f00ddc4a3766d