### PR TITLE
Add warning log for empty valid actions in trainer

### DIFF
--- a/game-ai-training/ai/trainer.py
+++ b/game-ai-training/ai/trainer.py
@@ -88,8 +88,11 @@ class TrainingManager:
             # Get current state and valid actions
             state = env.get_state(current_player)
             valid_actions = env.get_valid_actions(current_player)
-            
+
             if valid_actions == []:
+                warning(
+                    "No valid actions left", step=step_count, player=current_player
+                )
                 break
             
             # Bot chooses action


### PR DESCRIPTION
## Summary
- warn when an episode ends early due to lack of valid actions

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848cccc2354832a90dfe0010268da06