### PR TITLE
Fix discard action ID collision

### DIFF
--- a/game-ai-training/ai/environment.py
+++ b/game-ai-training/ai/environment.py
@@ -14,7 +14,7 @@ class GameEnvironment:
     def __init__(self, env_id: int = 0):
         self.node_process = None
         self.game_state = None
-        self.action_space_size = 60
+        self.action_space_size = 70
         self.state_size = 200
 
         # identifier for logging when multiple environments are used
@@ -242,7 +242,13 @@ class GameEnvironment:
     
     def step(self, action: int, player_id: int) -> Tuple[np.ndarray, float, bool]:
         """Execute action and return next_state, reward, done"""
-        if action >= 50:
+        if action >= 60:
+            cmd = {
+                "action": "makeMove",
+                "playerId": player_id,
+                "actionId": action
+            }
+        elif action >= 50:
             cmd = {
                 "action": "makeSpecialMove",
                 "playerId": player_id,

--- a/game-ai-training/game/game_wrapper.js
+++ b/game-ai-training/game/game_wrapper.js
@@ -153,7 +153,7 @@ class GameWrapper {
             const validActions = [];
             const player = this.game.players[playerId];
             this.specialActions = {};
-            let specialId = 50;
+            let specialId = 50; // range 50-59 reserved for special moves
 
             // Limit to the first 5 cards so that generated action IDs never
             // exceed the Python trainer's action space of 50. Each card index
@@ -214,11 +214,11 @@ class GameWrapper {
             }
 
             if (!this.game.hasAnyValidMove(playerId)) {
-                // Discard actions use IDs 40-49 (10 possible discards). Constrain
-                // the number of cards considered so action IDs remain < 50.
+                // Discard actions use IDs 60-69 (10 possible discards). Constrain
+                // the number of cards considered so action IDs remain < 70.
                 const maxDiscardCards = Math.min(player.cards.length, 10);
                 for (let cardIdx = 0; cardIdx < maxDiscardCards; cardIdx++) {
-                    validActions.push(40 + cardIdx);
+                    validActions.push(60 + cardIdx);
                 }
             }
 
@@ -241,8 +241,8 @@ class GameWrapper {
             let result;
             let playedCard;
             let jokerPlayed = false;
-            if (actionId >= 40) {
-                const cardIndex = actionId - 40;
+            if (actionId >= 60) {
+                const cardIndex = actionId - 60;
                 playedCard = this.game.players[playerId].cards[cardIndex];
                 result = this.game.discardCard(cardIndex);
             } else {

--- a/game-ai-training/tests/test_environment.py
+++ b/game-ai-training/tests/test_environment.py
@@ -177,12 +177,12 @@ def _run_make_move_home_entry_mock():
 
 def test_no_discard_actions_when_moves_available():
     actions = _run_get_valid_actions_mock(True)
-    assert 40 not in actions
+    assert 60 not in actions
 
 
 def test_includes_discard_actions_when_no_moves():
     actions = _run_get_valid_actions_mock(False)
-    assert 40 in actions
+    assert 60 in actions
 
 
 def test_make_move_handles_home_entry_choice():
@@ -275,7 +275,7 @@ def _run_discard_validation_mock():
         "  getGameState: function() { return {}; },",
         "  stats: { jokersPlayed: [0] }",
         "};",
-        "const res = wrapper.makeMove(0, 40);",
+        "const res = wrapper.makeMove(0, 60);",
         "process.stdout.write(JSON.stringify(res));"
     ]
     script = "\n".join(lines)


### PR DESCRIPTION
## Summary
- bump action space to 70 and adjust thresholds
- reserve IDs 60-69 for discards
- update GameWrapper to use new ranges
- adjust environment step logic and tests

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848cfc97620832a91b6021667005c6d