### PR TITLE
fix joker selection validation

### DIFF
--- a/game-ai-training/game/game.js
+++ b/game-ai-training/game/game.js
@@ -694,7 +694,8 @@ class Game {
     const occupiedPositions = this.pieces.filter(p =>
       p.id !== piece.id &&
       !p.completed &&
-      !p.inPenaltyZone
+      !p.inPenaltyZone &&
+      !p.inHomeStretch
     );
     
     if (occupiedPositions.length === 0) {

--- a/server/game.js
+++ b/server/game.js
@@ -685,7 +685,8 @@ discardCard(cardIndex) {
     const occupiedPositions = this.pieces.filter(p =>
       p.id !== piece.id &&
       !p.completed &&
-      !p.inPenaltyZone
+      !p.inPenaltyZone &&
+      !p.inHomeStretch
     );
     
     if (occupiedPositions.length === 0) {


### PR DESCRIPTION
## Summary
- exclude home stretch pieces from joker target list

## Testing
- `npm test`
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_6848d373c6d8832a8ba8eb1ebf12704a