### PR TITLE
Prevent empty action set from halting training

### DIFF
--- a/game-ai-training/game/game_wrapper.js
+++ b/game-ai-training/game/game_wrapper.js
@@ -222,6 +222,11 @@ class GameWrapper {
                 }
             }
 
+            if (validActions.length === 0 && player.cards.length > 0) {
+                // Fallback to discarding the first card so training can continue
+                validActions.push(60);
+            }
+
             return validActions.length > 0 ? validActions.slice(0, 10) : [];
         } catch (error) {
             return [];


### PR DESCRIPTION
## Summary
- ensure `getValidActions` in `game_wrapper.js` always provides at least one discard action

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6848d8520f8c832a8156c43a5a491161