### PR TITLE
Fix missing discard actions when playable card in sixth slot

### DIFF
--- a/game-ai-training/README.md
+++ b/game-ai-training/README.md
@@ -71,6 +71,6 @@ home-stretch or when a Joker move requires choosing a target position, the
 wrapper automatically selects the first valid option.
 
 When a seven card can be split across multiple pieces, `getValidActions` may
-include special actions with IDs of 50 or higher to represent the available
+include special actions with IDs of 60 or higher to represent the available
 split moves. If a bot attempts an unsupported action, no valid moves remain and
 the episode may finish very quickly as the agent runs out of legal actions.

--- a/game-ai-training/ai/environment.py
+++ b/game-ai-training/ai/environment.py
@@ -14,7 +14,7 @@ class GameEnvironment:
     def __init__(self, env_id: int = 0):
         self.node_process = None
         self.game_state = None
-        self.action_space_size = 70
+        self.action_space_size = 80
         self.state_size = 200
 
         # identifier for logging when multiple environments are used
@@ -243,13 +243,13 @@ class GameEnvironment:
     
     def step(self, action: int, player_id: int) -> Tuple[np.ndarray, float, bool]:
         """Execute action and return next_state, reward, done"""
-        if action >= 60:
+        if action >= 70:
             cmd = {
                 "action": "makeMove",
                 "playerId": player_id,
                 "actionId": action
             }
-        elif action >= 50:
+        elif action >= 60:
             cmd = {
                 "action": "makeSpecialMove",
                 "playerId": player_id,


### PR DESCRIPTION
## Summary
- increase move generation to scan up to six cards
- shift special action range to start at 60
- move discard actions to start at 70
- expand environment action space to 80
- update tests for new ranges

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6848dde176fc832aa94204f20ed2b322