### PR TITLE
Relax discard validation for larger hands

### DIFF
--- a/game-ai-training/game/game.js
+++ b/game-ai-training/game/game.js
@@ -316,7 +316,7 @@ class Game {
 
   // Se nem todas as peças estão no castigo, verificar se o jogador tem peças fora
   if (!allInPenalty) {
-    if (hasMove) {
+    if (hasMove && player.cards.length <= 6) {
       throw new Error("Você ainda tem jogadas disponíveis");
     }
     // Não possui movimentos válidos, permitir descarte

--- a/server/game.js
+++ b/server/game.js
@@ -313,7 +313,7 @@ discardCard(cardIndex) {
 
   // Se nem todas as peças estão no castigo, verificar se o jogador tem peças fora
   if (!allInPenalty) {
-    if (hasMove) {
+    if (hasMove && player.cards.length <= 6) {
       throw new Error("Você ainda tem jogadas disponíveis");
     }
     // Não possui movimentos válidos, permitir descarte


### PR DESCRIPTION
## Summary
- allow discarding a card even when moves exist if the player has more than six cards in hand
  - patched both the server and training game implementations

## Testing
- `npm test --silent`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6848e30d15b4832ab4f83f6e9ea174f7