### PR TITLE
Fix move detection for card 7

### DIFF
--- a/game-ai-training/game/game.js
+++ b/game-ai-training/game/game.js
@@ -1409,19 +1409,47 @@ class Game {
     }
 
     for (const card of player.cards) {
-      for (const piece of pieces) {
-        const tempGame = this.cloneForSimulation();
-        const tempPiece = tempGame.pieces.find(p => p.id === piece.id);
-
-        try {
-          if (card.value === '7') {
-            tempGame.movePieceForward(tempPiece, 7);
-          } else {
-            tempGame.executeMove(tempPiece, card);
+      if (card.value === '7') {
+        // Look for valid split moves with two different pieces first
+        for (const pieceA of pieces) {
+          for (const pieceB of pieces) {
+            if (pieceA.id === pieceB.id) continue;
+            for (let s = 1; s <= 6; s++) {
+              const moves = [
+                { pieceId: pieceA.id, steps: s },
+                { pieceId: pieceB.id, steps: 7 - s }
+              ];
+              const tempGame = this.cloneForSimulation();
+              try {
+                tempGame.makeSpecialMove(moves);
+                return true;
+              } catch (e) {
+                continue;
+              }
+            }
           }
-          return true;
-        } catch (e) {
-          continue;
+        }
+
+        // Fallback to single piece moves
+        for (const piece of pieces) {
+          const tempGame = this.cloneForSimulation();
+          try {
+            tempGame.makeSpecialMove([{ pieceId: piece.id, steps: 7 }]);
+            return true;
+          } catch (e) {
+            continue;
+          }
+        }
+      } else {
+        for (const piece of pieces) {
+          const tempGame = this.cloneForSimulation();
+          const tempPiece = tempGame.pieces.find(p => p.id === piece.id);
+          try {
+            tempGame.executeMove(tempPiece, card);
+            return true;
+          } catch (e) {
+            continue;
+          }
         }
       }
     }

--- a/server/__tests__/game.test.js
+++ b/server/__tests__/game.test.js
@@ -541,6 +541,29 @@ describe('Game class', () => {
     expect(game.hasAnyValidMove(player.position)).toBe(false);
   });
 
+  test('hasAnyValidMove true with 7 when only one piece can move', () => {
+    const game = new Game('single7');
+    game.addPlayer('1', 'A');
+    game.addPlayer('2', 'B');
+    game.addPlayer('3', 'C');
+    game.addPlayer('4', 'D');
+    game.startGame();
+
+    const movable = game.pieces.find(p => p.id === 'p0_1');
+    movable.inPenaltyZone = false;
+    movable.position = { row: 0, col: 0 };
+
+    const others = game.pieces.filter(p => p.playerId === 0 && p.id !== movable.id);
+    others.forEach(p => {
+      p.inPenaltyZone = true;
+    });
+
+    game.players[0].cards = [{ suit: '♠', value: '7' }];
+    game.currentPlayerIndex = 0;
+
+    expect(game.hasAnyValidMove(0)).toBe(true);
+  });
+
   test('player can control partner pieces after all in home stretch', () => {
     const game = new Game('partnerPlay');
     game.addPlayer('1', 'A');

--- a/server/game.js
+++ b/server/game.js
@@ -1400,19 +1400,47 @@ discardCard(cardIndex) {
     }
 
     for (const card of player.cards) {
-      for (const piece of pieces) {
-        const tempGame = this.cloneForSimulation();
-        const tempPiece = tempGame.pieces.find(p => p.id === piece.id);
-
-        try {
-          if (card.value === '7') {
-            tempGame.movePieceForward(tempPiece, 7);
-          } else {
-            tempGame.executeMove(tempPiece, card);
+      if (card.value === '7') {
+        // First look for valid split moves involving two distinct pieces
+        for (const pieceA of pieces) {
+          for (const pieceB of pieces) {
+            if (pieceA.id === pieceB.id) continue;
+            for (let s = 1; s <= 6; s++) {
+              const moves = [
+                { pieceId: pieceA.id, steps: s },
+                { pieceId: pieceB.id, steps: 7 - s }
+              ];
+              const tempGame = this.cloneForSimulation();
+              try {
+                tempGame.makeSpecialMove(moves);
+                return true;
+              } catch (e) {
+                continue;
+              }
+            }
           }
-          return true;
-        } catch (e) {
-          continue;
+        }
+
+        // If no split is possible, check single-piece moves
+        for (const piece of pieces) {
+          const tempGame = this.cloneForSimulation();
+          try {
+            tempGame.makeSpecialMove([{ pieceId: piece.id, steps: 7 }]);
+            return true;
+          } catch (e) {
+            continue;
+          }
+        }
+      } else {
+        for (const piece of pieces) {
+          const tempGame = this.cloneForSimulation();
+          const tempPiece = tempGame.pieces.find(p => p.id === piece.id);
+          try {
+            tempGame.executeMove(tempPiece, card);
+            return true;
+          } catch (e) {
+            continue;
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary
- improve `hasAnyValidMove` by falling back to one-piece moves when no split is possible
- add regression test for single 7-card move

## Testing
- `npm test --silent`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6848ec18f584832ab2dcf509c19e4f4e