### PR TITLE
Add special move fallback for discards

### DIFF
--- a/game-ai-training/game/game_wrapper.js
+++ b/game-ai-training/game/game_wrapper.js
@@ -284,6 +284,56 @@ class GameWrapper {
                                 }
                             }
                         }
+
+                        if (!result) {
+                            for (let ci = 0; ci < player.cards.length && !result; ci++) {
+                                if (player.cards[ci].value !== '7') continue;
+                                const pieceIds = [];
+                                for (let pn = 1; pn <= 5; pn++) {
+                                    const pid = `p${playerId}_${pn}`;
+                                    const p = this.game.pieces.find(pp => pp.id === pid && !pp.completed && !pp.inPenaltyZone);
+                                    if (p) pieceIds.push(pid);
+                                }
+                                for (let i = 0; i < pieceIds.length && !result; i++) {
+                                    for (let j = i + 1; j < pieceIds.length && !result; j++) {
+                                        for (let s = 1; s <= 6 && !result; s++) {
+                                            const moves = [
+                                                { pieceId: pieceIds[i], steps: s },
+                                                { pieceId: pieceIds[j], steps: 7 - s }
+                                            ];
+                                            const sim = this.game.cloneForSimulation();
+                                            try {
+                                                sim.makeSpecialMove(moves);
+                                                playedCard = player.cards[ci];
+                                                result = this.game.makeSpecialMove(moves);
+                                                if (result && result.action === 'homeEntryChoice') {
+                                                    result = this.game.resumeSpecialMove(true);
+                                                }
+                                            } catch (err) {
+                                                continue;
+                                            }
+                                        }
+                                    }
+                                }
+                                if (!result) {
+                                    for (let k = 0; k < pieceIds.length && !result; k++) {
+                                        const moves = [{ pieceId: pieceIds[k], steps: 7 }];
+                                        const sim = this.game.cloneForSimulation();
+                                        try {
+                                            sim.makeSpecialMove(moves);
+                                            playedCard = player.cards[ci];
+                                            result = this.game.makeSpecialMove(moves);
+                                            if (result && result.action === 'homeEntryChoice') {
+                                                result = this.game.resumeSpecialMove(true);
+                                            }
+                                        } catch (err) {
+                                            continue;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
                         if (!result) throw e;
                     } else {
                         throw e;


### PR DESCRIPTION
## Summary
- when a discard is rejected because moves are available, also search for 7-split moves

## Testing
- `pytest -q game-ai-training/tests` *(fails: ModuleNotFoundError: No module named 'matplotlib')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848f285c938832aa4acb86b0dba7839