### PR TITLE
Fix partner checks in cloneForSimulation

### DIFF
--- a/game-ai-training/game/game.js
+++ b/game-ai-training/game/game.js
@@ -1383,7 +1383,14 @@ class Game {
   cloneForSimulation() {
     const clone = new Game(this.roomId);
     clone.players = JSON.parse(JSON.stringify(this.players));
-    clone.teams = JSON.parse(JSON.stringify(this.teams));
+
+    // Ensure team arrays reference the cloned player objects rather than
+    // fresh copies so that helper methods relying on object identity behave
+    // the same as in the main game instance.
+    clone.teams = this.teams.map(team =>
+      team.map(p => clone.players.find(cp => cp.id === p.id))
+    );
+
     clone.deck = JSON.parse(JSON.stringify(this.deck));
     clone.discardPile = JSON.parse(JSON.stringify(this.discardPile));
     clone.currentPlayerIndex = this.currentPlayerIndex;

--- a/server/game.js
+++ b/server/game.js
@@ -1410,7 +1410,13 @@ discardCard(cardIndex) {
   cloneForSimulation() {
     const clone = new Game(this.roomId);
     clone.players = JSON.parse(JSON.stringify(this.players));
-    clone.teams = JSON.parse(JSON.stringify(this.teams));
+
+    // Recreate team arrays referencing the cloned player objects so that
+    // identity checks like `team.includes(playerObj)` continue to work.
+    clone.teams = this.teams.map(team =>
+      team.map(p => clone.players.find(cp => cp.id === p.id))
+    );
+
     clone.deck = JSON.parse(JSON.stringify(this.deck));
     clone.discardPile = JSON.parse(JSON.stringify(this.discardPile));
     clone.currentPlayerIndex = this.currentPlayerIndex;


### PR DESCRIPTION
## Summary
- update `cloneForSimulation` so team arrays reference cloned players
- same fix in training copy of the game

## Testing
- `pip install -r game-ai-training/requirements.txt`
- `pytest game-ai-training/tests`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6848fbe06e0c832ab6b0b9dc9d1d2826