### PR TITLE
Fix discard loop fallback

### DIFF
--- a/game-ai-training/game/game_wrapper.js
+++ b/game-ai-training/game/game_wrapper.js
@@ -334,7 +334,19 @@ class GameWrapper {
                             }
                         }
 
-                        if (!result) throw e;
+                        if (!result) {
+                            // Could not find a valid move. Force the discard
+                            // so the training loop can proceed rather than
+                            // failing repeatedly.
+                            const fallbackCard = player.cards[cardIndex];
+                            this.game.discardPile.push(fallbackCard);
+                            player.cards.splice(cardIndex, 1);
+                            this.game.stats.roundsWithoutPlay[player.position]++;
+                            this.game.nextTurn();
+                            const dMsg = `${player.name} descartou um ${fallbackCard.value === 'JOKER' ? 'C' : fallbackCard.value}`;
+                            this.game.history.push(dMsg);
+                            result = { success: true, action: 'discard' };
+                        }
                     } else {
                         throw e;
                     }


### PR DESCRIPTION
## Summary
- force discarding a card when game_wrapper can't find a playable move

## Testing
- `pytest -q`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6849691a8908832a951af0c7e50d9fda