### PR TITLE
Fix partner piece selection bug

### DIFF
--- a/game-ai-training/game/game_wrapper.js
+++ b/game-ai-training/game/game_wrapper.js
@@ -391,6 +391,12 @@ class GameWrapper {
             } else {
                 const cardIndex = Math.floor(actionId / 10);
                 let pieceNumber = actionId % 10;
+                // Piece numbers for partner pieces may encode as 10 which would
+                // otherwise wrap to 0 when using modulo 10. Normalize so 10 is
+                // preserved after the modulo operation.
+                if (pieceNumber === 0) {
+                    pieceNumber = 10;
+                }
                 let ownerId = playerId;
                 if (pieceNumber > 5) {
                     const partner = this.game.partnerIdFor && this.game.partnerIdFor(playerId);

--- a/game-ai-training/tests/test_environment.py
+++ b/game-ai-training/tests/test_environment.py
@@ -480,6 +480,51 @@ def _run_partner_move_mock():
     return json.loads(lines[-1]) if lines else {}
 
 
+def _run_partner_move_five_mock():
+    """Execute a move targeting the fifth partner piece."""
+    lines = [
+        "const fs = require('fs');",
+        "const Module = require('module');",
+        "const path = require('path');",
+        "const filename = path.join('game-ai-training','game','game_wrapper.js');",
+        "let code = fs.readFileSync(filename, 'utf8');",
+        "code = code.replace(/new GameWrapper\\(\\);\\s*$/, 'module.exports = GameWrapper;');",
+        "const m = new Module(filename);",
+        "m.filename = filename;",
+        "m.paths = Module._nodeModulePaths(path.dirname(filename));",
+        "m._compile(code, filename);",
+        "const GameWrapper = m.exports;",
+        "const wrapper = new GameWrapper();",
+        "wrapper.game = {",
+        "  isActive: true,",
+        "  currentPlayerIndex: 0,",
+        "  players: [{ cards: [{}] }, {}],",
+        "  partnerIdFor: () => 1,",
+        "  pieces: [{ id: 'p1_5' }],",
+        "  discardPile: [],",
+        "  makeMove: function(pid, idx) { this.called = [pid, idx]; return { success: true }; },",
+        "  getCurrentPlayer: function() { return this.players[this.currentPlayerIndex]; },",
+        "  drawCard: function() { return {}; },",
+        "  checkWinCondition: function() { return false; },",
+        "  getWinningTeam: function() { return null; },",
+        "  getGameState: function() { return {}; },",
+        "  nextTurn: function() {},",
+        "  stats: { jokersPlayed: [0] }",
+        "};",
+        "wrapper.makeMove(0, 10);",
+        "process.stdout.write(JSON.stringify({ called: wrapper.game.called }));"
+    ]
+    script = "\n".join(lines)
+
+    root = Path(__file__).resolve().parents[2]
+    with tempfile.NamedTemporaryFile('w+', suffix='.js', delete=False) as tmp:
+        tmp.write(script)
+        tmp.flush()
+        output = subprocess.check_output(['node', tmp.name], cwd=root, text=True)
+    lines = [line for line in output.splitlines() if line.startswith('{')]
+    return json.loads(lines[-1]) if lines else {}
+
+
 def test_partner_actions_listed_when_all_home():
     actions = _run_partner_actions_mock()
     assert 6 in actions
@@ -488,6 +533,11 @@ def test_partner_actions_listed_when_all_home():
 def test_make_move_accepts_partner_piece():
     result = _run_partner_move_mock()
     assert result['called'][0] == 'p1_1'
+
+
+def test_make_move_accepts_partner_piece_five():
+    result = _run_partner_move_five_mock()
+    assert result['called'][0] == 'p1_5'
 
 
 def _run_get_special_actions_mock():


### PR DESCRIPTION
## Summary
- handle partner piece number 10 when decoding action IDs
- add regression test for controlling partner's fifth piece

## Testing
- `pip install -r game-ai-training/requirements.txt`
- `pytest game-ai-training/tests`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6849743d1ca4832aac77b12e419f7e38