### PR TITLE
Fix partner piece card index handling

### DIFF
--- a/game-ai-training/game/game_wrapper.js
+++ b/game-ai-training/game/game_wrapper.js
@@ -389,13 +389,17 @@ class GameWrapper {
                     }
                 }
             } else {
-                const cardIndex = Math.floor(actionId / 10);
                 let pieceNumber = actionId % 10;
+                let cardIndex;
                 // Piece numbers for partner pieces may encode as 10 which would
                 // otherwise wrap to 0 when using modulo 10. Normalize so 10 is
-                // preserved after the modulo operation.
+                // preserved after the modulo operation and adjust the card
+                // index accordingly.
                 if (pieceNumber === 0) {
                     pieceNumber = 10;
+                    cardIndex = (actionId - pieceNumber) / 10;
+                } else {
+                    cardIndex = Math.floor(actionId / 10);
                 }
                 let ownerId = playerId;
                 if (pieceNumber > 5) {

--- a/game-ai-training/tests/test_environment.py
+++ b/game-ai-training/tests/test_environment.py
@@ -532,12 +532,12 @@ def test_partner_actions_listed_when_all_home():
 
 def test_make_move_accepts_partner_piece():
     result = _run_partner_move_mock()
-    assert result['called'][0] == 'p1_1'
+    assert result['called'] == ['p1_1', 0]
 
 
 def test_make_move_accepts_partner_piece_five():
     result = _run_partner_move_five_mock()
-    assert result['called'][0] == 'p1_5'
+    assert result['called'] == ['p1_5', 0]
 
 
 def _run_get_special_actions_mock():


### PR DESCRIPTION
## Summary
- fix action decoding for partner's fifth piece so card index is correct
- update tests to ensure card index is preserved

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684978b32c68832a9be2df704f134a2b