### PR TITLE
Penalize invalid moves

### DIFF
--- a/game-ai-training/ai/environment.py
+++ b/game-ai-training/ai/environment.py
@@ -263,12 +263,14 @@ class GameEnvironment:
             }
 
         response = self.send_command(cmd)
+        invalid_attempts = 0
 
         # If the chosen action failed, iteratively try other valid actions
         # until one succeeds or we run out of alternatives. This helps keep the
         # training loop moving even when the model proposes an invalid move.
         tried_actions = {action}
         while not response.get('success'):
+            invalid_attempts += 1
             error(
                 "Action failed", env=self.env_id, player=player_id,
                 action=action, response=response
@@ -310,6 +312,7 @@ class GameEnvironment:
 
         # Calculate reward based on the final response
         reward = 0.1 if response.get('success') else -0.1
+        reward -= 0.1 * invalid_attempts
         done = response.get('gameEnded', False)
 
         # Update game state whenever provided

--- a/game-ai-training/tests/test_environment.py
+++ b/game-ai-training/tests/test_environment.py
@@ -53,7 +53,7 @@ def test_step_updates_state_on_failure():
         with patch.object(env, 'get_state', return_value=np.zeros(env.state_size)):
             next_state, reward, done = env.step(1, 0)
 
-    assert reward == -0.1
+    assert reward == -0.2
     assert done is False
     assert env.game_state == {'foo': 'bar', 'lastMove': 'moved', 'gameEnded': False, 'winningTeam': None}
     assert env.move_history[-1]['move'] == 'moved'
@@ -657,7 +657,7 @@ def test_step_retries_until_success():
             with patch.object(env, 'get_state', return_value=np.zeros(env.state_size)):
                 next_state, reward, done = env.step(1, 0)
 
-    assert reward == 0.1
+    assert reward == -0.1
     assert mock_cmd.call_count == 3
 
 


### PR DESCRIPTION
## Summary
- add invalid move penalty when stepping environment
- adjust environment tests for new penalty logic

## Testing
- `pip install -r game-ai-training/requirements.txt`
- `pytest game-ai-training/tests`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684988fe0c34832a91f1293ef4a08a6e