### PR TITLE
Fix discard validation

### DIFF
--- a/game-ai-training/game/game_wrapper.js
+++ b/game-ai-training/game/game_wrapper.js
@@ -317,6 +317,20 @@ class GameWrapper {
 
             const clone = this.game.cloneForSimulation();
 
+            if (actionId >= 70) {
+                const cardIndex = actionId - 70;
+                const player = clone.players[playerId];
+                if (!player || cardIndex < 0 || cardIndex >= player.cards.length) {
+                    return false;
+                }
+                try {
+                    clone.discardCard(cardIndex);
+                    return true;
+                } catch (e) {
+                    return false;
+                }
+            }
+
             if (actionId >= 60) {
                 const moves = this.specialActions[actionId];
                 if (!moves) return false;


### PR DESCRIPTION
## Summary
- validate discard actions properly in game wrapper
- test discard validation logic

## Testing
- `npm test --silent`
- `pytest -q` *(fails: ModuleNotFoundError for matplotlib)*

------
https://chatgpt.com/codex/tasks/task_e_684a46454854832a8e8186cd6200847d