### PR TITLE
Improve replay logging

### DIFF
--- a/game-ai-training/game/game.js
+++ b/game-ai-training/game/game.js
@@ -1531,6 +1531,17 @@ class Game {
       stats: this.stats
     };
   }
+
+  getGameStateWithCards() {
+    const state = this.getGameState();
+    state.players = this.players.map(p => ({
+      id: p.id,
+      name: p.name,
+      position: p.position,
+      cards: p.cards
+    }));
+    return state;
+  }
 }
 
 module.exports = { Game };

--- a/public/js/replay.js
+++ b/public/js/replay.js
@@ -18,6 +18,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const prevBtn = document.getElementById('prev-move');
   const nextBtn = document.getElementById('next-move');
   const fileList = document.getElementById('replay-files');
+  const cardsContainer = document.getElementById('cards-container');
 
   const playerColors = ['#3498db', '#000000', '#e74c3c', '#2ecc71'];
   let replayData = [];
@@ -128,6 +129,7 @@ document.addEventListener('DOMContentLoaded', () => {
     lastMoveDiv.textContent = item.move || '';
     updateInfo(state);
     updateBoard(state);
+    updateCards(state.currentPlayerCards || []);
   }
 
   function updateInfo(state) {
@@ -255,12 +257,28 @@ document.addEventListener('DOMContentLoaded', () => {
     `;
   }
 
+  function updateCards(cards) {
+    if (!cardsContainer) return;
+    cardsContainer.innerHTML = '';
+    cards.forEach(card => {
+      const el = document.createElement('div');
+      el.className = 'card';
+      el.innerHTML = createCardHTML(card);
+      cardsContainer.appendChild(el);
+    });
+    cardsContainer.classList.remove('compact');
+    if (cardsContainer.scrollWidth > cardsContainer.clientWidth) {
+      cardsContainer.classList.add('compact');
+    }
+  }
+
   function adjustBoardSize() {
     const info = document.querySelector('.game-info');
+    const hand = document.querySelector('.player-hand');
     const cssMax = Math.min(window.innerWidth * 0.8, window.innerHeight * 0.8);
     let size = cssMax;
-    if (info) {
-      const available = window.innerHeight - info.offsetHeight - 32;
+    if (info && hand) {
+      const available = window.innerHeight - info.offsetHeight - hand.offsetHeight - 32;
       size = Math.min(cssMax, available);
     }
     board.style.width = `${size}px`;

--- a/public/replay.html
+++ b/public/replay.html
@@ -66,6 +66,9 @@
       </div>
       <div id="stats-panel" class="stats-panel hidden"></div>
     </div>
+    <div class="player-hand">
+      <div id="cards-container"></div>
+    </div>
   </div>
 
   <script src="js/replay.js"></script>

--- a/server/game.js
+++ b/server/game.js
@@ -1523,6 +1523,17 @@ discardCard(cardIndex) {
       stats: this.stats
     };
   }
+
+  getGameStateWithCards() {
+    const state = this.getGameState();
+    state.players = this.players.map(p => ({
+      id: p.id,
+      name: p.name,
+      position: p.position,
+      cards: p.cards
+    }));
+    return state;
+  }
 }
 
 module.exports = { Game };

--- a/server/server.js
+++ b/server/server.js
@@ -93,6 +93,11 @@ function logTurnState(game) {
   console.log(`Mão: ${hand}`);
   console.log(`Suas peças: ${ownPieces}`);
   console.log(`Outros: ${others}`);
+
+  const snap = game.getGameStateWithCards();
+  delete snap.lastMove;
+  snap.currentPlayerCards = player.cards.map(c => ({ ...c }));
+  game.history.push({ move: `Turno de ${player.name}`, state: snap });
 }
 
 function logMoveDetails(player, pieceId, oldPos, result, game, card) {
@@ -154,7 +159,7 @@ function logMoveDetails(player, pieceId, oldPos, result, game, card) {
     message += ' e avançou para o corredor de chegada';
   }
 
-  const snapState = game.getGameState();
+  const snapState = game.getGameStateWithCards();
   delete snapState.lastMove;
   const snapshot = JSON.parse(JSON.stringify(snapState));
   game.history.push({ move: message, state: snapshot });
@@ -169,7 +174,7 @@ function announceHomeStretch(game, roomId) {
         const playerName = game.players[i].name;
         const partnerName = game.players[partnerId].name;
         const msg = `${playerName} agora pode jogar com as peças de ${partnerName}`;
-        const snapState = game.getGameState();
+        const snapState = game.getGameStateWithCards();
         delete snapState.lastMove;
         const snap = JSON.parse(JSON.stringify(snapState));
         game.history.push({ move: msg, state: snap });


### PR DESCRIPTION
## Summary
- include player cards in game snapshots
- track hand at the start of each turn for replays
- show the active player's cards in replay viewer

## Testing
- `npm test` *(fails: pretest only)*
- `pip install -r game-ai-training/requirements.txt` *(fails to complete due to network limits)*

------
https://chatgpt.com/codex/tasks/task_e_684b2799bc1c832aa257f11182d31bf9