### PR TITLE
Add cards to training game state logs

### DIFF
--- a/game-ai-training/game/game_wrapper.js
+++ b/game-ai-training/game/game_wrapper.js
@@ -134,7 +134,14 @@ class GameWrapper {
             };
         }
 
-        // Prefer the game's own helper so fields like `lastMove` are included
+        // Prefer the game's helper that includes card information when
+        // available so saved history snapshots contain full state.
+        if (typeof this.game.getGameStateWithCards === 'function') {
+            return this.game.getGameStateWithCards();
+        }
+
+        // Fallback to basic game state without cards if the extended helper is
+        // not implemented.
         if (typeof this.game.getGameState === 'function') {
             return this.game.getGameState();
         }


### PR DESCRIPTION
## Summary
- extend `game_wrapper.js` to use `getGameStateWithCards` if available

## Testing
- `pip install -r game-ai-training/requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684b2d575100832a827cceb71635f4df