### PR TITLE
Fix replay card visibility

### DIFF
--- a/public/js/replay.js
+++ b/public/js/replay.js
@@ -129,7 +129,13 @@ document.addEventListener('DOMContentLoaded', () => {
     lastMoveDiv.textContent = item.move || '';
     updateInfo(state);
     updateBoard(state);
-    updateCards(state.currentPlayerCards || []);
+    const currentCards =
+      state.currentPlayerCards ||
+      (state.players &&
+        state.players[state.currentPlayerIndex] &&
+        state.players[state.currentPlayerIndex].cards) ||
+      [];
+    updateCards(currentCards);
   }
 
   function updateInfo(state) {


### PR DESCRIPTION
## Summary
- ensure replay shows cards for each snapshot

## Testing
- `npm test` *(fails: npm install could not finish in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_684b2f5a95e4832abef5369bca600e7a