### PR TITLE
Fix partner capture detection

### DIFF
--- a/server/__tests__/game.test.js
+++ b/server/__tests__/game.test.js
@@ -710,6 +710,21 @@ describe('Game class', () => {
     expect(() => game.discardCard(0)).toThrow();
   });
 
+  test('isPartner works after player objects are replaced', () => {
+    const game = new Game('partnerRef');
+    game.addPlayer('1', 'A');
+    game.addPlayer('2', 'B');
+    game.addPlayer('3', 'C');
+    game.addPlayer('4', 'D');
+    game.setupTeams();
+
+    // Simulate players being recreated (e.g., from a saved state)
+    game.players = game.players.map(p => ({ ...p }));
+
+    expect(game.isPartner(0, 2)).toBe(true);
+    expect(game.isPartner(1, 3)).toBe(true);
+  });
+
   test('endGame sets game inactive', () => {
     const game = new Game('lock');
     game.isActive = true;

--- a/server/game.js
+++ b/server/game.js
@@ -1298,13 +1298,16 @@ discardCard(cardIndex) {
     // Jogador não é parceiro de si mesmo
     if (playerId1 === playerId2) return false;
 
-    // Verificar se os jogadores são parceiros usando
-    // os índices atuais na lista de jogadores
-    const playerObj1 = this.players[playerId1];
-    const playerObj2 = this.players[playerId2];
-    if (!playerObj1 || !playerObj2) return false;
-    return this.teams.some(
-      team => team.includes(playerObj1) && team.includes(playerObj2)
+    // Buscar os IDs atuais dos jogadores. Mesmo que os objetos dos jogadores
+    // tenham sido recriados (por exemplo, após uma reconexão ou carga de
+    // estado), seus IDs permanecem constantes. Usar os IDs evita depender da
+    // identidade dos objetos em `this.teams`, que pode ficar obsoleta.
+    const id1 = this.players[playerId1]?.id;
+    const id2 = this.players[playerId2]?.id;
+    if (!id1 || !id2) return false;
+
+    return this.teams.some(team =>
+      team.some(p => p.id === id1) && team.some(p => p.id === id2)
     );
   }
 


### PR DESCRIPTION
## Summary
- avoid comparing player objects when checking partnerships
- test that partnerships still work if player objects are recreated

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b314616b8832a8d3d755926b1f53b