### PR TITLE
Fix invalid discard handling in training environment

### DIFF
--- a/game-ai-training/ai/environment.py
+++ b/game-ai-training/ai/environment.py
@@ -242,6 +242,9 @@ class GameEnvironment:
                 filtered.append(act)
 
         if not filtered:
+            discard_actions = [a for a in actions if a >= 70]
+            if discard_actions:
+                return [discard_actions[0]]
             return []
 
         return filtered[:10] if len(filtered) > 10 else filtered  # Limit actions

--- a/game-ai-training/tests/test_environment.py
+++ b/game-ai-training/tests/test_environment.py
@@ -30,6 +30,14 @@ def test_get_valid_actions_returns_empty_on_error():
     assert actions == []
 
 
+def test_get_valid_actions_preserves_discard_when_filtered():
+    env = GameEnvironment()
+    with patch.object(env, 'send_command', return_value={'validActions': [70, 71]}):
+        with patch.object(env, 'is_action_valid', return_value=False):
+            actions = env.get_valid_actions(0)
+    assert actions == [70]
+
+
 def test_step_updates_game_state_and_returns_rewards():
     env = GameEnvironment()
     with patch.object(env, 'send_command', return_value={'success': True, 'gameState': {'foo': 'bar'}, 'gameEnded': False, 'winningTeam': None}):


### PR DESCRIPTION
## Summary
- allow GameEnvironment to keep a discard when all actions are filtered out
- test that discards are preserved when validation rejects them

## Testing
- `pip install -r game-ai-training/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b30111de4832a8a128a3b775e6a85