### PR TITLE
Fix 7 card handling

### DIFF
--- a/game-ai-training/game/game_wrapper.js
+++ b/game-ai-training/game/game_wrapper.js
@@ -200,6 +200,21 @@ class GameWrapper {
                     }
                 }
 
+                // Single-piece seven moves
+                for (const pid of movable) {
+                    const moves = [{ pieceId: pid, steps: 7 }];
+                    const clone = this.game.cloneForSimulation();
+                    try {
+                        clone.makeSpecialMove(moves);
+                        specialActionsList.push(specialId);
+                        this.specialActions[specialId] = moves;
+                        specialId++;
+                    } catch (e) {
+                        // invalid move, ignore
+                    }
+                }
+
+                // Split moves across two pieces
                 for (let i = 0; i < movable.length; i++) {
                     for (let j = i + 1; j < movable.length; j++) {
                         for (let steps = 1; steps <= 6; steps++) {


### PR DESCRIPTION
## Summary
- allow single-piece moves with a 7 card
- add regression test for single-piece seven

## Testing
- `npm test`
- `pip install -r game-ai-training/requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684b442c437c832aa653b684e0087ee4