### PR TITLE
Fix Joker validation in training wrapper

### DIFF
--- a/game-ai-training/game/game_wrapper.js
+++ b/game-ai-training/game/game_wrapper.js
@@ -395,9 +395,14 @@ class GameWrapper {
                 return false;
             }
 
+            if (res && (res.action === 'homeEntryChoice' || res.action === 'choosePosition')) {
+                return true;
+            }
+
             if (res && res.success === false) {
                 return false;
             }
+
             return true;
         } catch (e) {
             return false;


### PR DESCRIPTION
## Summary
- treat `choosePosition` as a valid move in `isActionValid`

## Testing
- `pytest -q game-ai-training/tests`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684b4892b5cc832a82314d85cb1373ca