### PR TITLE
Improve invalid action fallback

### DIFF
--- a/game-ai-training/tests/test_environment.py
+++ b/game-ai-training/tests/test_environment.py
@@ -30,6 +30,14 @@ def test_get_valid_actions_returns_empty_on_error():
     assert actions == []
 
 
+def test_get_valid_actions_returns_discard_on_error_with_state():
+    env = GameEnvironment()
+    env.game_state = {'players': [{'cards': [{}]}]}
+    with patch.object(env, 'send_command', return_value={'error': 'fail'}):
+        actions = env.get_valid_actions(0)
+    assert actions == [70]
+
+
 def test_get_valid_actions_preserves_discard_when_filtered():
     env = GameEnvironment()
     with patch.object(env, 'send_command', return_value={'validActions': [70, 71]}):


### PR DESCRIPTION
## Summary
- add `_default_discards` helper for generating discard moves
- use discard fallback when `get_valid_actions` encounters errors or filtered list is empty
- test fallback behaviour

## Testing
- `pip install -r game-ai-training/requirements.txt`
- `pytest -q game-ai-training/tests`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684b7a37bb30832ab54c707db2aee84e