### PR TITLE
Fix Joker move validation

### DIFF
--- a/game-ai-training/game/game.js
+++ b/game-ai-training/game/game.js
@@ -727,6 +727,7 @@ class Game {
     }
     const occupiedPositions = this.pieces.filter(p =>
       p.id !== piece.id &&
+      p.playerId !== piece.playerId &&
       !p.completed &&
       !p.inPenaltyZone &&
       !p.inHomeStretch

--- a/game-ai-training/game/game_wrapper.js
+++ b/game-ai-training/game/game_wrapper.js
@@ -397,7 +397,20 @@ class GameWrapper {
                 return false;
             }
 
-            if (res && (res.action === 'homeEntryChoice' || res.action === 'choosePosition')) {
+            if (res && res.action === 'choosePosition') {
+                const piece = clone.pieces.find(p => p.id === pid);
+                for (const target of res.validPositions || []) {
+                    try {
+                        clone.moveToSelectedPosition(piece, target.id);
+                        return true;
+                    } catch (e) {
+                        continue;
+                    }
+                }
+                return false;
+            }
+
+            if (res && res.action === 'homeEntryChoice') {
                 return true;
             }
 

--- a/game-ai-training/tests/test_environment.py
+++ b/game-ai-training/tests/test_environment.py
@@ -651,6 +651,48 @@ def test_is_action_valid_discard():
     assert _run_is_action_valid_discard(5, 75) is False
 
 
+def _run_is_action_valid_joker_no_targets():
+    """Run GameWrapper.isActionValid when Joker has no valid targets."""
+    lines = [
+        "const fs = require('fs');",
+        "const Module = require('module');",
+        "const path = require('path');",
+        "const filename = path.join('game-ai-training','game','game_wrapper.js');",
+        "let code = fs.readFileSync(filename, 'utf8');",
+        "code = code.replace(/new GameWrapper\\(\\);\\s*$/, 'module.exports = GameWrapper;');",
+        "const m = new Module(filename);",
+        "m.filename = filename;",
+        "m.paths = Module._nodeModulePaths(path.dirname(filename));",
+        "m._compile(code, filename);",
+        "const GameWrapper = m.exports;",
+        "const wrapper = new GameWrapper();",
+        "wrapper.game = {",
+        "  players: [{ cards: [{ value: 'JOKER' }] }],",
+        "  pieces: [{ id: 'p0_1', completed: false, inPenaltyZone: false }],",
+        "  cloneForSimulation: function() { return {",
+        "    players: this.players,",
+        "    pieces: this.pieces,",
+        "    makeMove: () => ({ action: 'choosePosition', validPositions: [] }),",
+        "    moveToSelectedPosition: function() {}",
+        "  }; }",
+        "};",
+        "process.stdout.write(JSON.stringify(wrapper.isActionValid(0, 1)));"
+    ]
+    script = "\n".join(lines)
+
+    root = Path(__file__).resolve().parents[2]
+    with tempfile.NamedTemporaryFile('w+', suffix='.js', delete=False) as tmp:
+        tmp.write(script)
+        tmp.flush()
+        output = subprocess.check_output(['node', tmp.name], cwd=root, text=True)
+    lines = [line for line in output.splitlines() if line.strip()]
+    return json.loads(lines[-1]) if lines else None
+
+
+def test_is_action_valid_joker_no_targets():
+    assert _run_is_action_valid_joker_no_targets() is False
+
+
 def _run_get_special_actions_mock():
     """Run GameWrapper.getValidActions with a 7 card to ensure special actions are generated."""
     lines = [

--- a/server/__tests__/game.test.js
+++ b/server/__tests__/game.test.js
@@ -508,6 +508,28 @@ describe('Game class', () => {
     expect(() => game.moveToSelectedPosition(mover, target.id)).toThrow();
   });
 
+  test('moveToOccupiedSpace excludes own pieces from targets', () => {
+    const game = new Game('jokerTargets');
+    const mover = game.pieces.find(p => p.id === 'p0_1');
+    const friendly = game.pieces.find(p => p.id === 'p0_2');
+    const opponent = game.pieces.find(p => p.id === 'p1_1');
+
+    mover.inPenaltyZone = false;
+    mover.position = { row: 0, col: 8 };
+
+    friendly.inPenaltyZone = false;
+    friendly.position = { row: 0, col: 9 };
+
+    opponent.inPenaltyZone = false;
+    opponent.position = { row: 1, col: 8 };
+
+    const result = game.moveToOccupiedSpace(mover);
+    const ids = result.validPositions.map(v => v.id);
+
+    expect(ids).toContain(opponent.id);
+    expect(ids).not.toContain(friendly.id);
+  });
+
   test('executeMove cannot use Joker to leave home stretch', () => {
     const game = new Game('jokerHome');
     const mover = game.pieces.find(p => p.id === 'p0_1');

--- a/server/game.js
+++ b/server/game.js
@@ -720,6 +720,7 @@ discardCard(cardIndex) {
     }
     const occupiedPositions = this.pieces.filter(p =>
       p.id !== piece.id &&
+      p.playerId !== piece.playerId &&
       !p.completed &&
       !p.inPenaltyZone &&
       !p.inHomeStretch


### PR DESCRIPTION
## Summary
- restrict Joker targets to opponent pieces
- validate Joker actions have at least one legal target
- cover Joker rules with Jest and pytest

## Testing
- `npm test`
- `pip install -r game-ai-training/requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684b8899d570832a90402bcc684693d1