### PR TITLE
Add basic bot slot filling

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -98,6 +98,10 @@ input[type="text"] {
     box-shadow: 0 2px 5px rgba(0,0,0,0.1);
 }
 
+#fill-bots-btn {
+    margin-top: 1rem;
+}
+
 .players-list ul {
     list-style: none;
 }

--- a/public/index.html
+++ b/public/index.html
@@ -48,6 +48,7 @@
                 <h3>Jogadores:</h3>
                 <ul id="players-list"></ul>
             </div>
+            <button id="fill-bots-btn" class="btn secondary">Preencher com Bots</button>
             
             <div id="teams-setup" class="hidden">
                 <h3>Definir Duplas</h3>

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -13,6 +13,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const team2List = document.getElementById('team2-list');
     const waitingMessage = document.getElementById('waiting-message');
     const copyLinkBtn = document.getElementById('copy-link-btn');
+    const fillBotsBtn = document.getElementById('fill-bots-btn');
     
     // Botões
     const createRoomBtn = document.getElementById('create-room-btn');
@@ -245,6 +246,11 @@ function handleError(message) {
             }
             playersList.appendChild(li);
         });
+        if (players.length < 4) {
+            fillBotsBtn.classList.remove('hidden');
+        } else {
+            fillBotsBtn.classList.add('hidden');
+        }
     }
     
     function populateTeamLists() {
@@ -343,6 +349,12 @@ function handleError(message) {
         navigator.clipboard.writeText(shareLink).then(() => {
             alert('Link copiado para a área de transferência');
         });
+    });
+
+    fillBotsBtn.addEventListener('click', () => {
+        if (socket && roomId) {
+            socket.emit('fillBots', { roomId });
+        }
     });
     
     confirmTeamsBtn.addEventListener('click', () => {

--- a/server/game.js
+++ b/server/game.js
@@ -58,7 +58,7 @@ class Game {
     return pieces;
   }
 
-  addPlayer(id, name) {
+  addPlayer(id, name, isBot = false) {
     if (process.env.DEBUG === 'true') {
       console.log(`Tentando adicionar jogador ${name} (${id}) à sala ${this.roomId}`);
     }
@@ -83,7 +83,8 @@ class Game {
       id,
       name,
       cards: [],
-      position: this.players.length // 0, 1, 2 ou 3
+      position: this.players.length, // 0, 1, 2 ou 3
+      isBot
     });
     
     if (process.env.DEBUG === 'true') {

--- a/server/server.js
+++ b/server/server.js
@@ -488,6 +488,25 @@ socket.on('discardCard', ({ roomId, cardIndex }) => {
   }
 });
 
+  socket.on('fillBots', ({ roomId }) => {
+    const game = rooms.get(roomId);
+    if (!game) return;
+
+    while (game.players.length < 4) {
+      const idx = game.players.length;
+      const botId = `bot_${idx}`;
+      const botName = `Bot ${idx + 1}`;
+      game.addPlayer(botId, botName, true);
+    }
+
+    io.to(roomId).emit('updatePlayers', game.getPlayersInfo());
+
+    if (game.players.length === 4) {
+      const creatorId = game.players[0].id;
+      io.to(creatorId).emit('teamsReady');
+    }
+  });
+
 
   // Solicitar estado do jogo (para reconexão)
 // No evento 'requestGameState' no server.js


### PR DESCRIPTION
## Summary
- add button on lobby page to fill empty seats with bots
- style new button and show/hide based on current players
- update server to support filling seats with bot players
- extend `Game.addPlayer` to mark bots

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856df56a180832ab4f383edd40cf719