### PR TITLE
Introduce bot service and manager

### DIFF
--- a/game-ai-training/bot_service.py
+++ b/game-ai-training/bot_service.py
@@ -1,0 +1,47 @@
+import json
+import os
+import sys
+
+from ai.environment import GameEnvironment
+from ai.bot import GameBot
+from json_logger import info
+
+
+def load_bots(model_dir: str):
+    env = GameEnvironment()
+    bots = []
+    for i in range(4):
+        bot = GameBot(i, env.state_size, env.action_space_size, device="cpu")
+        path = os.path.join(model_dir, f"bot_{i}.pth")
+        if os.path.exists(path):
+            bot.load_model(path)
+            info("Loaded model", bot=i)
+        bots.append(bot)
+    return env, bots
+
+
+def main():
+    model_dir = os.environ.get("BOT_MODEL_DIR", "models/final")
+    env, bots = load_bots(model_dir)
+
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            cmd = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if cmd.get("cmd") == "predict":
+            env.game_state = cmd.get("gameState", {})
+            pid = int(cmd.get("playerId", 0))
+            valid = cmd.get("validActions", [])
+            state = env.get_state(pid)
+            action = bots[pid].act(state, valid)
+            print(json.dumps({"actionId": action}), flush=True)
+        elif cmd.get("cmd") == "quit":
+            break
+
+
+if __name__ == "__main__":
+    main()

--- a/server/bot_manager.js
+++ b/server/bot_manager.js
@@ -1,0 +1,76 @@
+const { spawn } = require('child_process');
+const path = require('path');
+const BotWrapper = require('./bot_wrapper');
+
+class BotManager {
+  constructor(game, io) {
+    this.game = game;
+    this.io = io;
+    this.wrapper = new BotWrapper(game);
+    this.proc = spawn('python3', [path.join(__dirname, '../game-ai-training/bot_service.py')]);
+    this.buffer = '';
+    this.queue = [];
+    this.proc.stdout.on('data', data => {
+      this.buffer += data.toString();
+      let idx;
+      while ((idx = this.buffer.indexOf('\n')) >= 0) {
+        const line = this.buffer.slice(0, idx);
+        this.buffer = this.buffer.slice(idx + 1);
+        let obj;
+        try {
+          obj = JSON.parse(line);
+        } catch {
+          obj = null;
+        }
+        const resolve = this.queue.shift();
+        if (resolve) resolve(obj);
+      }
+    });
+  }
+
+  requestAction(playerId) {
+    return new Promise(resolve => {
+      const msg = {
+        cmd: 'predict',
+        playerId,
+        gameState: this.wrapper.getGameState(),
+        validActions: this.wrapper.getValidActions(playerId)
+      };
+      this.proc.stdin.write(JSON.stringify(msg) + '\n');
+      this.queue.push(resolve);
+    });
+  }
+
+  async playBots() {
+    while (this.game.isActive) {
+      const current = this.game.getCurrentPlayer();
+      if (!current || !current.isBot) break;
+      const res = await this.requestAction(current.position);
+      const actionId = res && res.actionId !== undefined ? res.actionId : 70;
+      const result = this.wrapper.makeMove(current.position, actionId);
+      const roomId = this.game.roomId;
+      this.io.to(roomId).emit('gameStateUpdate', result.gameState);
+      const last = this.game.history[this.game.history.length - 1];
+      if (last && last.move) {
+        this.io.to(roomId).emit('lastMove', { message: last.move });
+      }
+      if (result.gameEnded) {
+        this.io.to(roomId).emit('gameOver', {
+          winners: result.winningTeam,
+          stats: result.stats
+        });
+        this.game.endGame();
+        break;
+      }
+    }
+  }
+
+  stop() {
+    if (this.proc) {
+      this.proc.stdin.write(JSON.stringify({ cmd: 'quit' }) + '\n');
+      this.proc.kill();
+    }
+  }
+}
+
+module.exports = BotManager;

--- a/server/bot_wrapper.js
+++ b/server/bot_wrapper.js
@@ -1,0 +1,232 @@
+const { Game } = require('./game');
+
+class BotWrapper {
+  constructor(game) {
+    this.game = game;
+    this.specialActions = {};
+  }
+
+  getGameState() {
+    if (typeof this.game.getGameStateWithCards === 'function') {
+      return this.game.getGameStateWithCards();
+    }
+    return this.game.getGameState();
+  }
+
+  getValidActions(playerId) {
+    try {
+      if (!this.game || !this.game.players || !this.game.players[playerId]) {
+        return [0];
+      }
+
+      const moveActions = [];
+      const specialActionsList = [];
+      const player = this.game.players[playerId];
+      this.specialActions = {};
+      let specialId = 60;
+      const maxMoveCards = Math.min(player.cards.length, 6);
+
+      const pieceInfos = [];
+      for (let n = 1; n <= 5; n++) {
+        pieceInfos.push({ owner: playerId, num: n, id: `p${playerId}_${n}` });
+      }
+      if (this.game.hasAllPiecesInHomeStretch && this.game.partnerIdFor &&
+          this.game.hasAllPiecesInHomeStretch(playerId)) {
+        const partner = this.game.partnerIdFor(playerId);
+        if (partner !== null && partner !== undefined) {
+          for (let n = 1; n <= 5; n++) {
+            pieceInfos.push({ owner: partner, num: n + 5, id: `p${partner}_${n}` });
+          }
+        }
+      }
+
+      for (let cardIdx = 0; cardIdx < Math.min(player.cards.length, 4); cardIdx++) {
+        if (player.cards[cardIdx].value !== '7') continue;
+
+        const movable = [];
+        for (const info of pieceInfos) {
+          const p = this.game.pieces.find(pp => pp.id === info.id);
+          if (p && !p.completed && !p.inPenaltyZone) {
+            movable.push(info.id);
+          }
+        }
+
+        for (const pid of movable) {
+          const moves = [{ pieceId: pid, steps: 7 }];
+          const clone = this.game.cloneForSimulation();
+          try {
+            clone.makeSpecialMove(moves);
+            specialActionsList.push(specialId);
+            this.specialActions[specialId] = moves;
+            specialId++;
+          } catch (e) {
+            // ignore invalid
+          }
+        }
+
+        for (let i = 0; i < movable.length; i++) {
+          for (let j = i + 1; j < movable.length; j++) {
+            for (let steps = 1; steps <= 6; steps++) {
+              const moves = [
+                { pieceId: movable[i], steps },
+                { pieceId: movable[j], steps: 7 - steps }
+              ];
+              const clone = this.game.cloneForSimulation();
+              try {
+                clone.makeSpecialMove(moves);
+                specialActionsList.push(specialId);
+                this.specialActions[specialId] = moves;
+                specialId++;
+              } catch (e) {
+                continue;
+              }
+            }
+          }
+        }
+      }
+
+      for (let cardIdx = 0; cardIdx < maxMoveCards; cardIdx++) {
+        for (const info of pieceInfos) {
+          const piece = this.game.pieces.find(p => p.id === info.id);
+          if (!piece || piece.completed) {
+            continue;
+          }
+          const clone = this.game.cloneForSimulation();
+          try {
+            clone.makeMove(info.id, cardIdx);
+            moveActions.push(cardIdx * 10 + info.num);
+          } catch (e) {
+            continue;
+          }
+        }
+      }
+
+      const validActions = [...specialActionsList, ...moveActions];
+
+      if (validActions.length === 0) {
+        const maxDiscardCards = Math.min(player.cards.length, 10);
+        for (let cardIdx = 0; cardIdx < maxDiscardCards; cardIdx++) {
+          validActions.push(70 + cardIdx);
+        }
+      }
+
+      return validActions;
+    } catch (e) {
+      return [];
+    }
+  }
+
+  makeMove(playerId, actionId) {
+    try {
+      if (!this.game || !this.game.isActive) {
+        throw new Error('Game is not active');
+      }
+      if (playerId !== this.game.currentPlayerIndex) {
+        throw new Error('Not this player\'s turn');
+      }
+
+      let result;
+      let playedCard;
+      let jokerPlayed = false;
+
+      if (actionId >= 70) {
+        const cardIndex = actionId - 70;
+        playedCard = this.game.players[playerId].cards[cardIndex];
+
+        if (this.game.hasAnyValidMove && this.game.hasAnyValidMove(playerId)) {
+          const alt = this.getValidActions(playerId)[0];
+          if (alt !== undefined) {
+            return this.makeMove(playerId, alt);
+          }
+        }
+
+        try {
+          result = this.game.discardCard(cardIndex);
+        } catch (e) {
+          throw e;
+        }
+      } else {
+        let pieceNumber = actionId % 10;
+        let cardIndex;
+        if (pieceNumber === 0) {
+          pieceNumber = 10;
+          cardIndex = (actionId - pieceNumber) / 10;
+        } else {
+          cardIndex = Math.floor(actionId / 10);
+        }
+        let ownerId = playerId;
+        if (pieceNumber > 5) {
+          const partner = this.game.partnerIdFor && this.game.partnerIdFor(playerId);
+          if (partner === null || partner === undefined) {
+            throw new Error('Invalid partner move');
+          }
+          ownerId = partner;
+          pieceNumber -= 5;
+        }
+        const pieceId = `p${ownerId}_${pieceNumber}`;
+        playedCard = this.game.players[playerId].cards[cardIndex];
+        result = this.game.makeMove(pieceId, cardIndex);
+
+        if (result && result.action === 'homeEntryChoice') {
+          result = this.game.makeMove(pieceId, cardIndex, true);
+        }
+
+        if (result && result.action === 'choosePosition') {
+          const target = result.validPositions && result.validPositions[0];
+          if (!target) {
+            throw new Error('No valid Joker positions');
+          }
+          const piece = this.game.pieces.find(p => p.id === pieceId);
+          result = this.game.moveToSelectedPosition(piece, target.id);
+          this.game.discardPile.push(playedCard);
+          this.game.players[playerId].cards.splice(cardIndex, 1);
+          jokerPlayed = true;
+          const playerName = this.game.players[playerId].name;
+          const msg = `${playerName} moveu ${pieceId} com C`;
+          this.game.history.push({ move: msg, state: this.getGameState() });
+          this.game.nextTurn();
+        }
+      }
+
+      if (jokerPlayed) {
+        this.game.stats.jokersPlayed[playerId]++;
+      }
+
+      const nextPlayer = this.game.getCurrentPlayer();
+      if (nextPlayer) {
+        try {
+          nextPlayer.cards.push(this.game.drawCard());
+        } catch (e) {}
+      }
+
+      const gameEnded = this.game.checkWinCondition();
+      const winningTeam = gameEnded ? this.game.getWinningTeam() : null;
+
+      const response = {
+        success: true,
+        action: result && result.action ? result.action : 'move',
+        captures: result && result.captures ? result.captures : [],
+        gameState: this.getGameState(),
+        gameEnded,
+        winningTeam
+      };
+
+      if (gameEnded) {
+        response.stats = {
+          summary: this.game.getStatisticsSummary(),
+          full: this.game.stats
+        };
+      }
+
+      return response;
+    } catch (error) {
+      return {
+        success: false,
+        error: error.message,
+        gameState: this.getGameState()
+      };
+    }
+  }
+}
+
+module.exports = BotWrapper;


### PR DESCRIPTION
## Summary
- add `bot_service.py` for lightweight model predictions over stdin/stdout
- implement `BotWrapper` and `BotManager` to communicate with the Python bot service

## Testing
- `pip install -r game-ai-training/requirements.txt`
- `pytest game-ai-training/tests`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6856e35600ac832aa85c4cde62dfaf90