### PR TITLE
Integrate bots with game server

### DIFF
--- a/server/bot_manager.js
+++ b/server/bot_manager.js
@@ -7,6 +7,7 @@ class BotManager {
     this.game = game;
     this.io = io;
     this.wrapper = new BotWrapper(game);
+    this.running = false;
     this.proc = spawn('python3', [path.join(__dirname, '../game-ai-training/bot_service.py')]);
     this.buffer = '';
     this.queue = [];
@@ -42,6 +43,8 @@ class BotManager {
   }
 
   async playBots() {
+    if (this.running) return;
+    this.running = true;
     while (this.game.isActive) {
       const current = this.game.getCurrentPlayer();
       if (!current || !current.isBot) break;
@@ -63,6 +66,7 @@ class BotManager {
         break;
       }
     }
+    this.running = false;
   }
 
   stop() {


### PR DESCRIPTION
## Summary
- load BotManager when a game has bots
- trigger bot moves whenever a bot's turn starts
- stop the bot process when games finish or rooms are removed
- prevent concurrent bot loops

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856ee026dec832aa9e909ea6b267bfb