### PR TITLE
Add Python deps for bots

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,18 @@ FROM node:18-alpine
 
 WORKDIR /app
 
-COPY package*.json ./
+# Install Python for the bot manager and its dependencies
+RUN apk add --no-cache python3 py3-pip
 
+# Install Node.js dependencies
+COPY package*.json ./
 RUN npm install
 
+# Install Python dependencies for the bot service
+COPY game-ai-training/requirements.txt ./game-ai-training/requirements.txt
+RUN pip3 install --no-cache-dir -r game-ai-training/requirements.txt
+
+# Copy the rest of the application code
 COPY . .
 
 EXPOSE 3000


### PR DESCRIPTION
## Summary
- install python3 and pip
- install Python requirements for bot service

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856f15f72b4832ab7e1b54bdd4329a8