### PR TITLE
Add bot turn delay and human turn notification

### DIFF
--- a/server/bot_manager.js
+++ b/server/bot_manager.js
@@ -65,6 +65,20 @@ class BotManager {
         this.game.endGame();
         break;
       }
+
+      const nextPlayer = this.game.getCurrentPlayer();
+      if (!nextPlayer) break;
+
+      if (!nextPlayer.isBot) {
+        this.io.to(nextPlayer.id).emit('yourTurn', {
+          cards: nextPlayer.cards,
+          canMove: this.game.hasAnyValidMove(nextPlayer.position)
+        });
+        break;
+      }
+
+      const delay = 4000 + Math.random() * 4000;
+      await new Promise(resolve => setTimeout(resolve, delay));
     }
     this.running = false;
   }


### PR DESCRIPTION
## Summary
- slow down bot turns in `bot_manager` so they wait 4‒8s between moves
- notify human players at the end of bot turns so they see their new cards

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856f54cb65c832aab36b46bb89454ee