### PR TITLE
Save replay when bots finish game

### DIFF
--- a/server/bot_manager.js
+++ b/server/bot_manager.js
@@ -30,9 +30,10 @@ function logTurnState(game) {
 }
 
 class BotManager {
-  constructor(game, io) {
+  constructor(game, io, onGameOver = null) {
     this.game = game;
     this.io = io;
+    this.onGameOver = typeof onGameOver === 'function' ? onGameOver : null;
     this.wrapper = new BotWrapper(game);
     this.running = false;
     this.proc = spawn('python3', [path.join(__dirname, '../game-ai-training/bot_service.py')]);
@@ -90,6 +91,13 @@ class BotManager {
           winners: result.winningTeam,
           stats: result.stats
         });
+        if (this.onGameOver) {
+          try {
+            this.onGameOver(this.game);
+          } catch (e) {
+            console.error('onGameOver callback failed:', e);
+          }
+        }
         this.game.endGame();
         break;
       }

--- a/server/server.js
+++ b/server/server.js
@@ -198,7 +198,7 @@ function launchGame(game) {
   game.startGame();
 
   if (game.players.some(p => p.isBot)) {
-    game.botManager = new BotManager(game, io);
+    game.botManager = new BotManager(game, io, saveReplay);
   } else {
     game.botManager = null;
   }


### PR DESCRIPTION
## Summary
- update `BotManager` to optionally run an onGameOver callback
- call the callback before ending the game when bots finish
- pass `saveReplay` from `server.js` to `BotManager`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68574848d59c832a9b2b937a7040f5d3