### PR TITLE
Fix 7-card modal with single movable piece

### DIFF
--- a/public/js/game.js
+++ b/public/js/game.js
@@ -1224,7 +1224,7 @@ function makeMove() {
         const movable = gameState.pieces.filter(p => {
             if (!canControlPiece(playerPosition, p.playerId)) return false;
             if (p.inPenaltyZone || p.completed) return false;
-            if (p.inHomeStretch) return canMoveInHomeStretch(p);
+            if (p.inHomeStretch) return false;
             return true;
         });
 


### PR DESCRIPTION
## Summary
- avoid prompting for piece split when only one controllable piece is outside home stretch

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857ef691700832a84af8c3b5f8c702c