### PR TITLE
Fix bot seven logic

### DIFF
--- a/game-ai-training/game/game_wrapper.js
+++ b/game-ai-training/game/game_wrapper.js
@@ -200,15 +200,22 @@ class GameWrapper {
 
             // Generate special move actions for card 7 first so they are not
             // truncated when many normal moves exist.
-            const sevenIndices = cardIndices
-                .filter(i => player.cards[i].value === '7')
-                .slice(0, 4);
+            // Look through the entire hand for sevens so they are always
+            // considered, even when more than six unique card values are
+            // present. Limit to the first four sevens to keep the action
+            // space bounded.
+            const sevenIndices = [];
+            for (let i = 0; i < player.cards.length && sevenIndices.length < 4; i++) {
+                if (player.cards[i].value === '7') {
+                    sevenIndices.push(i);
+                }
+            }
             for (const cardIdx of sevenIndices) {
 
                 const movable = [];
                 for (const info of pieceInfos) {
                     const p = this.game.pieces.find(pp => pp.id === info.id);
-                    if (p && !p.completed && !p.inPenaltyZone) {
+                    if (p && !p.completed && !p.inPenaltyZone && !p.inHomeStretch) {
                         movable.push(info.id);
                     }
                 }

--- a/server/bot_wrapper.js
+++ b/server/bot_wrapper.js
@@ -49,15 +49,21 @@ class BotWrapper {
         }
       }
 
-      const sevenIndices = cardIndices
-        .filter(i => player.cards[i].value === '7')
-        .slice(0, 4);
+      // Search the entire hand for sevens so bots consider them even when
+      // more than six unique values appear. Limit to the first four sevens
+      // to mirror the training wrapper logic.
+      const sevenIndices = [];
+      for (let i = 0; i < player.cards.length && sevenIndices.length < 4; i++) {
+        if (player.cards[i].value === '7') {
+          sevenIndices.push(i);
+        }
+      }
       for (const cardIdx of sevenIndices) {
 
         const movable = [];
         for (const info of pieceInfos) {
           const p = this.game.pieces.find(pp => pp.id === info.id);
-          if (p && !p.completed && !p.inPenaltyZone) {
+          if (p && !p.completed && !p.inPenaltyZone && !p.inHomeStretch) {
             movable.push(info.id);
           }
         }


### PR DESCRIPTION
## Summary
- look at entire hand for sevens when generating special actions
- limit to first four sevens
- handle sevens for bots in game wrapper and server wrapper

## Testing
- `npm test`
- `pip install -r game-ai-training/requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6858101f2394832ab8ad1489194bcedb