### PR TITLE
Include move count and winners in summary

### DIFF
--- a/game-ai-training/game/game.js
+++ b/game-ai-training/game/game.js
@@ -1395,6 +1395,8 @@ class Game {
     const jok = pick(stat.jokersPlayed);
     const mostCap = pick(stat.timesCaptured);
 
+    const winners = this.getWinningTeam() || [];
+
     return {
       mostCaptures: {
         name: this.players[capt.idx]?.name,
@@ -1411,7 +1413,9 @@ class Game {
       mostCaptured: {
         name: this.players[mostCap.idx]?.name,
         count: mostCap.max
-      }
+      },
+      movesPlayed: this.history.length,
+      winners: winners.map(p => p.name)
     };
   }
 

--- a/server/game.js
+++ b/server/game.js
@@ -1391,6 +1391,7 @@ discardCard(cardIndex) {
     const stuck = pick(stat.roundsWithoutPlay);
     const jok = pick(stat.jokersPlayed);
     const mostCap = pick(stat.timesCaptured);
+    const winners = this.getWinningTeam() || [];
 
     return {
       mostCaptures: {
@@ -1408,7 +1409,9 @@ discardCard(cardIndex) {
       mostCaptured: {
         name: this.players[mostCap.idx]?.name,
         count: mostCap.max
-      }
+      },
+      movesPlayed: this.history.length,
+      winners: winners.map(p => p.name)
     };
   }
 


### PR DESCRIPTION
## Summary
- extend statistics summary with `movesPlayed` and `winners`
- keep server and training versions consistent

## Testing
- `pip install -r game-ai-training/requirements.txt`
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685818a177a4832ab32ff13733e6bfb9