### PR TITLE
Fix special move detection for card 7

### DIFF
--- a/game-ai-training/game/game_wrapper.js
+++ b/game-ai-training/game/game_wrapper.js
@@ -215,7 +215,10 @@ class GameWrapper {
                 const movable = [];
                 for (const info of pieceInfos) {
                     const p = this.game.pieces.find(pp => pp.id === info.id);
-                    if (p && !p.completed && !p.inPenaltyZone && !p.inHomeStretch) {
+                    if (p && !p.completed && !p.inPenaltyZone) {
+                        // Allow pieces already in the home stretch to be
+                        // considered for splitting the movement. The game will
+                        // reject illegal moves.
                         movable.push(info.id);
                     }
                 }

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -1251,7 +1251,9 @@ function makeMove() {
         const movable = gameState.pieces.filter(p => {
             if (!canControlPiece(playerPosition, p.playerId)) return false;
             if (p.inPenaltyZone || p.completed) return false;
-            if (p.inHomeStretch) return false;
+            // Allow pieces already in the home stretch to be considered for
+            // splitting the movement. The server will validate whether the
+            // desired move is legal.
             return true;
         });
 

--- a/server/bot_wrapper.js
+++ b/server/bot_wrapper.js
@@ -63,7 +63,9 @@ class BotWrapper {
         const movable = [];
         for (const info of pieceInfos) {
           const p = this.game.pieces.find(pp => pp.id === info.id);
-          if (p && !p.completed && !p.inPenaltyZone && !p.inHomeStretch) {
+          if (p && !p.completed && !p.inPenaltyZone) {
+            // Include pieces already in the home stretch. The game engine will
+            // validate whether the resulting split move is legal.
             movable.push(info.id);
           }
         }


### PR DESCRIPTION
## Summary
- allow pieces already in the home stretch to be considered for splitting the 7-card movement
- update bot wrappers so the training and server bots consider home-stretch pieces

## Testing
- `npm test`
- `pytest game-ai-training/tests`

------
https://chatgpt.com/codex/tasks/task_e_685993360514832aa3e18b5bfe4b7e72