### PR TITLE
Fix special move prompt when only one piece is movable

### DIFF
--- a/public/js/game.js
+++ b/public/js/game.js
@@ -1257,7 +1257,9 @@ function makeMove() {
             return true;
         });
 
-        if (movable.length <= 1) {
+        const movableTrack = movable.filter(p => !p.inHomeStretch);
+
+        if (movableTrack.length <= 1) {
             socket.emit('makeSpecialMove', {
                 roomId,
                 moves: [{ pieceId: selectedPieceId, steps: 7 }],


### PR DESCRIPTION
## Summary
- update the `initiateSpecialMove` logic to ignore home stretch pieces when determining if more than one piece can move

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859a086a560832a9ae092631dcad307