### PR TITLE
Fix missing piece display after animation update

### DIFF
--- a/public/js/game.js
+++ b/public/js/game.js
@@ -278,7 +278,7 @@ function handleRoomJoined(data) {
 
 function handleGameStarted(state) {
   console.log('Novo jogo iniciado:', state);
-  const old = prevPieces;
+  const old = prevPieces || [];
   gameState = state;
   updateBoard(old);
   updateTeams();
@@ -321,7 +321,7 @@ function handlePlayerInfo(data) {
     // Manipuladores de eventos do socket
     function handleGameStateUpdate(state) {
         console.log('Estado do jogo recebido:', state);
-        const old = prevPieces;
+        const old = prevPieces || [];
         gameState = state;
 
         clearJokerMode();
@@ -560,6 +560,7 @@ function checkIfStuckInPenalty(cards, canMoveFlag) {
     
    // Modifique a função updateBoard para incluir o indicador de peças
 function updateBoard(oldPieces = []) {
+  if (!oldPieces) oldPieces = [];
   if (!gameState) return;
 
   clearJokerMode();


### PR DESCRIPTION
## Summary
- guard against null `prevPieces` when updating board
- ensure `updateBoard` can accept `null` for old pieces

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859a18fc9b4832a8fb3b2c5f90964ba