### PR TITLE
Fix bot log history

### DIFF
--- a/server/log_utils.js
+++ b/server/log_utils.js
@@ -24,11 +24,6 @@ function logTurnState(game) {
   console.log(`Suas peças: ${ownPieces}`);
   console.log(`Outros: ${others}`);
 
-  const snapState = game.getGameStateWithCards();
-  delete snapState.lastMove;
-  snapState.currentPlayerCards = player.cards.map(c => ({ ...c }));
-  const snapshot = JSON.parse(JSON.stringify(snapState));
-  game.history.push({ move: `Turno de ${player.name}`, state: snapshot });
 }
 
 function logMoveDetails(player, pieceId, oldPos, result, game, card) {


### PR DESCRIPTION
## Summary
- clean up `logTurnState` so it doesn't push snapshots to history

## Testing
- `npm test`
- `pytest game-ai-training/tests`

------
https://chatgpt.com/codex/tasks/task_e_6859adc8ee5c832aa360536615ce74dd