### PR TITLE
Add valid split calculation to training game

### DIFF
--- a/game-ai-training/game/game.js
+++ b/game-ai-training/game/game.js
@@ -1503,6 +1503,24 @@ class Game {
     return false;
   }
 
+  getValidSplits(pieceAId, pieceBId) {
+    const valid = [];
+    for (let s = 1; s <= 6; s++) {
+      const moves = [
+        { pieceId: pieceAId, steps: s },
+        { pieceId: pieceBId, steps: 7 - s }
+      ];
+      const clone = this.cloneForSimulation();
+      try {
+        clone.makeSpecialMove(moves);
+        valid.push(s);
+      } catch (e) {
+        continue;
+      }
+    }
+    return valid;
+  }
+
   getPlayersInfo() {
     return this.players.map(p => ({
       id: p.id,


### PR DESCRIPTION
## Summary
- implement `getValidSplits` in the training Game class
- maintain parity with server seven-card logic

## Testing
- `npm test`
- `pytest` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6859b09134ec832ab2e3b2bc98aed6d1