### PR TITLE
Switch training to PPO with improved rewards

### DIFF
--- a/game-ai-training/config.py
+++ b/game-ai-training/config.py
@@ -6,13 +6,11 @@ TRAINING_CONFIG = {
     'learning_rate': 0.001,
     'batch_size': 32,
     'memory_size': 10000,
-    'epsilon_start': 1.0,
-    'epsilon_min': 0.01,
-    'epsilon_decay': 0.995,
     'gamma': 0.95,
     'hidden_size': 512,
-    'update_target_freq': 100,
-    'train_freq': 4
+    'train_freq': 4,
+    'ppo_clip': 0.2,
+    'entropy_weight': 0.01
 }
 
 # Paths

--- a/game-ai-training/tests/test_environment.py
+++ b/game-ai-training/tests/test_environment.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 import subprocess
 from pathlib import Path
 import tempfile
+import pytest
 from ai.environment import GameEnvironment
 
 
@@ -52,7 +53,7 @@ def test_step_updates_game_state_and_returns_rewards():
         with patch.object(env, 'is_action_valid', return_value=True):
             with patch.object(env, 'get_state', return_value=np.zeros(env.state_size)):
                 next_state, reward, done = env.step(1, 0)
-    assert reward == 0.0
+    assert reward == 0.05
     assert done is False
     assert env.game_state == {'foo': 'bar', 'gameEnded': False, 'winningTeam': None}
     assert isinstance(next_state, np.ndarray)
@@ -851,7 +852,7 @@ def test_step_retries_until_success():
                 with patch.object(env, 'get_state', return_value=np.zeros(env.state_size)):
                     next_state, reward, done = env.step(1, 0)
 
-    assert reward == -0.2
+    assert reward == pytest.approx(-0.15)
     assert mock_cmd.call_count == 3
 
 


### PR DESCRIPTION
## Summary
- implement PPO-based `GameBot` with action masking
- revamp reward logic to encourage progress and penalize captures
- adjust tests for new rewards
- add PPO hyperparameters

## Testing
- `pip install -r game-ai-training/requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685ac4a8b258832a92bf22b0d2476994