### PR TITLE
Fix missing update_target_freq in GameBot

### DIFF
--- a/game-ai-training/ai/bot.py
+++ b/game-ai-training/ai/bot.py
@@ -47,6 +47,9 @@ class GameBot:
         self.entropy_weight = TRAINING_CONFIG.get('entropy_weight', 0.01)
         self.batch_size = TRAINING_CONFIG['batch_size']
         self.train_freq = TRAINING_CONFIG['train_freq']
+        # Number of steps between calls to update_target_network().
+        # Some configs (e.g. quick_start.sh) override this value.
+        self.update_target_freq = TRAINING_CONFIG.get('update_target_freq', 1000)
         self.step_count = 0
 
         self.epsilon = 0.0

--- a/game-ai-training/config.py
+++ b/game-ai-training/config.py
@@ -10,7 +10,12 @@ TRAINING_CONFIG = {
     'hidden_size': 512,
     'train_freq': 4,
     'ppo_clip': 0.2,
-    'entropy_weight': 0.01
+    'entropy_weight': 0.01,
+    # How often the bot's target network should be updated.
+    # Used by TrainingManager to call GameBot.update_target_network().
+    # Defaulting to a relatively high value keeps updates infrequent
+    # but allows quick overrides in custom configs.
+    'update_target_freq': 1000
 }
 
 # Paths


### PR DESCRIPTION
## Summary
- add `update_target_freq` to base training config and use it in GameBot
- document the new setting

## Testing
- `pip install -r game-ai-training/requirements.txt`
- `pytest -q game-ai-training/tests`

------
https://chatgpt.com/codex/tasks/task_e_685ad04d5ce4832ab08f35f674363282