### PR TITLE
Replace epsilon plot with KL divergence

### DIFF
--- a/game-ai-training/ai/bot.py
+++ b/game-ai-training/ai/bot.py
@@ -87,7 +87,7 @@ class GameBot:
 
     def replay(self):
         if len(self.memory) < self.batch_size:
-            return
+            return None
 
         states, actions, rewards, dones, log_probs, values = zip(*self.memory)
         self.memory = []
@@ -119,6 +119,7 @@ class GameBot:
         dist = torch.distributions.Categorical(probs)
         new_log_probs = dist.log_prob(actions_t)
         entropy = dist.entropy().mean()
+        approx_kl = (old_log_probs_t.detach() - new_log_probs).mean().item()
 
         ratio = (new_log_probs - old_log_probs_t.detach()).exp()
         surr1 = ratio * advantages
@@ -132,6 +133,8 @@ class GameBot:
         self.optimizer.step()
 
         self.losses.append(float(loss.item()))
+
+        return approx_kl
 
     def update_target_network(self):
         pass


### PR DESCRIPTION
## Summary
- capture approximate KL divergence in `GameBot.replay`
- track KL divergence values in `TrainingManager`
- plot KL divergence instead of epsilon
- remove unused epsilon output

## Testing
- `pip install -r game-ai-training/requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685add350de8832abc2169207e69283c