### PR TITLE
Randomize bot seats each episode

### DIFF
--- a/game-ai-training/ai/trainer.py
+++ b/game-ai-training/ai/trainer.py
@@ -9,6 +9,7 @@ from ai.environment import GameEnvironment
 from ai.bot import GameBot
 from config import TRAINING_CONFIG, MODEL_DIR, PLOT_DIR, LOG_DIR
 from json_logger import info, warning
+import random
 
 class TrainingManager:
     def __init__(self, num_envs: int = 1):
@@ -66,10 +67,19 @@ class TrainingManager:
             self.bots.append(bot)
 
         info("Created bots for training", count=num_bots, gpus=num_gpus)
+
+    def _shuffle_bots(self) -> None:
+        """Randomize bot seating positions for the next episode."""
+        random.shuffle(self.bots)
+        for idx, bot in enumerate(self.bots):
+            bot.player_id = idx
     
     def train_episode(self, env=None):
         """Run a single training episode using the provided environment."""
         env = env or self.env
+
+        # Randomize bot seating for this episode
+        self._shuffle_bots()
 
         # Reset environment
         initial_state = env.reset()

--- a/game-ai-training/tests/test_trainer.py
+++ b/game-ai-training/tests/test_trainer.py
@@ -77,9 +77,10 @@ def test_train_episode_increments_wins():
         manager.env = MockGameEnvironment()
         manager.create_bots(num_bots=4)
 
-        initial_wins = manager.bots[0].wins
-        manager.train_episode()
-        assert manager.bots[0].wins == initial_wins + 1
+        with patch.object(manager, '_shuffle_bots', lambda: None):
+            initial_wins = manager.bots[0].wins
+            manager.train_episode()
+            assert manager.bots[0].wins == initial_wins + 1
 
 
 def test_train_episode_breaks_on_no_actions():
@@ -98,5 +99,6 @@ def test_train_episode_breaks_on_no_actions():
         manager.env = env
         manager.create_bots(num_bots=4)
 
-        manager.train_episode()
-        env.step.assert_not_called()
+        with patch.object(manager, '_shuffle_bots', lambda: None):
+            manager.train_episode()
+            env.step.assert_not_called()


### PR DESCRIPTION
## Summary
- shuffle bot order before each training episode so bots change seats and partners
- adjust trainer unit tests to handle bot shuffling

## Testing
- `pip install -r game-ai-training/requirements.txt`
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685ae36af0a0832aba6944e1a66614f2