### PR TITLE
Reflect bot identities in training logs

### DIFF
--- a/game-ai-training/ai/bot.py
+++ b/game-ai-training/ai/bot.py
@@ -31,11 +31,12 @@ class ActorCritic(nn.Module):
 class GameBot:
     """PPO-based game bot."""
 
-    def __init__(self, player_id: int, state_size: int, action_size: int, device: str = None):
+    def __init__(self, player_id: int, state_size: int, action_size: int, device: str = None, bot_id: int = None):
         self.device = torch.device(device or ("cuda" if torch.cuda.is_available() else "cpu"))
-        info("Bot using device", bot=player_id, device=str(self.device))
+        info("Bot using device", bot=bot_id if bot_id is not None else player_id, device=str(self.device))
 
         self.player_id = player_id
+        self.bot_id = bot_id if bot_id is not None else player_id
         self.state_size = state_size
         self.action_size = action_size
 

--- a/game-ai-training/ai/environment.py
+++ b/game-ai-training/ai/environment.py
@@ -208,13 +208,23 @@ class GameEnvironment:
         except Exception as e:
             return {"error": f"Communication error: {e}"}
     
-    def reset(self) -> np.ndarray:
-        """Reset game and return initial state"""
+    def reset(self, bot_names=None) -> np.ndarray:
+        """Reset game and return initial state.
+
+        Parameters
+        ----------
+        bot_names : Optional[List[str]]
+            Names to assign to seats 0-3 so logs reflect the actual bots.
+        """
         if not self.node_process or self.node_process.poll() is not None:
             if not self.start_node_game():
                 return np.zeros(self.state_size)
-        
-        response = self.send_command({"action": "reset"})
+
+        command = {"action": "reset"}
+        if bot_names:
+            command["botNames"] = bot_names
+
+        response = self.send_command(command)
         if response.get('success'):
             self.game_state = response.get("gameState", {})
             # Ensure win information fields exist for trainer

--- a/game-ai-training/ai/trainer.py
+++ b/game-ai-training/ai/trainer.py
@@ -54,7 +54,8 @@ class TrainingManager:
                     player_id=i,
                     state_size=self.env.state_size,
                     action_size=self.env.action_space_size,
-                    device=device
+                    device=device,
+                    bot_id=i
                 )
             except TypeError:
                 # For backward compatibility or when GameBot is mocked without
@@ -62,7 +63,8 @@ class TrainingManager:
                 bot = GameBot(
                     player_id=i,
                     state_size=self.env.state_size,
-                    action_size=self.env.action_space_size
+                    action_size=self.env.action_space_size,
+                    bot_id=i
                 )
             self.bots.append(bot)
 
@@ -81,8 +83,11 @@ class TrainingManager:
         # Randomize bot seating for this episode
         self._shuffle_bots()
 
-        # Reset environment
-        initial_state = env.reset()
+        # Names for logging the actual bot identities in the Node game
+        bot_names = [f"Bot_{bot.bot_id}" if hasattr(bot, 'bot_id') else f"Bot_{i}" for i, bot in enumerate(self.bots)]
+
+        # Reset environment with the ordered bot names
+        initial_state = env.reset(bot_names=bot_names)
         
         episode_rewards = [0] * 4
         states = [None] * 4

--- a/game-ai-training/game/game_wrapper.js
+++ b/game-ai-training/game/game_wrapper.js
@@ -45,13 +45,14 @@ class GameWrapper {
         process.stdout.write(JSON.stringify(response) + '\n');
     }
     
-    setupGame() {
+    setupGame(botNames) {
         try {
             this.game = new Game("training_room");
 
             // Add 4 bot players
             for (let i = 0; i < 4; i++) {
-                this.game.addPlayer(`bot_${i}`, `Bot_${i}`);
+                const name = Array.isArray(botNames) && botNames[i] ? botNames[i] : `Bot_${i}`;
+                this.game.addPlayer(`bot_${i}`, name);
             }
 
             this.game.startGame();
@@ -93,7 +94,7 @@ class GameWrapper {
         try {
             switch (command.action) {
                 case 'reset':
-                    if (this.setupGame()) {
+                    if (this.setupGame(command.botNames)) {
                         return {
                             success: true,
                             gameState: this.getGameState()

--- a/game-ai-training/tests/test_trainer.py
+++ b/game-ai-training/tests/test_trainer.py
@@ -12,7 +12,7 @@ class MockGameEnvironment:
         self.env_id = 0
         self.saved_file = None
 
-    def reset(self):
+    def reset(self, bot_names=None):
         self.game_state = {'currentPlayerIndex': 0, 'gameEnded': False, 'winningTeam': None}
         return np.zeros(self.state_size)
 
@@ -38,8 +38,9 @@ class MockGameEnvironment:
 
 
 class DummyGameBot:
-    def __init__(self, player_id, state_size, action_size):
+    def __init__(self, player_id, state_size, action_size, device=None, bot_id=None):
         self.player_id = player_id
+        self.bot_id = bot_id if bot_id is not None else player_id
         self.state_size = state_size
         self.action_space_size = action_size
         self.wins = 0


### PR DESCRIPTION
## Summary
- inject bot names when resetting the game so Node logs the shuffled bot identities
- allow `GameEnvironment.reset` to accept `bot_names`
- track static `bot_id` on `GameBot`
- update trainer and tests for the new parameters

## Testing
- `pip install -r game-ai-training/requirements.txt`
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685afc2e9784832ab574d06f386777f7