### PR TITLE
Fix partner control after move rollback

### DIFF
--- a/server/game.js
+++ b/server/game.js
@@ -445,6 +445,7 @@ discardCard(cardIndex) {
       // Reverter para o estado salvo
       this.pieces = snapshot.pieces;
       this.players = snapshot.players;
+      this.relinkTeams();
       this.discardPile = snapshot.discardPile;
       this.stats = snapshot.stats;
       this.pendingSpecialMove = snapshot.pendingSpecialMove;
@@ -517,6 +518,7 @@ discardCard(cardIndex) {
     } catch (err) {
       this.pieces = snapshot.pieces;
       this.players = snapshot.players;
+      this.relinkTeams();
       this.discardPile = snapshot.discardPile;
       this.stats = snapshot.stats;
       this.pendingSpecialMove = snapshot.pendingSpecialMove;
@@ -1324,6 +1326,14 @@ discardCard(cardIndex) {
     if (!team) return null;
     const partner = team.find(p => p.position !== playerId);
     return partner ? partner.position : null;
+  }
+
+  relinkTeams() {
+    this.teams = this.teams.map(team =>
+      team.map(player =>
+        this.players.find(p => p.position === player.position)
+      )
+    );
   }
 
   canControlPiece(controllerId, pieceOwnerId) {


### PR DESCRIPTION
## Summary
- ensure teams remain in sync with player list
- update team references when a move rollback occurs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b68b9a9c4832abd2adf8513534695