### PR TITLE
Add penalty when skipping home entry

### DIFF
--- a/game-ai-training/ai/environment.py
+++ b/game-ai-training/ai/environment.py
@@ -514,6 +514,20 @@ class GameEnvironment:
                         if diff > 0:
                             reward += 0.1 * diff
 
+                        # Penalize skipping the home entrance when it was
+                        # possible to enter.
+                        forward = (new_idx - prev_idx) % len(self._track)
+                        backward = (prev_idx - new_idx) % len(self._track)
+                        moved_forward = forward <= backward
+                        prev_steps = self._steps_to_entrance(prev_info['pos'], owner)
+                        if (
+                            moved_forward
+                            and 0 < prev_steps <= 6
+                            and forward > prev_steps
+                            and not p.get('inHomeStretch')
+                        ):
+                            reward -= 0.3
+
                 if owner in my_team:
                     if prev_info and not prev_info['in_penalty'] and now_penalty:
                         reward -= 0.5

--- a/game-ai-training/tests/test_environment.py
+++ b/game-ai-training/tests/test_environment.py
@@ -876,3 +876,55 @@ def test_step_discards_when_all_actions_fail():
 
     assert mock_cmd.call_count == 3
     assert mock_cmd.call_args[0][0]['actionId'] >= 70
+
+
+def test_penalty_for_skipping_home_entry():
+    env = GameEnvironment()
+
+    env.game_state = {
+        'pieces': [
+            {
+                'id': 'p0_1',
+                'playerId': 0,
+                'position': {'row': 0, 'col': 2},
+                'inPenaltyZone': False,
+                'inHomeStretch': False,
+                'completed': False
+            }
+        ],
+        'teams': [[{'position': 0}], [{'position': 1}], [{'position': 2}], [{'position': 3}]]
+    }
+
+    new_state = {
+        'pieces': [
+            {
+                'id': 'p0_1',
+                'playerId': 0,
+                'position': {'row': 0, 'col': 8},
+                'inPenaltyZone': False,
+                'inHomeStretch': False,
+                'completed': False
+            }
+        ],
+        'teams': env.game_state['teams']
+    }
+
+    response = {
+        'success': True,
+        'gameState': new_state,
+        'gameEnded': False,
+        'winningTeam': None
+    }
+
+    idx_map = {(0, 2): 10, (0, 8): 20}
+    step_map = {(0, 2): 2, (0, 8): 70}
+
+    with patch.object(env, 'send_command', return_value=response):
+        with patch.object(env, 'is_action_valid', return_value=True):
+            with patch.object(env, 'get_state', return_value=np.zeros(env.state_size)):
+                with patch.object(env, '_track_index', side_effect=lambda pos: idx_map.get((pos['row'], pos['col']), -1)):
+                    with patch.object(env, '_steps_to_entrance', side_effect=lambda pos, pid: step_map.get((pos['row'], pos['col']), -1)):
+                        _, reward, _ = env.step(1, 0)
+
+    assert reward == pytest.approx(5.95)
+


### PR DESCRIPTION
## Summary
- refine GameEnvironment rewards to penalize skipping the home stretch entrance
- add regression test

## Testing
- `pip install -r game-ai-training/requirements.txt`
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685bf02f995c832a84d3a246789ed3a4