### PR TITLE
Reset bot stats for tournament

### DIFF
--- a/game-ai-training/ai/bot.py
+++ b/game-ai-training/ai/bot.py
@@ -149,10 +149,16 @@ class GameBot:
             'total_reward': self.total_reward,
         }, filepath)
 
-    def load_model(self, filepath: str) -> None:
+    def load_model(self, filepath: str, reset_stats: bool = False) -> None:
+        """Load model weights and optionally ignore stored statistics."""
         checkpoint = torch.load(filepath, map_location=self.device)
         self.model.load_state_dict(checkpoint['model_state_dict'])
         self.optimizer.load_state_dict(checkpoint['optimizer_state_dict'])
-        self.wins = checkpoint.get('wins', 0)
-        self.games_played = checkpoint.get('games_played', 0)
-        self.total_reward = checkpoint.get('total_reward', 0.0)
+        if reset_stats:
+            self.wins = 0
+            self.games_played = 0
+            self.total_reward = 0.0
+        else:
+            self.wins = checkpoint.get('wins', 0)
+            self.games_played = checkpoint.get('games_played', 0)
+            self.total_reward = checkpoint.get('total_reward', 0.0)

--- a/game-ai-training/tournament.py
+++ b/game-ai-training/tournament.py
@@ -53,7 +53,8 @@ def load_bots(env: GameEnvironment, dirs: List[str]) -> List[GameBot]:
         )
         model_path = os.path.join(MODEL_DIR, dname, f"bot_{seat}.pth")
         if os.path.exists(model_path):
-            bot.load_model(model_path)
+            # Ignore saved win/loss statistics so each run starts fresh
+            bot.load_model(model_path, reset_stats=True)
         else:
             print(f"Warning: {model_path} not found; using untrained bot")
         bots.append(bot)


### PR DESCRIPTION
## Summary
- allow clearing win statistics when loading models
- reset wins/games_played each time tournament bots load

## Testing
- `pip install -r game-ai-training/requirements.txt`
- `pytest game-ai-training/tests`

------
https://chatgpt.com/codex/tasks/task_e_685bf678879c832ab234d9f724699e70