### PR TITLE
Remove progress reward from training

### DIFF
--- a/game-ai-training/ai/environment.py
+++ b/game-ai-training/ai/environment.py
@@ -521,10 +521,6 @@ class GameEnvironment:
                     prev_idx = self._track_index(prev_info['pos'])
                     new_idx = self._track_index(pos)
                     if prev_idx != -1 and new_idx != -1:
-                        diff = (prev_idx - new_idx) % len(self._track)
-                        if diff > 0:
-                            reward += 0.1 * diff
-
                         # Penalize skipping the home entrance when it was
                         # possible to enter.
                         forward = (new_idx - prev_idx) % len(self._track)

--- a/game-ai-training/tests/test_environment.py
+++ b/game-ai-training/tests/test_environment.py
@@ -926,5 +926,5 @@ def test_penalty_for_skipping_home_entry():
                     with patch.object(env, '_steps_to_entrance', side_effect=lambda pos, pid: step_map.get((pos['row'], pos['col']), -1)):
                         _, reward, _ = env.step(1, 0)
 
-    assert reward == pytest.approx(5.95)
+    assert reward == pytest.approx(-0.25)
 


### PR DESCRIPTION
## Summary
- remove small bonus for moving along the track
- adjust tests for updated reward logic

## Testing
- `pip install -r game-ai-training/requirements.txt`
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685c31c35768832aaf269e503e57b436