### PR TITLE
Add reward logging and curriculum support

### DIFF
--- a/game-ai-training/README.md
+++ b/game-ai-training/README.md
@@ -35,6 +35,19 @@ specifies the desired KL divergence between policy updates. The trainer logs a
 warning if the measured KL divergence stays below half of this value for more
 than 100 update steps.
 
+### Reward Monitoring
+
+Training logs now include counts for several reward sources after each episode:
+
+- Home stretch entries
+- Penalty exits that capture an opponent
+- Captures
+- Game wins
+
+The entropy of this distribution is plotted to help detect reward starvation.
+You can adjust the extra incentive for these events over time using the
+`REWARD_SCHEDULE` variable in `config.py`.
+
 ## Match Logging
 
 Passing the `--save-match-log` flag to `main.py` writes the move history of

--- a/game-ai-training/config.py
+++ b/game-ai-training/config.py
@@ -30,3 +30,16 @@ LOG_DIR = 'logs'
 import os
 JSON_LOGGING = os.getenv('JSON_LOGGING', '0').lower() in ('1', 'true', 'yes')
 
+# Reward shaping
+# ``HEAVY_REWARD_BASE`` defines the default additional reward granted when a
+# high value play occurs such as entering the home stretch or leaving the
+# penalty zone with a capture. ``REWARD_SCHEDULE`` can override this value at
+# different points during training to implement a simple curriculum. Each tuple
+# in the list is ``(episode_start, heavy_reward)``.
+HEAVY_REWARD_BASE = 2.0
+# By default the weight remains constant. Users may extend this list in their
+# own config to increase or decrease the incentive over time.
+REWARD_SCHEDULE = [
+    (0, HEAVY_REWARD_BASE),
+]
+


### PR DESCRIPTION
## Summary
- track reward event frequencies in `GameEnvironment`
- compute reward source entropy and plot it
- configure adjustable reward schedule in `config`
- expose helper methods in `TrainingManager` and environment
- document reward monitoring features
- add tests for new functionality

## Testing
- `pip install -r game-ai-training/requirements.txt`
- `pytest -q game-ai-training/tests`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685c8c3cc64c832a82b3acad05b362c8