### PR TITLE
Handle legacy model format in training

### DIFF
--- a/game-ai-training/tests/test_bot.py
+++ b/game-ai-training/tests/test_bot.py
@@ -1,0 +1,22 @@
+import sys
+import pytest
+from unittest.mock import MagicMock
+
+
+def test_load_model_legacy_error(tmp_path):
+    torch_mock = MagicMock()
+    torch_mock.cuda.is_available.return_value = False
+    torch_mock.device = lambda *args, **kwargs: 'cpu'
+    torch_mock.load.return_value = {
+        'q_network_state_dict': {},
+        'optimizer_state_dict': {}
+    }
+    sys.modules['torch'] = torch_mock
+    sys.modules['torch.nn'] = MagicMock()
+    sys.modules['torch.optim'] = MagicMock()
+
+    from ai.bot import GameBot
+
+    bot = GameBot(player_id=0, state_size=1, action_size=1)
+    with pytest.raises(ValueError):
+        bot.load_model(str(tmp_path / 'legacy.pth'))

--- a/game-ai-training/tournament.py
+++ b/game-ai-training/tournament.py
@@ -83,7 +83,11 @@ def load_bots(env: GameEnvironment, dirs: List[str]) -> List[GameBot]:
         model_path = os.path.join(MODEL_DIR, dname, f"bot_{seat}.pth")
         if os.path.exists(model_path):
             # Ignore saved win/loss statistics so each run starts fresh
-            bot.load_model(model_path, reset_stats=True)
+            try:
+                bot.load_model(model_path, reset_stats=True)
+            except (KeyError, ValueError) as e:
+                print(f"Failed to load {model_path}: {e}")
+                print("Using untrained bot instead")
         else:
             print(f"Warning: {model_path} not found; using untrained bot")
         bots.append(bot)


### PR DESCRIPTION
## Summary
- raise a helpful error when loading checkpoints saved before the PPO switch
- gracefully continue tournament setup if a legacy model is selected
- add regression test for legacy model detection

## Testing
- `pip install -r game-ai-training/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d67c18288832ab48de384555a3b47