### PR TITLE
Enable DQN bots in tournaments

### DIFF
--- a/game-ai-training/tests/test_bot.py
+++ b/game-ai-training/tests/test_bot.py
@@ -20,3 +20,21 @@ def test_load_model_legacy_error(tmp_path):
     bot = GameBot(player_id=0, state_size=1, action_size=1)
     with pytest.raises(ValueError):
         bot.load_model(str(tmp_path / 'legacy.pth'))
+
+
+def test_dqn_bot_loads_legacy_checkpoint(tmp_path):
+    torch_mock = MagicMock()
+    torch_mock.cuda.is_available.return_value = False
+    torch_mock.device = lambda *args, **kwargs: 'cpu'
+    torch_mock.load.return_value = {
+        'q_network_state_dict': {},
+        'optimizer_state_dict': {},
+    }
+    sys.modules['torch'] = torch_mock
+    sys.modules['torch.nn'] = MagicMock()
+    sys.modules['torch.optim'] = MagicMock()
+
+    from ai.bot import DQNBot
+
+    bot = DQNBot(player_id=0, state_size=1, action_size=1)
+    bot.load_model(str(tmp_path / 'legacy.pth'))


### PR DESCRIPTION
## Summary
- support loading legacy DQN checkpoints via new `DQNBot`
- detect bot type when loading models in the tournament script
- keep teams fixed when shuffling and print clearer per-bot statistics
- test that DQNBot accepts legacy models

## Testing
- `pip install matplotlib numpy`
- `pytest -q game-ai-training/tests`

------
https://chatgpt.com/codex/tasks/task_e_685d6a46b8dc832aac18d0bd6217fccf