### PR TITLE
Update reward system rules

### DIFF
--- a/game-ai-training/config.py
+++ b/game-ai-training/config.py
@@ -36,7 +36,7 @@ JSON_LOGGING = os.getenv('JSON_LOGGING', '0').lower() in ('1', 'true', 'yes')
 # penalty zone with a capture. ``REWARD_SCHEDULE`` can override this value at
 # different points during training to implement a simple curriculum. Each tuple
 # in the list is ``(episode_start, heavy_reward)``.
-HEAVY_REWARD_BASE = 2.0
+HEAVY_REWARD_BASE = 6.0
 # By default the weight remains constant. Users may extend this list in their
 # own config to increase or decrease the incentive over time.
 REWARD_SCHEDULE = [

--- a/game-ai-training/tests/test_environment.py
+++ b/game-ai-training/tests/test_environment.py
@@ -946,5 +946,5 @@ def test_penalty_for_skipping_home_entry():
                     with patch.object(env, '_steps_to_entrance', side_effect=lambda pos, pid: step_map.get((pos['row'], pos['col']), -1)):
                         _, reward, _ = env.step(1, 0)
 
-    assert reward == pytest.approx(-0.25)
+    assert reward == pytest.approx(-0.55)
 


### PR DESCRIPTION
## Summary
- tune heavy reward base in config
- penalize skipping home stretch more heavily
- reward/penalize game results
- reward special 7 card split moves
- update unit test for new penalty value

## Testing
- `pip install -r game-ai-training/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e99f76b68832ab90de91ba14e20ee