### PR TITLE
Add heavy reward breakdown tracking

### DIFF
--- a/game-ai-training/README.md
+++ b/game-ai-training/README.md
@@ -48,6 +48,11 @@ The entropy of this distribution is plotted to help detect reward starvation.
 You can adjust the extra incentive for these events over time using the
 `REWARD_SCHEDULE` variable in `config.py`.
 
+Heavy reward events, such as entering the home stretch or capturing from the
+starting square, are tracked separately and overlaid on the reward breakdown
+plot. This helps confirm that bots are making the desired power moves during
+training.
+
 ## Match Logging
 
 Passing the `--save-match-log` flag to `main.py` writes the move history of


### PR DESCRIPTION
## Summary
- track heavy reward breakdown in `GameEnvironment`
- export heavy reward history from `TrainingManager`
- plot heavy reward overlays in the reward breakdown graph
- document heavy reward tracking in README

## Testing
- `pip install -r game-ai-training/requirements.txt` *(fails: torch download incomplete)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_685ecdabd098832aa21281b9818d0491