### PR TITLE
Lower capture rewards and improve bot compatibility

### DIFF
--- a/game-ai-training/ai/bot.py
+++ b/game-ai-training/ai/bot.py
@@ -8,12 +8,16 @@ import threading
 from config import TRAINING_CONFIG
 from json_logger import info
 
+# Fallback when torch.nn.Module is mocked during tests
+BASE_MODULE = nn.Module if isinstance(nn.Module, type) else object
 
-class ActorCritic(nn.Module):
+
+class ActorCritic(BASE_MODULE):
     """Simple actor-critic network used by PPO."""
 
     def __init__(self, state_size: int, action_size: int, hidden_size: int = 512):
-        super().__init__()
+        if hasattr(super(), '__init__'):
+            super().__init__()
         self.shared = nn.Sequential(
             nn.Linear(state_size, hidden_size),
             nn.ReLU(),
@@ -22,6 +26,21 @@ class ActorCritic(nn.Module):
         )
         self.policy_head = nn.Linear(hidden_size, action_size)
         self.value_head = nn.Linear(hidden_size, 1)
+
+    def to(self, device):
+        if hasattr(super(), 'to'):
+            return super().to(device)
+        return self
+
+    def parameters(self):
+        if hasattr(super(), 'parameters'):
+            return super().parameters()
+        return []
+
+    def load_state_dict(self, state_dict):
+        if hasattr(super(), 'load_state_dict'):
+            return super().load_state_dict(state_dict)
+        return None
 
     def forward(self, x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
         features = self.shared(x)
@@ -182,11 +201,12 @@ class GameBot:
             self.total_reward = checkpoint.get('total_reward', 0.0)
 
 
-class DQNNet(nn.Module):
+class DQNNet(BASE_MODULE):
     """Simple feed-forward network for DQN models."""
 
     def __init__(self, state_size: int, action_size: int, hidden_size: int = 512):
-        super().__init__()
+        if hasattr(super(), '__init__'):
+            super().__init__()
         self.layers = nn.Sequential(
             nn.Linear(state_size, hidden_size),
             nn.ReLU(),
@@ -194,6 +214,21 @@ class DQNNet(nn.Module):
             nn.ReLU(),
             nn.Linear(hidden_size, action_size),
         )
+
+    def to(self, device):
+        if hasattr(super(), 'to'):
+            return super().to(device)
+        return self
+
+    def parameters(self):
+        if hasattr(super(), 'parameters'):
+            return super().parameters()
+        return []
+
+    def load_state_dict(self, state_dict):
+        if hasattr(super(), 'load_state_dict'):
+            return super().load_state_dict(state_dict)
+        return None
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return self.layers(x)

--- a/game-ai-training/ai/environment.py
+++ b/game-ai-training/ai/environment.py
@@ -630,7 +630,7 @@ class GameEnvironment:
                 owner = info.get('player_id')
                 near = prev_near_home.get(cid, False)
                 if owner in my_team:
-                    reward += 0.5
+                    reward += 0.3
                     if info.get('pos') == self._starts[owner]:
                         reward += self.heavy_reward
                         self.heavy_reward_events += 1
@@ -644,7 +644,7 @@ class GameEnvironment:
                         self.heavy_reward_events += 2
                         self.heavy_reward_breakdown['capture'] += 2
                 else:
-                    reward += 0.5 if near else 0.2
+                    reward += 0.3 if near else 0.1
                 self.reward_event_counts['capture'] += 1
 
             if action >= 60:

--- a/game-ai-training/ai/trainer.py
+++ b/game-ai-training/ai/trainer.py
@@ -247,7 +247,7 @@ class TrainingManager:
         # Store raw reward source counts to allow plotting breakdowns later
         self.reward_breakdown_history.append(dict(env.reward_event_counts))
         self.heavy_reward_breakdown_history.append(
-            dict(env.heavy_reward_breakdown)
+            dict(getattr(env, 'heavy_reward_breakdown', {}))
         )
 
         return episode_rewards


### PR DESCRIPTION
## Summary
- decrease standard capture rewards in `GameEnvironment`
- handle mocked `torch.nn` by introducing `BASE_MODULE` and fallback methods
- avoid crashes when `heavy_reward_breakdown` is missing

## Testing
- `pip install -r game-ai-training/requirements.txt`
- `pytest game-ai-training/tests`

------
https://chatgpt.com/codex/tasks/task_e_685efad2950c832aa1d82d17318d0649