### PR TITLE
Adjust tournament logging and test compatibility

### DIFF
--- a/game-ai-training/ai/trainer.py
+++ b/game-ai-training/ai/trainer.py
@@ -246,9 +246,12 @@ class TrainingManager:
 
         # Store raw reward source counts to allow plotting breakdowns later
         self.reward_breakdown_history.append(dict(env.reward_event_counts))
-        self.heavy_reward_breakdown_history.append(
-            dict(env.heavy_reward_breakdown)
-        )
+        if hasattr(env, 'heavy_reward_breakdown'):
+            self.heavy_reward_breakdown_history.append(
+                dict(env.heavy_reward_breakdown)
+            )
+        else:
+            self.heavy_reward_breakdown_history.append({})
 
         return episode_rewards
     


### PR DESCRIPTION
## Summary
- support mocking in ActorCritic and DQNNet so tests work
- avoid AttributeErrors when environments omit heavy reward info
- trim tournament to 100 games and store logs for each win

## Testing
- `pip install -r game-ai-training/requirements.txt`
- `pytest game-ai-training/tests`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685efb26c67c832a9ec77d237327c8ac