### PR TITLE
Add tournament logging and reduce games

### DIFF
--- a/game-ai-training/README.md
+++ b/game-ai-training/README.md
@@ -114,6 +114,7 @@ Run it from the repository root:
 python3 game-ai-training/tournament.py
 ```
 
-Select the model directory for each team when prompted. The script plays 200
-games, prints the winner of each game, and updates win statistics every ten
-games.
+Select the model directory for each team when prompted. The script now plays
+100 games, prints the winner of each game, and updates win statistics every ten
+games. When a game ends with a winner, the full move history is saved in the
+`logs/` directory using the same JSON format as the training match logs.


### PR DESCRIPTION
## Summary
- drop tournament length from 200 to 100 games
- store logs for every game that has a winner using the same JSON format as training
- document the new behaviour in the tournament section of the README

## Testing
- `pip install -r game-ai-training/requirements.txt`
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685efe4ee574832aafeb5904018fcd03