### PR TITLE
Simplify rewards and adjust plotting

### DIFF
--- a/game-ai-training/README.md
+++ b/game-ai-training/README.md
@@ -39,19 +39,18 @@ than 100 update steps.
 
 Training logs now include counts for several reward sources after each episode:
 
-- Home stretch entries
-- Penalty exits that capture an opponent
-- Captures
+- Valid moves that don't enter the home stretch
+- Invalid moves
+- Team pieces entering the home stretch
+- Opponent pieces entering the home stretch
 - Game wins
 
 The entropy of this distribution is plotted to help detect reward starvation.
 You can adjust the extra incentive for these events over time using the
 `REWARD_SCHEDULE` variable in `config.py`.
 
-Heavy reward events, such as entering the home stretch or capturing from the
-starting square, are tracked separately and overlaid on the reward breakdown
-plot. This helps confirm that bots are making the desired power moves during
-training.
+Heavy reward tracking from earlier versions has been removed as the new reward
+scheme relies solely on these simpler events.
 
 ## Match Logging
 

--- a/game-ai-training/ai/trainer.py
+++ b/game-ai-training/ai/trainer.py
@@ -421,23 +421,18 @@ class TrainingManager:
                 for key, value in entry.items():
                     totals[key] = totals.get(key, 0) + value
             sorted_keys = sorted(totals, key=totals.get, reverse=True)
-            main_keys = sorted_keys[:4]
-            data = {k: [] for k in main_keys + ['other']}
+            main_keys = sorted_keys[:5]
+            data = {k: [] for k in main_keys}
             heavy_data = {k: [] for k in main_keys}
             for idx, entry in enumerate(self.reward_breakdown_history):
-                other_total = 0.0
                 heavy_entry = {}
                 if idx < len(self.heavy_reward_breakdown_history):
                     heavy_entry = self.heavy_reward_breakdown_history[idx]
                 for k in main_keys:
                     data[k].append(entry.get(k, 0.0))
                     heavy_data[k].append(heavy_entry.get(k, 0.0))
-                for k, v in entry.items():
-                    if k not in main_keys:
-                        other_total += v
-                data['other'].append(other_total)
-            stacks = [data[k] for k in main_keys + ['other']]
-            axs[1, 2].stackplot(episodes, stacks, labels=main_keys + ['other'])
+            stacks = [data[k] for k in main_keys]
+            axs[1, 2].stackplot(episodes, stacks, labels=main_keys)
             for k, values in heavy_data.items():
                 axs[1, 2].plot(episodes, values, linestyle='--', label=f'{k} heavy')
             axs[1, 2].set_title('Reward Breakdown by Type')


### PR DESCRIPTION
## Summary
- track new reward event types in `GameEnvironment`
- record invalid and valid moves during `step`
- display all reward categories in trainer plots
- update README reward monitoring section
- adjust tests for new reward counters

## Testing
- `pip install -r game-ai-training/requirements.txt`
- `pytest -q`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_686141fb6a64832a948105aecb5af9ac