### PR TITLE
Add missing penalty_exit tracking

### DIFF
--- a/game-ai-training/ai/environment.py
+++ b/game-ai-training/ai/environment.py
@@ -54,6 +54,8 @@ class GameEnvironment:
             'valid_move': 0,
             'invalid_move': 0,
             'home_entry': 0,
+            'penalty_exit': 0,
+            'capture': 0,
             'enemy_home_entry': 0,
             'game_win': 0,
         }


### PR DESCRIPTION
## Summary
- fix KeyError during training by adding `penalty_exit` and `capture` to `reward_event_counts`

## Testing
- `pip install -r game-ai-training/requirements.txt` *(fails: Torch download not available)*
- `pytest -q` *(fails: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686148b875d0832aad3681339fc2fa28