### PR TITLE
Adjust reward scaling and tracking

### DIFF
--- a/game-ai-training/tests/test_trainer.py
+++ b/game-ai-training/tests/test_trainer.py
@@ -17,6 +17,15 @@ class MockGameEnvironment:
             'capture': 0,
             'game_win': 0
         }
+        self.reward_event_totals = {
+            'home_entry': 0.0,
+            'penalty_exit': 0.0,
+            'capture': 0.0,
+            'game_win': 0.0,
+            'valid_move': 0.0,
+            'invalid_move': 0.0,
+            'enemy_home_entry': 0.0,
+        }
 
     def reset(self, bot_names=None):
         self.game_state = {'currentPlayerIndex': 0, 'gameEnded': False, 'winningTeam': None}


### PR DESCRIPTION
## Summary
- add custom rewards for home stretch entries
- log reward totals for every event
- penalize long episodes by step and length
- visualize episode lengths and stacked reward breakdown
- update training tests for new reward tracking

## Testing
- `pip install -r game-ai-training/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861d54e6b64832abcd4751b8ea395e5