### PR TITLE
Adjust reward decay and endgame bonuses

### DIFF
--- a/game-ai-training/ai/environment.py
+++ b/game-ai-training/ai/environment.py
@@ -411,8 +411,18 @@ class GameEnvironment:
             return True
         return bool(response.get("valid"))
     
-    def step(self, action: int, player_id: int) -> Tuple[np.ndarray, float, bool]:
-        """Execute action and return next_state, reward, done"""
+    def step(self, action: int, player_id: int, step_count: int = 0) -> Tuple[np.ndarray, float, bool]:
+        """Execute action and return next_state, reward, done
+
+        Parameters
+        ----------
+        action : int
+            The action index to perform.
+        player_id : int
+            ID of the player executing the action.
+        step_count : int, optional
+            Current step number of the episode (1-indexed). Defaults to ``0``.
+        """
         invalid_attempts = 0
         tried_actions = set()
 
@@ -567,11 +577,13 @@ class GameEnvironment:
         if done:
             winners = response.get('winningTeam') or []
             if any(pl.get('position') == player_id for pl in winners):
-                reward += 3000.0
+                bonus = 3000.0 + (1000 - step_count) * 2
+                reward += bonus
                 self.reward_event_counts['game_win'] += 1
-                self.reward_event_totals['game_win'] += 3000.0
+                self.reward_event_totals['game_win'] += bonus
             else:
-                reward -= 1000.0
+                penalty = 1000.0 + step_count
+                reward -= penalty
 
         # Log failures for easier debugging
         if not response.get('success'):

--- a/game-ai-training/ai/trainer.py
+++ b/game-ai-training/ai/trainer.py
@@ -184,10 +184,13 @@ class TrainingManager:
             action = current_bot.act(state, valid_actions)
             
             # Execute action
-            next_state, reward, done = env.step(action, current_player)
-
             step_num = step_count + 1
-            reward -= 0.02 * step_num
+            try:
+                next_state, reward, done = env.step(action, current_player, step_num)
+            except TypeError:
+                next_state, reward, done = env.step(action, current_player)
+
+            reward -= 0.02 * step_num * (1 + step_num / 500.0)
             decay = step_num // 200
             if decay > 0:
                 if reward > 0:


### PR DESCRIPTION
## Summary
- tweak per-step reward decay to scale with steps
- adjust end-of-game reward logic
- handle older environment implementations when calling `step`

## Testing
- `pip install -r game-ai-training/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68628242b754832aa4547c070f8e027f