### PR TITLE
Implement step penalty tweaks

### DIFF
--- a/game-ai-training/tests/test_environment.py
+++ b/game-ai-training/tests/test_environment.py
@@ -53,7 +53,7 @@ def test_step_updates_game_state_and_returns_rewards():
         with patch.object(env, 'is_action_valid', return_value=True):
             with patch.object(env, 'get_state', return_value=np.zeros(env.state_size)):
                 next_state, reward, done = env.step(1, 0)
-    assert reward == -0.1
+    assert reward == 0.0
     assert env.reward_event_counts['valid_move'] == 1
     assert env.reward_event_counts['invalid_move'] == 0
     assert done is False
@@ -876,7 +876,7 @@ def test_step_retries_until_success():
                 with patch.object(env, 'get_state', return_value=np.zeros(env.state_size)):
                     next_state, reward, done = env.step(1, 0)
 
-    assert reward == pytest.approx(-0.5)
+    assert reward == pytest.approx(-0.4)
     assert env.reward_event_counts['invalid_move'] == 2
     assert env.reward_event_counts['valid_move'] == 1
     assert mock_cmd.call_count == 3
@@ -934,7 +934,7 @@ def test_team_penalty_applied_after_interval():
             with patch.object(env, 'get_state', return_value=np.zeros(env.state_size)):
                 _, reward, _ = env.step(1, 2, step_count=62)
 
-    assert reward == pytest.approx(-50.1)
+    assert reward == pytest.approx(-52.1385, rel=1e-4)
     assert env.reward_event_counts['no_home_penalty'] == 1
 
 
@@ -960,7 +960,7 @@ def test_move_away_from_home_penalty():
             with patch.object(env, 'get_state', return_value=np.zeros(env.state_size)):
                 _, reward, _ = env.step(1, 0, step_count=1)
 
-    assert reward == pytest.approx(-50.1)
+    assert reward == pytest.approx(-50.01)
     assert env.reward_event_counts['avoid_home_penalty'] == 1
 
 


### PR DESCRIPTION
## Summary
- add `timeout` tracking for rewards
- apply stronger early home entry rewards and dynamic decay
- penalize teams with no home entry by step 150
- update tests for new reward logic

## Testing
- `pip install -r game-ai-training/requirements.txt`
- `pytest -q game-ai-training/tests`

------
https://chatgpt.com/codex/tasks/task_e_6862ee6cf934832ab3c12dffca745511