### PR TITLE
Restore reward system and dynamic penalties

### DIFF
--- a/game-ai-training/tests/test_trainer.py
+++ b/game-ai-training/tests/test_trainer.py
@@ -37,7 +37,7 @@ class MockGameEnvironment:
     def get_valid_actions(self, player_id):
         return [0]
 
-    def step(self, action, player_id):
+    def step(self, action, player_id, step_count=0):
         self.game_state = {
             'currentPlayerIndex': 0,
             'gameEnded': True,


### PR DESCRIPTION
## Summary
- revert environment to older reward logic and keep HOMESTRETCH reward scale
- apply per-turn decay using `0.01 * (step_count ** 1.3)` for moves not entering home
- scale win bonus to double the total home-entry rewards and penalize losses with half of that sum
- retain shorter training episodes capped at 350 steps

## Testing
- `pip install -r game-ai-training/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863c2dffde0832ab84abf50d50680ee