### PR TITLE
Adjust home stretch rewards and penalties

### DIFF
--- a/game-ai-training/ai/trainer.py
+++ b/game-ai-training/ai/trainer.py
@@ -155,7 +155,7 @@ class TrainingManager:
         actions = [None] * 4
         
         step_count = 0
-        max_steps = 350
+        max_steps = 550
         
         while step_count < max_steps:
             # Get current player from game state
@@ -211,7 +211,10 @@ class TrainingManager:
         
         # Update statistics
         for i, bot in enumerate(self.bots):
-            bot.total_reward += episode_rewards[i]
+            capped = episode_rewards[i]
+            if capped < -2000:
+                capped = -2000
+            bot.total_reward += capped
             bot.games_played += 1
         
         # Check for winners
@@ -227,7 +230,10 @@ class TrainingManager:
             info("Game summary", summary=summary)
 
         self.training_stats['games_played'] += 1
-        self.training_stats['episode_rewards'].append(sum(episode_rewards))
+        ep_total = sum(episode_rewards)
+        if ep_total < -2000:
+            ep_total = -2000
+        self.training_stats['episode_rewards'].append(ep_total)
         entropy = self._reward_entropy(env.reward_event_counts)
         self.training_stats['reward_entropies'].append(entropy)
         info(

--- a/game-ai-training/config.py
+++ b/game-ai-training/config.py
@@ -36,7 +36,7 @@ JSON_LOGGING = os.getenv('JSON_LOGGING', '0').lower() in ('1', 'true', 'yes')
 # penalty zone with a capture. ``REWARD_SCHEDULE`` can override this value at
 # different points during training to implement a simple curriculum. Each tuple
 # in the list is ``(episode_start, heavy_reward)``.
-HEAVY_REWARD_BASE = 6.0
+HEAVY_REWARD_BASE = 200.0
 # By default the weight remains constant. Users may extend this list in their
 # own config to increase or decrease the incentive over time.
 REWARD_SCHEDULE = [

--- a/game-ai-training/tests/test_environment.py
+++ b/game-ai-training/tests/test_environment.py
@@ -926,15 +926,15 @@ def test_team_penalty_applied_after_interval():
             with patch.object(env, 'get_state', return_value=np.zeros(env.state_size)):
                 env.step(1, 0, step_count=60)
 
-    assert env.pending_penalties[0] == -50.0
-    assert env.pending_penalties[2] == -50.0
+    assert env.pending_penalties[0] == -20.0
+    assert env.pending_penalties[2] == -20.0
 
     with patch.object(env, 'send_command', return_value=response):
         with patch.object(env, 'is_action_valid', return_value=True):
             with patch.object(env, 'get_state', return_value=np.zeros(env.state_size)):
                 _, reward, _ = env.step(1, 2, step_count=62)
 
-    assert reward == pytest.approx(-52.1385, rel=1e-4)
+    assert reward == pytest.approx(-20.9368, rel=1e-4)
     assert env.reward_event_counts['no_home_penalty'] == 1
 
 
@@ -960,7 +960,7 @@ def test_move_away_from_home_penalty():
             with patch.object(env, 'get_state', return_value=np.zeros(env.state_size)):
                 _, reward, _ = env.step(1, 0, step_count=1)
 
-    assert reward == pytest.approx(-50.01)
+    assert reward == pytest.approx(-20.01)
     assert env.reward_event_counts['avoid_home_penalty'] == 1
 
 


### PR DESCRIPTION
## Summary
- double reward table for pieces entering home stretch
- add home stretch coordinates and tracking helpers
- reward pieces for deeper home stretch entries and completions
- lower entrance skip and inactivity penalties
- tweak decay rate for valid moves
- bump heavy reward base value
- update tests for new penalty values
- show negative reward bars in breakdown plot
- add early home entry bonus and harsher late move penalty
- extend training episodes to 550 turns and clamp negative rewards

## Testing
- `pip install -r game-ai-training/requirements.txt`
- `pytest -q game-ai-training/tests`


------
https://chatgpt.com/codex/tasks/task_e_6863e9fb325c832aa647bf8b77410898