### PR TITLE
Fix reward breakdown sign

### DIFF
--- a/game-ai-training/ai/trainer.py
+++ b/game-ai-training/ai/trainer.py
@@ -245,8 +245,8 @@ class TrainingManager:
             entropy=f"{entropy:.3f}"
         )
 
-        # Store raw reward source counts to allow plotting breakdowns later
-        self.reward_breakdown_history.append(dict(env.reward_event_counts))
+        # Store per-episode reward totals to allow plotting breakdowns later
+        self.reward_breakdown_history.append(dict(env.reward_event_totals))
 
         return episode_rewards
     


### PR DESCRIPTION
## Summary
- record reward totals instead of counts for reward breakdown plot

## Testing
- `pip install -r game-ai-training/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863f2cba3a0832a94fc35d518d89333