### PR TITLE
Improve reward breakdown color scheme

### DIFF
--- a/game-ai-training/README.md
+++ b/game-ai-training/README.md
@@ -48,7 +48,8 @@ current simplified system:
 
 The entropy of the event counts is plotted to help detect reward starvation. A
 per‑episode breakdown subplot shows these positive and negative rewards over
-time. Heavy reward tracking from earlier versions has been removed.
+time using shades of blue for positive values and purple for negative values.
+Heavy reward tracking from earlier versions has been removed.
 
 ## Match Logging
 

--- a/game-ai-training/ai/trainer.py
+++ b/game-ai-training/ai/trainer.py
@@ -426,23 +426,37 @@ class TrainingManager:
 
             pos_bottom = np.zeros(len(episodes))
             neg_bottom = np.zeros(len(episodes))
-            colors = plt.cm.tab10.colors
+            num_keys = len(main_keys) + 1
+            pos_colors = plt.cm.Blues(np.linspace(0.4, 0.9, num_keys))
+            neg_colors = plt.cm.Purples(np.linspace(0.4, 0.9, num_keys))
             for idx, k in enumerate(main_keys + ['other']):
                 values = np.array(data[k])
                 pos_vals = np.where(values > 0, values, 0)
                 neg_vals = np.where(values < 0, values, 0)
-                color = colors[idx % len(colors)]
+                pos_color = pos_colors[idx]
+                neg_color = neg_colors[idx]
                 label_used = False
                 if np.any(pos_vals):
-                    axs[1, 2].bar(episodes, pos_vals, bottom=pos_bottom, color=color, label=k)
+                    axs[1, 2].bar(
+                        episodes,
+                        pos_vals,
+                        bottom=pos_bottom,
+                        color=pos_color,
+                        label=f"{k} (+)"
+                    )
                     pos_bottom += pos_vals
                     label_used = True
                 if np.any(neg_vals):
-                    axs[1, 2].bar(episodes, neg_vals, bottom=neg_bottom, color=color, label=k if not label_used else None)
+                    axs[1, 2].bar(
+                        episodes,
+                        neg_vals,
+                        bottom=neg_bottom,
+                        color=neg_color,
+                        label=f"{k} (-)" if not label_used else None
+                    )
                     neg_bottom += neg_vals
                 elif not label_used:
-                    # Ensure legend entry even when values are all zero
-                    axs[1, 2].bar([], [], color=color, label=k)
+                    axs[1, 2].bar([], [], color=pos_color, label=f"{k} (+)")
             axs[1, 2].axhline(0, color='black', linewidth=0.8)
             axs[1, 2].set_title('Reward Breakdown by Type')
             axs[1, 2].set_xlabel('Episode')


### PR DESCRIPTION
## Summary
- color code positive and negative reward bars differently
- document the new reward breakdown colors

## Testing
- `pip install -r game-ai-training/requirements.txt`
- `pytest game-ai-training/tests`

------
https://chatgpt.com/codex/tasks/task_e_68640277c740832ab1b894c4c58401ea