### PR TITLE
Improve reward balance and visuals

### DIFF
--- a/game-ai-training/README.md
+++ b/game-ai-training/README.md
@@ -42,9 +42,11 @@ current simplified system:
 
 - Valid moves that do not enter the home stretch (−0.1 each)
 - Invalid moves (−0.2 each)
-- Team pieces entering the home stretch (+10 each)
+- Team pieces entering the home stretch receive a bonus starting at +40 and
+  an extra +50 if the entry occurs within the first 50 turns.
 - Opponent pieces entering the home stretch (−5 each)
-- Game wins (+3000)
+- Game wins award a large bonus of roughly 13k points depending on how quickly
+  the match ends.
 
 The entropy of the event counts is plotted to help detect reward starvation. A
 per‑episode breakdown subplot shows the reward contribution of **every** event

--- a/game-ai-training/ai/environment.py
+++ b/game-ai-training/ai/environment.py
@@ -744,7 +744,7 @@ class GameEnvironment:
                         else:
                             home_reward_sum += base
                         if step_count < 50:
-                            home_reward_sum += 100.0
+                            home_reward_sum += 50.0
                     elif (
                         prev_info['in_home']
                         and p.get('inHomeStretch')
@@ -918,13 +918,13 @@ class GameEnvironment:
 
             winners = response.get('winningTeam') or []
             total_home = sum(HOME_ENTRY_REWARDS)
-            win_bonus = total_home * 2
+            win_bonus = total_home * 3
             loss_penalty = total_home / 2
             if winners:
                 if any(pl.get('position') == player_id for pl in winners):
                     reward += win_bonus
                     if step_count < 350:
-                        reward += max(0.0, 1000 - step_count * 2)
+                        reward += max(0.0, 1500 - step_count * 2)
                     self.reward_event_counts['game_win'] += 1
                     self.reward_event_totals['game_win'] += win_bonus
                 else:
@@ -938,9 +938,8 @@ class GameEnvironment:
         
         next_state = self.get_state(player_id)
 
-        # Scale positive rewards to increase their impact on training
-        if reward > 0:
-            reward *= 5
+        # Positive rewards are applied directly without additional scaling
+        # so that penalties remain meaningful relative to bonuses.
 
         return next_state, reward, done
     

--- a/game-ai-training/ai/trainer.py
+++ b/game-ai-training/ai/trainer.py
@@ -423,7 +423,9 @@ class TrainingManager:
             pos_bottom = np.zeros(len(episodes))
             neg_bottom = np.zeros(len(episodes))
 
-            colors = plt.cm.get_cmap('tab20')(np.linspace(0, 1, len(sorted_keys)))
+            palette = plt.cm.tab20.colors
+            color_map = {k: palette[i % len(palette)]
+                         for i, k in enumerate(sorted_keys)}
 
             for idx, k in enumerate(sorted_keys):
                 values = np.array(data[k])
@@ -436,7 +438,7 @@ class TrainingManager:
                         episodes,
                         pos_vals,
                         bottom=pos_bottom,
-                        color=colors[idx],
+                        color=color_map[k],
                         label=label,
                     )
                     label = None
@@ -446,13 +448,13 @@ class TrainingManager:
                         episodes,
                         neg_vals,
                         bottom=neg_bottom,
-                        color=colors[idx],
+                        color=color_map[k],
                         label=label,
                     )
                     label = None
                     neg_bottom += neg_vals
                 if label is not None:
-                    axs[1, 2].bar([], [], color=colors[idx], label=label)
+                    axs[1, 2].bar([], [], color=color_map[k], label=label)
 
             axs[1, 2].axhline(0, color='black', linewidth=0.8)
             axs[1, 2].set_title('Reward Breakdown by Type')

--- a/game-ai-training/config.py
+++ b/game-ai-training/config.py
@@ -36,10 +36,12 @@ JSON_LOGGING = os.getenv('JSON_LOGGING', '0').lower() in ('1', 'true', 'yes')
 # penalty zone with a capture. ``REWARD_SCHEDULE`` can override this value at
 # different points during training to implement a simple curriculum. Each tuple
 # in the list is ``(episode_start, heavy_reward)``.
-HEAVY_REWARD_BASE = 200.0
-# By default the weight remains constant. Users may extend this list in their
-# own config to increase or decrease the incentive over time.
+HEAVY_REWARD_BASE = 40.0
+# By default the heavy reward starts moderately high and decreases as training
+# progresses so bots focus more on winning games rather than individual moves.
 REWARD_SCHEDULE = [
     (0, HEAVY_REWARD_BASE),
+    (1000, HEAVY_REWARD_BASE * 0.75),
+    (3000, HEAVY_REWARD_BASE * 0.5),
 ]
 

--- a/game-ai-training/tests/test_environment.py
+++ b/game-ai-training/tests/test_environment.py
@@ -934,7 +934,7 @@ def test_team_penalty_applied_after_interval():
             with patch.object(env, 'get_state', return_value=np.zeros(env.state_size)):
                 _, reward, _ = env.step(1, 2, step_count=62)
 
-    assert reward == pytest.approx(-20.9368, rel=1e-4)
+    assert reward == pytest.approx(-20.7077, rel=1e-4)
     assert env.reward_event_counts['no_home_penalty'] == 1
 
 
@@ -960,7 +960,7 @@ def test_move_away_from_home_penalty():
             with patch.object(env, 'get_state', return_value=np.zeros(env.state_size)):
                 _, reward, _ = env.step(1, 0, step_count=1)
 
-    assert reward == pytest.approx(-20.01)
+    assert reward == pytest.approx(-20.005)
     assert env.reward_event_counts['avoid_home_penalty'] == 1
 
 


### PR DESCRIPTION
## Summary
- scale down heavy reward bonus and add a decreasing schedule
- remove reward multiplier and reduce early home entry bonus
- boost win bonus logic
- use distinct colors for reward breakdown plot
- adjust docs and tests for new reward values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68642eb13bd0832a9a370ccd9cfa26b5