### PR TITLE
Update reward system and training config

### DIFF
--- a/game-ai-training/ai/trainer.py
+++ b/game-ai-training/ai/trainer.py
@@ -423,9 +423,15 @@ class TrainingManager:
             pos_bottom = np.zeros(len(episodes))
             neg_bottom = np.zeros(len(episodes))
 
-            palette = plt.cm.tab20.colors
-            color_map = {k: palette[i % len(palette)]
-                         for i, k in enumerate(sorted_keys)}
+            custom_colors = [
+                '#1f77b4', '#ff7f0e', '#2ca02c', '#d62728',
+                '#9467bd', '#8c564b', '#e377c2', '#7f7f7f',
+                '#bcbd22', '#17becf'
+            ]
+            color_map = {
+                k: custom_colors[i % len(custom_colors)]
+                for i, k in enumerate(sorted_keys)
+            }
 
             for idx, k in enumerate(sorted_keys):
                 values = np.array(data[k])

--- a/game-ai-training/config.py
+++ b/game-ai-training/config.py
@@ -3,15 +3,15 @@ TRAINING_CONFIG = {
     'num_episodes': 5000,
     'save_frequency': 500,
     'stats_frequency': 10,
-    'learning_rate': 0.001,
+    'learning_rate': 2.5e-5,
     'batch_size': 32,
     'memory_size': 10000,
     'gamma': 0.95,
     'hidden_size': 512,
     'train_freq': 4,
-    'ppo_clip': 0.2,
-    # Encourage exploration slightly more by increasing the entropy term.
-    'entropy_weight': 0.02,
+    'ppo_clip': 0.1,
+    # Slight entropy bonus to maintain exploration without destabilising updates.
+    'entropy_weight': 0.005,
     # Target KL divergence used for monitoring training stability.
     'kl_target': 0.02,
     # How often the bot's target network should be updated.
@@ -36,9 +36,8 @@ JSON_LOGGING = os.getenv('JSON_LOGGING', '0').lower() in ('1', 'true', 'yes')
 # penalty zone with a capture. ``REWARD_SCHEDULE`` can override this value at
 # different points during training to implement a simple curriculum. Each tuple
 # in the list is ``(episode_start, heavy_reward)``.
-HEAVY_REWARD_BASE = 40.0
-# By default the heavy reward starts moderately high and decreases as training
-# progresses so bots focus more on winning games rather than individual moves.
+HEAVY_REWARD_BASE = 200.0
+# The heavy reward decreases over time so early training emphasises key moves
 REWARD_SCHEDULE = [
     (0, HEAVY_REWARD_BASE),
     (1000, HEAVY_REWARD_BASE * 0.75),


### PR DESCRIPTION
## Summary
- tweak PPO training parameters for stability
- reduce dense reward magnitudes and adjust heavy reward schedule
- overhaul win bonuses and team completion rewards
- refine negative reward when moving away from entrance
- brighten reward breakdown colors
- add step logging for reward summaries

## Testing
- `pip install -r game-ai-training/requirements.txt`
- `pytest -q game-ai-training/tests`

------
https://chatgpt.com/codex/tasks/task_e_68643be42d50832a8a996d0ffc70202c