### PR TITLE
log summary once per game

### DIFF
--- a/game-ai-training/ai/environment.py
+++ b/game-ai-training/ai/environment.py
@@ -952,12 +952,13 @@ class GameEnvironment:
             key=lambda x: abs(x[1]),
             reverse=True
         )[:3]
-        info(
-            "Step summary",
-            reward=f"{reward:.2f}",
-            done=done,
-            top_sources={k: round(v, 2) for k, v in top_sources}
-        )
+        if done:
+            info(
+                "Step summary",
+                reward=f"{reward:.2f}",
+                done=done,
+                top_sources={k: round(v, 2) for k, v in top_sources}
+            )
 
         # Positive rewards are applied directly without additional scaling
         # so that penalties remain meaningful relative to bonuses.


### PR DESCRIPTION
## Summary
- log the step summary only when a game ends

## Testing
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68644080e074832a9efc9184df952cb1