### PR TITLE
Add custom reward breakdown colors

### DIFF
--- a/game-ai-training/README.md
+++ b/game-ai-training/README.md
@@ -45,7 +45,7 @@ current simplified system:
 - Team pieces entering the home stretch receive a bonus starting at +40 and
   an extra +50 if the entry occurs within the first 50 turns.
 - Opponent pieces entering the home stretch (−5 each)
-- Game wins award a large bonus of roughly 13k points depending on how quickly
+- Game wins award a large bonus of roughly 20k points depending on how quickly
   the match ends.
 
 The entropy of the event counts is plotted to help detect reward starvation. A

--- a/game-ai-training/ai/environment.py
+++ b/game-ai-training/ai/environment.py
@@ -14,7 +14,7 @@ from config import HEAVY_REWARD_BASE
 # Normalised reward weights used throughout the environment
 INVALID_MOVE_PENALTY = -0.1
 COMPLETION_BONUS = 300.0
-WIN_BONUS = 500.0
+WIN_BONUS = 20000.0
 
 # Reward scale for the nth piece entering the home stretch for a team
 # Normalized to keep dense rewards smaller
@@ -905,9 +905,9 @@ class GameEnvironment:
                 before = prev['dist']
                 after = self._steps_to_entrance(new.get('position'), player_id)
                 if 0 < before <= 3 and (after == -1 or after > before):
-                    reward -= 20.0
+                    reward -= 60.0
                     self.reward_event_counts['avoid_home_penalty'] += 1
-                    self.reward_event_totals['avoid_home_penalty'] += -20.0
+                    self.reward_event_totals['avoid_home_penalty'] += -60.0
                     break
 
             # Apply team-level penalty every 60 turns if no piece reached home
@@ -922,7 +922,7 @@ class GameEnvironment:
                     if not home_present:
                         for pid in team_players:
                             if pid is not None and 0 <= pid < len(self.pending_penalties):
-                                self.pending_penalties[pid] -= 20.0
+                                self.pending_penalties[pid] -= 60.0
                 self.next_penalty_check += 60
 
 

--- a/game-ai-training/ai/trainer.py
+++ b/game-ai-training/ai/trainer.py
@@ -491,10 +491,23 @@ class TrainingManager:
                 '#9467bd', '#8c564b', '#e377c2', '#7f7f7f',
                 '#bcbd22', '#17becf'
             ]
-            color_map = {
-                k: custom_colors[i % len(custom_colors)]
-                for i, k in enumerate(sorted_keys)
+
+            predefined_colors = {
+                'home_entry': 'red',
+                'penalty_exit': 'blue',
+                'capture': 'green',
+                'game_win': 'purple',
+                'completion': 'yellow',
             }
+
+            color_map = {}
+            color_index = 0
+            for k in sorted_keys:
+                if k in predefined_colors:
+                    color_map[k] = predefined_colors[k]
+                else:
+                    color_map[k] = custom_colors[color_index % len(custom_colors)]
+                    color_index += 1
 
             for idx, k in enumerate(sorted_keys):
                 values = np.array(data[k])

--- a/game-ai-training/tests/test_environment.py
+++ b/game-ai-training/tests/test_environment.py
@@ -926,15 +926,15 @@ def test_team_penalty_applied_after_interval():
             with patch.object(env, 'get_state', return_value=np.zeros(env.state_size)):
                 env.step(1, 0, step_count=60)
 
-    assert env.pending_penalties[0] == -20.0
-    assert env.pending_penalties[2] == -20.0
+    assert env.pending_penalties[0] == -60.0
+    assert env.pending_penalties[2] == -60.0
 
     with patch.object(env, 'send_command', return_value=response):
         with patch.object(env, 'is_action_valid', return_value=True):
             with patch.object(env, 'get_state', return_value=np.zeros(env.state_size)):
                 _, reward, _ = env.step(1, 2, step_count=62)
 
-    assert reward == pytest.approx(-20.7077, rel=1e-4)
+    assert reward == pytest.approx(-60.7077, rel=1e-4)
     assert env.reward_event_counts['no_home_penalty'] == 1
 
 
@@ -960,7 +960,7 @@ def test_move_away_from_home_penalty():
             with patch.object(env, 'get_state', return_value=np.zeros(env.state_size)):
                 _, reward, _ = env.step(1, 0, step_count=1)
 
-    assert reward == pytest.approx(-20.005)
+    assert reward == pytest.approx(-60.005)
     assert env.reward_event_counts['avoid_home_penalty'] == 1
 
 


### PR DESCRIPTION
## Summary
- add mapping of specific rewards to custom colors in TrainingManager
- bump win bonus to 20k
- triple penalty for missing the home stretch and adjust tests

## Testing
- `pytest -q game-ai-training/tests`

------
https://chatgpt.com/codex/tasks/task_e_68645a199580832aba1d391adfc23f5b