### PR TITLE
Refine home stretch rewards and penalties

### DIFF
--- a/game-ai-training/tests/test_environment.py
+++ b/game-ai-training/tests/test_environment.py
@@ -934,7 +934,7 @@ def test_team_penalty_applied_after_interval():
             with patch.object(env, 'get_state', return_value=np.zeros(env.state_size)):
                 _, reward, _ = env.step(1, 2, step_count=62)
 
-    assert reward == pytest.approx(-60.7077, rel=1e-4)
+    assert reward == pytest.approx(-61.46978, rel=1e-4)
     assert env.reward_event_counts['no_home_penalty'] == 1
 
 
@@ -960,7 +960,7 @@ def test_move_away_from_home_penalty():
             with patch.object(env, 'get_state', return_value=np.zeros(env.state_size)):
                 _, reward, _ = env.step(1, 0, step_count=1)
 
-    assert reward == pytest.approx(-60.005)
+    assert reward == pytest.approx(-60.015)
     assert env.reward_event_counts['avoid_home_penalty'] == 1
 
 


### PR DESCRIPTION
## Summary
- adjust the HOME_ENTRY_REWARDS scale for bigger gaps
- give small reward on home entry and large one on completion
- track progress actions and penalise non-progress moves
- update tests for new reward calculations

## Testing
- `pip install -r game-ai-training/requirements.txt`
- `pytest -q game-ai-training/tests`

------
https://chatgpt.com/codex/tasks/task_e_6864736d5080832aa6acb84d964a7fc6