### PR TITLE
Tune completion delay

### DIFF
--- a/game-ai-training/ai/environment.py
+++ b/game-ai-training/ai/environment.py
@@ -27,7 +27,8 @@ HOME_ENTRY_REWARDS = [
 # Starts at ``COMPLETION_DELAY_BASE`` and is multiplied by
 # ``COMPLETION_DELAY_GROWTH`` every subsequent turn until reset.
 COMPLETION_DELAY_BASE = -2.0
-COMPLETION_DELAY_GROWTH = 1.08
+# Slower exponential rate so penalties do not dominate long games
+COMPLETION_DELAY_GROWTH = 1.02
 
 
 class GameEnvironment:

--- a/game-ai-training/tests/test_environment.py
+++ b/game-ai-training/tests/test_environment.py
@@ -934,7 +934,8 @@ def test_team_penalty_applied_after_interval():
             with patch.object(env, 'get_state', return_value=np.zeros(env.state_size)):
                 _, reward, _ = env.step(1, 2, step_count=62)
 
-    assert reward == pytest.approx(-63.62978, rel=1e-4)
+    # Updated expected value after reducing the completion delay growth rate
+    assert reward == pytest.approx(-63.50978, rel=1e-4)
     assert env.reward_event_counts['no_home_penalty'] == 1
 
 


### PR DESCRIPTION
## Summary
- slow down the exponential penalty growth so it doesn't dwarf rewards
- adjust unit tests for the updated rate

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68648c6ab35c832a81055539ff444737