### PR TITLE
Tune completion decay and positive reward scaling

### DIFF
--- a/game-ai-training/ai/environment.py
+++ b/game-ai-training/ai/environment.py
@@ -27,8 +27,11 @@ HOME_ENTRY_REWARDS = [
 # Starts at ``COMPLETION_DELAY_BASE`` and is multiplied by
 # ``COMPLETION_DELAY_GROWTH`` every subsequent turn until reset.
 COMPLETION_DELAY_BASE = -2.0
-# Slower exponential rate so penalties do not dominate long games
-COMPLETION_DELAY_GROWTH = 1.02
+# Further slow exponential rate so penalties do not dominate long games
+COMPLETION_DELAY_GROWTH = 1.01
+# Apply the same decay logic to positive rewards using the
+# ``POSITIVE_REWARD_DECAY`` factor.
+POSITIVE_REWARD_DECAY = 1.01
 
 
 class GameEnvironment:
@@ -1010,8 +1013,9 @@ class GameEnvironment:
                 top_sources={k: round(v, 2) for k, v in top_sources}
             )
 
-        # Positive rewards are applied directly without additional scaling
-        # so that penalties remain meaningful relative to bonuses.
+        # Scale down positive rewards as completion is delayed.
+        if reward > 0 and 0 <= team_idx < len(self.completion_delay_turns):
+            reward /= POSITIVE_REWARD_DECAY ** self.completion_delay_turns[team_idx]
 
         return next_state, reward, done
     

--- a/game-ai-training/tests/test_environment.py
+++ b/game-ai-training/tests/test_environment.py
@@ -934,8 +934,9 @@ def test_team_penalty_applied_after_interval():
             with patch.object(env, 'get_state', return_value=np.zeros(env.state_size)):
                 _, reward, _ = env.step(1, 2, step_count=62)
 
-    # Updated expected value after reducing the completion delay growth rate
-    assert reward == pytest.approx(-63.50978, rel=1e-4)
+    # Updated expected value after further slowing the delay growth rate and
+    # scaling positive rewards
+    assert reward == pytest.approx(-63.48978, rel=1e-4)
     assert env.reward_event_counts['no_home_penalty'] == 1
 
 


### PR DESCRIPTION
## Summary
- slow down completion delay penalty growth further
- reduce positive rewards using the same decay logic
- update environment tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686491c2c688832ab0c66535eac9e7a7