### PR TITLE
Boost win reward and PPO advantage

### DIFF
--- a/game-ai-training/ai/bot.py
+++ b/game-ai-training/ai/bot.py
@@ -115,16 +115,26 @@ class GameBot:
         self.last_value = value.squeeze(0)
         return int(action.item())
 
-    def remember(self, state, action, reward, next_state, done):
+    def remember(self, state, action, reward, next_state, done, game_won=False):
+        """Store a transition in memory."""
         self.memory.append(
-            (state, action, reward, done, self.last_log_prob, self.last_value, self.last_entropy)
+            (
+                state,
+                action,
+                reward,
+                done,
+                self.last_log_prob,
+                self.last_value,
+                self.last_entropy,
+                game_won,
+            )
         )
 
     def replay(self):
         if len(self.memory) < self.batch_size:
             return None
 
-        states, actions, rewards, dones, log_probs, values, entropies = zip(*self.memory)
+        states, actions, rewards, dones, log_probs, values, entropies, game_wons = zip(*self.memory)
         self.memory = []
 
         states_t = torch.FloatTensor(np.array(states)).to(self.device)
@@ -132,6 +142,7 @@ class GameBot:
         rewards_t = torch.FloatTensor(rewards).to(self.device)
         dones_t = torch.FloatTensor(dones).to(self.device)
         entropies_t = torch.FloatTensor(entropies).to(self.device)
+        game_wons_t = torch.FloatTensor(game_wons).to(self.device)
         old_log_probs_t = torch.stack(log_probs).to(self.device)
         values_t = torch.stack(values).to(self.device)
 
@@ -144,6 +155,8 @@ class GameBot:
             returns.insert(0, R)
         returns_t = torch.FloatTensor(returns).to(self.device)
         advantages = returns_t - values_t.detach()
+        # Encourage learning from successful episodes
+        advantages += dones_t * game_wons_t * 10000.0
 
         logits, new_values = self.model(states_t)
         logit_mask = torch.full_like(logits, float('-inf'))

--- a/game-ai-training/ai/environment.py
+++ b/game-ai-training/ai/environment.py
@@ -13,8 +13,8 @@ from config import HEAVY_REWARD_BASE
 
 # Normalised reward weights used throughout the environment
 INVALID_MOVE_PENALTY = -0.1
-COMPLETION_BONUS = 300.0
-WIN_BONUS = 20000.0
+COMPLETION_BONUS = 1000.0
+WIN_BONUS = 100000.0
 
 # Reward scale for the nth piece entering the home stretch for a team
 # Normalized to keep dense rewards smaller
@@ -1014,7 +1014,11 @@ class GameEnvironment:
             )
 
         # Scale down positive rewards as completion is delayed.
-        if reward > 0 and 0 <= team_idx < len(self.completion_delay_turns):
+        if (
+            reward > 0
+            and reward < 1000.0
+            and 0 <= team_idx < len(self.completion_delay_turns)
+        ):
             reward /= POSITIVE_REWARD_DECAY ** self.completion_delay_turns[team_idx]
 
         return next_state, reward, done

--- a/game-ai-training/ai/trainer.py
+++ b/game-ai-training/ai/trainer.py
@@ -215,6 +215,12 @@ class TrainingManager:
             
             # Execute action
             next_state, reward, done = env.step(action, current_player, step_count)
+            game_won = False
+            if done:
+                winners = env.game_state.get('winningTeam') or []
+                game_won = any(
+                    pl.get('position') == current_player for pl in winners
+                )
             reward += 0.01 * getattr(current_bot, 'last_entropy', 0.0)
             norm_reward = self._normalize_reward(reward)
             
@@ -225,7 +231,8 @@ class TrainingManager:
                     actions[current_player],
                     norm_reward,
                     next_state,
-                    done
+                    done,
+                    game_won,
                 )
             
             # Update tracking


### PR DESCRIPTION
## Summary
- make wins more lucrative by boosting constants
- keep rare events from decaying away
- store game_won state in memory so PPO can focus on winning episodes

## Testing
- `pip install -r game-ai-training/requirements.txt` *(fails: nvidia packages)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68649ad07584832aa606a2c8fe35f32c