### PR TITLE
Track completion stats and adjust decay

### DIFF
--- a/game-ai-training/README.md
+++ b/game-ai-training/README.md
@@ -50,6 +50,12 @@ current simplified system:
 - Episodes that end due to the 550 step limit apply a timeout penalty of
   −50k to every bot.
 
+Completion delay penalties now shrink as a team finishes more pieces, so
+early progress reduces the negative reward for later turns. The trainer also
+records how many pieces each bot has in the home stretch and how many are
+fully completed after every episode. These metrics appear in the training
+progress plots.
+
 The entropy of the event counts is plotted to help detect reward starvation. A
 per‑episode breakdown subplot shows the reward contribution of **every** event
 type. Positive values stack upward while negative values stack below zero. Each

--- a/game-ai-training/ai/environment.py
+++ b/game-ai-training/ai/environment.py
@@ -585,6 +585,11 @@ class GameEnvironment:
                 COMPLETION_DELAY_BASE
                 * (self.completion_delay_growth[team_idx] ** self.completion_delay_turns[team_idx])
             )
+            completed_so_far = 0
+            if 0 <= team_idx < len(prev_completed):
+                completed_so_far = prev_completed[team_idx]
+            fraction = min(completed_so_far / 10.0, 1.0)
+            decay *= max(0.0, 1.0 - fraction)
 
         skip_decay = False
         extra_delay = 0


### PR DESCRIPTION
## Summary
- scale completion delay penalty based on pieces finished
- store completed and homestretch counts per episode
- plot completed pieces per bot instead of PPO metrics
- document the new stats in the training README

## Testing
- `pip install -r game-ai-training/requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6865450d2aa8832aa51d69272fa94aa4