### PR TITLE
Improve PPO training stability with snapshot opponents

### DIFF
--- a/game-ai-training/tests/test_trainer.py
+++ b/game-ai-training/tests/test_trainer.py
@@ -26,6 +26,10 @@ class MockGameEnvironment:
             'invalid_move': 0.0,
             'enemy_home_entry': 0.0,
         }
+        self.reward_bonus_totals = {
+            'win_bonus': 0.0,
+            'final_move_bonus': 0.0,
+        }
 
     def reset(self, bot_names=None):
         self.game_state = {'currentPlayerIndex': 0, 'gameEnded': False, 'winningTeam': None}


### PR DESCRIPTION
## Summary
- track reward bonuses separately in `GameEnvironment`
- penalize stagnation after two pieces are complete
- add `was_final` flag when a step ends the match
- decouple win bonuses from rewards in `Trainer`
- rotate training focus and reseed periodically
- freeze best bot snapshots and use them as opponents
- update tests for new environment fields

## Testing
- `pip install -r game-ai-training/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865712c4c30832a9db2b1c301579b81