### PR TITLE
Tune reward weights

### DIFF
--- a/game-ai-training/ai/environment.py
+++ b/game-ai-training/ai/environment.py
@@ -12,34 +12,34 @@ from json_logger import info, error, warning
 from config import HEAVY_REWARD_BASE
 
 # Normalised reward weights used throughout the environment
-INVALID_MOVE_PENALTY = -0.1
-COMPLETION_BONUS = 200.0
+INVALID_MOVE_PENALTY = -0.05
+COMPLETION_BONUS = 300.0
 WIN_BONUS = 100000.0
 # Large penalty applied when the episode ends without a winner
-TIMEOUT_PENALTY = -WIN_BONUS / 2
+TIMEOUT_PENALTY = -WIN_BONUS / 4
 
 # Reward scale for the nth piece entering the home stretch for a team
 # Normalized to keep dense rewards smaller
 HOME_ENTRY_REWARDS = [
-    20, 60, 120, 200, 300,
-    420, 560, 720, 900, 1100
+    40, 120, 240, 400, 600,
+    840, 1120, 1440, 1800, 2200
 ]
 
 # Penalty applied each turn a team goes without completing a piece.
 # Starts at ``COMPLETION_DELAY_BASE`` and is multiplied by
 # ``COMPLETION_DELAY_GROWTH`` every subsequent turn until reset.
-COMPLETION_DELAY_BASE = -4.0
-# Increase growth so penalties escalate faster in long games
-COMPLETION_DELAY_GROWTH = 1.05
+COMPLETION_DELAY_BASE = -1.0
+# Slower growth prevents runaway negative rewards
+COMPLETION_DELAY_GROWTH = 1.02
 # Apply the same decay logic to positive rewards using the
 # ``POSITIVE_REWARD_DECAY`` factor.
 POSITIVE_REWARD_DECAY = 1.01
 
 # Additional sparse reward bonuses and penalties
 FINAL_MOVE_BONUS = 2000.0
-STAGNATION_PENALTY = -20.0
+STAGNATION_PENALTY = -10.0
 # Additional penalty when two pieces are complete but progress stalls
-LATE_STAGNATION_PENALTY = -50.0
+LATE_STAGNATION_PENALTY = -25.0
 
 
 class GameEnvironment:

--- a/game-ai-training/tests/test_environment.py
+++ b/game-ai-training/tests/test_environment.py
@@ -53,7 +53,7 @@ def test_step_updates_game_state_and_returns_rewards():
         with patch.object(env, 'is_action_valid', return_value=True):
             with patch.object(env, 'get_state', return_value=np.zeros(env.state_size)):
                 next_state, reward, done = env.step(1, 0)
-    assert reward == -4.0
+    assert reward == -1.0
     assert env.reward_event_counts['valid_move'] == 1
     assert env.reward_event_counts['invalid_move'] == 0
     assert done is False
@@ -74,7 +74,7 @@ def test_step_updates_state_on_failure():
             with patch.object(env, 'get_state', return_value=np.zeros(env.state_size)):
                 next_state, reward, done = env.step(1, 0)
 
-    assert reward == -5.1
+    assert reward == -1.55
     assert env.reward_event_counts['invalid_move'] == 11
     assert env.reward_event_counts['valid_move'] == 0
     assert done is False
@@ -876,7 +876,7 @@ def test_step_retries_until_success():
                 with patch.object(env, 'get_state', return_value=np.zeros(env.state_size)):
                     next_state, reward, done = env.step(1, 0)
 
-    assert reward == pytest.approx(-4.2)
+    assert reward == pytest.approx(-1.1)
     assert env.reward_event_counts['invalid_move'] == 2
     assert env.reward_event_counts['valid_move'] == 1
     assert mock_cmd.call_count == 3
@@ -936,7 +936,7 @@ def test_team_penalty_applied_after_interval():
 
     # Updated expected value after further slowing the delay growth rate and
     # scaling positive rewards
-    assert reward == pytest.approx(-65.46978, rel=1e-4)
+    assert reward == pytest.approx(-62.469784, rel=1e-4)
     assert env.reward_event_counts['no_home_penalty'] == 1
 
 


### PR DESCRIPTION
## Summary
- adjust reward constants for more balanced training
- update failing reward assertions in tests

## Testing
- `pip install -r game-ai-training/requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686596c62d74832aa0e7f14feba110b3