### PR TITLE
Add reward summary logs

### DIFF
--- a/game-ai-training/README.md
+++ b/game-ai-training/README.md
@@ -65,6 +65,10 @@ reward type uses a distinct color from Matplotlib's `tab20` palette so negative
 events are no longer lumped into a single “other” category.
 Heavy reward tracking from earlier versions has been removed.
 
+Every 100 episodes the trainer now logs the cumulative reward totals for each
+event type. These summaries are useful when sharing progress logs for further
+analysis.
+
 ## Match Logging
 
 Passing the `--save-match-log` flag to `main.py` writes the move history of


### PR DESCRIPTION
## Summary
- log cumulative reward totals every 100 episodes
- document reward summary logging in README

## Testing
- `pip install -r game-ai-training/requirements.txt` *(failed to complete due to environment limits)*
- `pytest -q game-ai-training/tests` *(failed: ModuleNotFoundError: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_e_6865b945306c832aba5ae876b8f26617