### PR TITLE
Remove win bonus decay

### DIFF
--- a/game-ai-training/ai/environment.py
+++ b/game-ai-training/ai/environment.py
@@ -113,7 +113,7 @@ class GameEnvironment:
 
         # Adjustable reward weight for important plays
         self.heavy_reward = HEAVY_REWARD_BASE
-        # Configurable win bonus that may decay over training
+        # Configurable win bonus applied when a team wins
         self.win_bonus = WIN_BONUS
 
         # Track how often each reward type occurs for analysis

--- a/game-ai-training/ai/trainer.py
+++ b/game-ai-training/ai/trainer.py
@@ -244,9 +244,6 @@ class TrainingManager:
             current_player = env.game_state.get('currentPlayerIndex', 0)
             current_bot = self.bots[current_player]
 
-            current_win_bonus = WIN_BONUS * (0.99 ** (self.total_training_steps // 1000))
-            if hasattr(env, "set_win_bonus"):
-                env.set_win_bonus(current_win_bonus)
 
             # Get current state and valid actions
             state = env.get_state(current_player)


### PR DESCRIPTION
## Summary
- keep win bonus constant instead of decaying during training
- update comment in the environment

## Testing
- `pip install -r game-ai-training/requirements.txt`
- `pytest -q game-ai-training/tests`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6865b9e15d8c832aa8be0abc2dbb17b4