### PR TITLE
Adjust reward and timeout tuning

### DIFF
--- a/game-ai-training/README.md
+++ b/game-ai-training/README.md
@@ -48,7 +48,7 @@ current simplified system:
 - Game wins award a large bonus of around 100k points depending on how quickly
   the match ends.
 - Episodes that end due to the 550 step limit apply a timeout penalty of
-  −50k to every bot.
+  roughly −8k per bot so the total deduction stays near −30k.
 
 Completion delay penalties now shrink as a team finishes more pieces, so
 early progress reduces the negative reward for later turns. The trainer also

--- a/game-ai-training/ai/environment.py
+++ b/game-ai-training/ai/environment.py
@@ -14,8 +14,9 @@ from config import HEAVY_REWARD_BASE
 # Normalised reward weights used throughout the environment
 INVALID_MOVE_PENALTY = -0.05
 WIN_BONUS = 100000.0
-# Large penalty applied when the episode ends without a winner
-TIMEOUT_PENALTY = -WIN_BONUS / 4
+# Timeout penalty per bot. Reduced so the total deduction for all four players
+# stays around 30k when a match reaches the step limit.
+TIMEOUT_PENALTY = -WIN_BONUS / 12
 
 # Reward scale for the nth piece entering the home stretch for a team
 # Normalized to keep dense rewards smaller
@@ -23,7 +24,8 @@ HOME_ENTRY_REWARDS = [
     40, 120, 240, 400, 600,
     840, 1120, 1440, 1800, 2200
 ]
-COMPLETION_BONUS = HOME_ENTRY_REWARDS[0] * 2
+# Extra reward when a player finishes all pieces
+COMPLETION_BONUS = HOME_ENTRY_REWARDS[0] * 5
 
 # Penalty applied each turn a team goes without completing a piece.
 # Starts at ``COMPLETION_DELAY_BASE`` and is multiplied by

--- a/game-ai-training/config.py
+++ b/game-ai-training/config.py
@@ -37,7 +37,7 @@ JSON_LOGGING = os.getenv('JSON_LOGGING', '0').lower() in ('1', 'true', 'yes')
 # penalty zone with a capture. ``REWARD_SCHEDULE`` can override this value at
 # different points during training to implement a simple curriculum. Each tuple
 # in the list is ``(episode_start, heavy_reward)``.
-HEAVY_REWARD_BASE = 200.0
+HEAVY_REWARD_BASE = 400.0
 # The heavy reward decreases over time so early training emphasises key moves
 REWARD_SCHEDULE = [
     (0, HEAVY_REWARD_BASE),


### PR DESCRIPTION
## Summary
- reduce timeout penalty to about 8k per player
- give bigger bonus when all pieces are completed
- increase heavy reward baseline
- note lower timeout penalty in training README

## Testing
- `pip install -r game-ai-training/requirements.txt`
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68668623f350832aaa43fd9cc7a31ebd