### PR TITLE
Increase AI reward bonuses

### DIFF
--- a/game-ai-training/ai/environment.py
+++ b/game-ai-training/ai/environment.py
@@ -20,9 +20,11 @@ TIMEOUT_PENALTY = -WIN_BONUS / 12
 
 # Reward scale for the nth piece entering the home stretch for a team
 # Normalized to keep dense rewards smaller
+# Reward scale for the nth piece entering the home stretch for a team
+# Values drastically increased to counteract generally negative returns
 HOME_ENTRY_REWARDS = [
-    40, 120, 240, 400, 600,
-    840, 1120, 1440, 1800, 2200
+    600, 1800, 3600, 6000, 9000,
+    12600, 16800, 21600, 27000, 33000
 ]
 # Extra reward when a player finishes all pieces
 COMPLETION_BONUS = HOME_ENTRY_REWARDS[0] * 5
@@ -41,7 +43,8 @@ COMPLETION_DELAY_CAP = -30000.0
 POSITIVE_REWARD_DECAY = 1.01
 
 # Additional sparse reward bonuses and penalties
-FINAL_MOVE_BONUS = 2000.0
+# Final move bonus dramatically increased to reduce negative totals
+FINAL_MOVE_BONUS = 30000.0
 STAGNATION_PENALTY = -10.0
 # Additional penalty when two pieces are complete but progress stalls
 LATE_STAGNATION_PENALTY = -25.0

--- a/game-ai-training/config.py
+++ b/game-ai-training/config.py
@@ -37,7 +37,8 @@ JSON_LOGGING = os.getenv('JSON_LOGGING', '0').lower() in ('1', 'true', 'yes')
 # penalty zone with a capture. ``REWARD_SCHEDULE`` can override this value at
 # different points during training to implement a simple curriculum. Each tuple
 # in the list is ``(episode_start, heavy_reward)``.
-HEAVY_REWARD_BASE = 400.0
+# Increase heavy reward to give stronger incentives for impactful plays
+HEAVY_REWARD_BASE = 6000.0
 # The heavy reward decreases over time so early training emphasises key moves
 REWARD_SCHEDULE = [
     (0, HEAVY_REWARD_BASE),


### PR DESCRIPTION
## Summary
- scale up heavy reward, home entry rewards and final move bonus

## Testing
- `pip install -r game-ai-training/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68668b11cf84832aadff5e868ecc2a46