### PR TITLE
Fix win condition to require completed pieces

### DIFF
--- a/game-ai-training/ai/environment.py
+++ b/game-ai-training/ai/environment.py
@@ -1222,24 +1222,13 @@ class GameEnvironment:
         np.random.seed(seed)
 
     def count_completed_pieces(self, player_id: int) -> int:
-        """Return how many pieces are completed for ``player_id`` based on
-        home stretch position."""
-        indexes = set()
+        """Return how many pieces are fully completed for ``player_id``."""
+
+        count = 0
         for p in self.game_state.get('pieces', []):
-            if p.get('playerId') == player_id and p.get('inHomeStretch'):
-                idx = self._home_index(p.get('position'), player_id)
-                if idx != -1:
-                    indexes.add(idx)
-        if not indexes:
-            return 0
-        home_len = len(self._home_stretches[player_id])
-        completed = 0
-        for idx in range(home_len - 1, -1, -1):
-            if idx in indexes:
-                completed += 1
-            else:
-                break
-        return completed
+            if p.get('playerId') == player_id and p.get('completed'):
+                count += 1
+        return count
 
     def get_completed_counts(self) -> List[int]:
         """Return completed piece counts for all players."""

--- a/game-ai-training/game/game.js
+++ b/game-ai-training/game/game.js
@@ -1359,13 +1359,13 @@ class Game {
       const team = this.teams[teamIndex];
       const playerIds = team.map(p => p.position);
 
-      // Considerar vitória quando todas as peças estão pelo menos no corredor
-      // de chegada (inHomeStretch) ou finalizadas (completed)
-      const allHome = this.pieces
+      // Considerar vitória apenas quando todas as peças estiverem
+      // finalizadas (completed)
+      const allComplete = this.pieces
         .filter(p => playerIds.includes(p.playerId))
-        .every(p => p.completed || p.inHomeStretch);
+        .every(p => p.completed);
 
-      if (allHome) {
+      if (allComplete) {
         return true;
       }
     }
@@ -1379,11 +1379,11 @@ class Game {
       const team = this.teams[teamIndex];
       const playerIds = team.map(p => p.position);
 
-      const allHome = this.pieces
+      const allComplete = this.pieces
         .filter(p => playerIds.includes(p.playerId))
-        .every(p => p.completed || p.inHomeStretch);
+        .every(p => p.completed);
 
-      if (allHome) {
+      if (allComplete) {
         return team;
       }
     }

--- a/game-ai-training/tests/game_wrapper.test.js
+++ b/game-ai-training/tests/game_wrapper.test.js
@@ -39,3 +39,29 @@ describe('GameWrapper.isActionValid', () => {
     expect(wrapper.isActionValid(0, actionId)).toBe(false);
   });
 });
+
+describe('GameWrapper win condition', () => {
+  test('requires all pieces to be completed', () => {
+    const GameWrapper = loadGameWrapper();
+    const wrapper = new GameWrapper();
+    wrapper.setupGame();
+
+    const game = wrapper.game;
+    for (const piece of game.pieces) {
+      if (piece.playerId === 0 || piece.playerId === 2) {
+        piece.inPenaltyZone = false;
+        piece.inHomeStretch = true;
+        piece.completed = true;
+      }
+    }
+
+    const lastPiece = game.pieces.find(p => p.id === 'p0_1');
+    lastPiece.completed = false;
+    lastPiece.inHomeStretch = true;
+
+    expect(game.checkWinCondition()).toBe(false);
+
+    lastPiece.completed = true;
+    expect(game.checkWinCondition()).toBe(true);
+  });
+});

--- a/game-ai-training/tests/test_environment.py
+++ b/game-ai-training/tests/test_environment.py
@@ -984,3 +984,15 @@ def test_move_away_from_home_penalty():
     assert env.reward_event_counts['avoid_home_penalty'] == 1
 
 
+def test_count_completed_pieces_uses_flag():
+    env = GameEnvironment()
+    env.game_state = {
+        'pieces': [
+            {'playerId': 0, 'completed': False, 'inHomeStretch': True, 'position': {'row': 1, 'col': 0}},
+            {'playerId': 0, 'completed': True, 'inHomeStretch': True, 'position': {'row': 2, 'col': 0}},
+            {'playerId': 0, 'completed': False, 'inHomeStretch': True, 'position': {'row': 3, 'col': 0}},
+        ]
+    }
+    assert env.count_completed_pieces(0) == 1
+
+


### PR DESCRIPTION
## Summary
- enforce completed pieces for a team to win in training game
- simplify `count_completed_pieces` to count only fully completed pieces
- test win condition logic in Node game wrapper
- test that environment uses completed flag

## Testing
- `pip install -r game-ai-training/requirements.txt`
- `pytest -q`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6866acca9f50832aa45ebeba71d29b82