### PR TITLE
Fix win detection when a single player finishes all pieces

### DIFF
--- a/game-ai-training/ai/environment.py
+++ b/game-ai-training/ai/environment.py
@@ -1028,6 +1028,16 @@ class GameEnvironment:
                 self.reward_event_counts['completion'] += 1
                 self.reward_event_totals['completion'] += COMPLETION_BONUS
 
+            if (
+                not done
+                and player_total
+                and after_player_completed == player_total
+            ):
+                done = True
+                response['winningTeam'] = [{'position': player_id}]
+                self.game_state['gameEnded'] = True
+                self.game_state['winningTeam'] = response['winningTeam']
+
 
 
             # Longer stagnation after two completions

--- a/game-ai-training/tests/test_environment.py
+++ b/game-ai-training/tests/test_environment.py
@@ -144,6 +144,39 @@ def test_completion_delay_penalty_capped():
     assert reward == COMPLETION_DELAY_CAP
 
 
+def test_step_flags_win_when_player_completes_all_pieces():
+    env = GameEnvironment()
+    env.game_state = {
+        'pieces': [
+            {'id': 'p0_1', 'playerId': 0, 'completed': True, 'position': {'row': 0, 'col': 0}},
+            {'id': 'p0_2', 'playerId': 0, 'completed': False, 'position': {'row': 1, 'col': 0}}
+        ],
+        'teams': [[{'position': 0}, {'position': 2}], [{'position': 1}, {'position': 3}]]
+    }
+
+    response = {
+        'success': True,
+        'gameState': {
+            'pieces': [
+                {'id': 'p0_1', 'playerId': 0, 'completed': True, 'position': {'row': 0, 'col': 0}},
+                {'id': 'p0_2', 'playerId': 0, 'completed': True, 'position': {'row': 1, 'col': 0}}
+            ],
+            'teams': env.game_state['teams']
+        },
+        'gameEnded': False,
+        'winningTeam': None
+    }
+
+    with patch.object(env, 'send_command', return_value=response):
+        with patch.object(env, 'is_action_valid', return_value=True):
+            with patch.object(env, 'get_state', return_value=np.zeros(env.state_size)):
+                _, reward, done = env.step(0, 0)
+
+    assert done is True
+    assert env.game_state['gameEnded'] is True
+    assert env.game_state['winningTeam'] == [{'position': 0}]
+
+
 def _run_get_valid_actions_mock(has_move: bool):
     """Helper to execute GameWrapper.getValidActions under Node with mocked
     hasAnyValidMove."""


### PR DESCRIPTION
## Summary
- mark episode as won when a player's pieces are all completed
- ensure winning team includes that player
- add regression test

## Testing
- `pip install -r game-ai-training/requirements.txt`
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6866bd415014832abb93947731727f8a