### PR TITLE
Fix team win detection

### DIFF
--- a/game-ai-training/ai/environment.py
+++ b/game-ai-training/ai/environment.py
@@ -1028,15 +1028,10 @@ class GameEnvironment:
                 self.reward_event_counts['completion'] += 1
                 self.reward_event_totals['completion'] += COMPLETION_BONUS
 
-            if (
-                not done
-                and player_total
-                and after_player_completed == player_total
-            ):
-                done = True
-                response['winningTeam'] = [{'position': player_id}]
-                self.game_state['gameEnded'] = True
-                self.game_state['winningTeam'] = response['winningTeam']
+            # Only end the game when an entire team finishes all pieces.
+            # Individual players completing their set should award the
+            # completion bonus above but the episode continues until the
+            # partner also finishes.
 
 
 

--- a/game-ai-training/tests/test_environment.py
+++ b/game-ai-training/tests/test_environment.py
@@ -153,6 +153,7 @@ def test_step_flags_win_when_player_completes_all_pieces():
         ],
         'teams': [[{'position': 0}, {'position': 2}], [{'position': 1}, {'position': 3}]]
     }
+    env.player_team_map = {0: 0, 2: 0, 1: 1, 3: 1}
 
     response = {
         'success': True,
@@ -172,9 +173,9 @@ def test_step_flags_win_when_player_completes_all_pieces():
             with patch.object(env, 'get_state', return_value=np.zeros(env.state_size)):
                 _, reward, done = env.step(0, 0)
 
-    assert done is True
-    assert env.game_state['gameEnded'] is True
-    assert env.game_state['winningTeam'] == [{'position': 0}]
+    assert done is False
+    assert env.game_state['gameEnded'] is False
+    assert env.game_state['winningTeam'] is None
 
 
 def test_step_flags_win_when_team_completes_all_pieces():
@@ -188,6 +189,7 @@ def test_step_flags_win_when_team_completes_all_pieces():
         ],
         'teams': [[{'position': 0}, {'position': 2}], [{'position': 1}, {'position': 3}]]
     }
+    env.player_team_map = {0: 0, 2: 0, 1: 1, 3: 1}
 
     response = {
         'success': True,


### PR DESCRIPTION
## Summary
- correct premature win detection
- update environment tests

## Testing
- `pytest -q game-ai-training/tests/test_environment.py::test_step_flags_win_when_player_completes_all_pieces game-ai-training/tests/test_environment.py::test_step_flags_win_when_team_completes_all_pieces`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867a572a488832a8ed54f08de24ced0