### PR TITLE
Fix training game win detection

### DIFF
--- a/game-ai-training/game/game.js
+++ b/game-ai-training/game/game.js
@@ -1103,6 +1103,23 @@ class Game {
     return stretches[playerId];
   }
 
+  // Ensure pieces occupying the last home stretch square are marked completed
+  syncCompletedPieces() {
+    for (const piece of this.pieces) {
+      const stretch = this.homeStretchForPlayer(piece.playerId);
+      if (!stretch) continue;
+      const last = stretch[stretch.length - 1];
+      if (
+        piece.position.row === last.row &&
+        piece.position.col === last.col &&
+        !piece.completed
+      ) {
+        piece.inHomeStretch = true;
+        piece.completed = true;
+      }
+    }
+  }
+
   // Verifica se o caminho no corredor de chegada está livre entre dois índices
   isHomeStretchPathClear(piece, startIndex, endIndex) {
     const stretch = this.homeStretchForPlayer(piece.playerId);
@@ -1362,6 +1379,7 @@ class Game {
 
   checkWinCondition() {
     // Verificar se alguma dupla venceu
+    this.syncCompletedPieces();
     if (this.gameEnded) {
       return true;
     }
@@ -1574,6 +1592,7 @@ class Game {
   }
 
   getGameState() {
+    this.syncCompletedPieces();
     return {
       roomId: this.roomId,
       players: this.getPlayersInfo(),

--- a/game-ai-training/tests/game_wrapper.test.js
+++ b/game-ai-training/tests/game_wrapper.test.js
@@ -64,4 +64,28 @@ describe('GameWrapper win condition', () => {
     lastPiece.completed = true;
     expect(game.checkWinCondition()).toBe(true);
   });
+
+  test('win detection marks final square piece completed', () => {
+    const GameWrapper = loadGameWrapper();
+    const wrapper = new GameWrapper();
+    wrapper.setupGame();
+
+    const game = wrapper.game;
+    for (const piece of game.pieces) {
+      if (piece.playerId === 0 || piece.playerId === 2) {
+        piece.inPenaltyZone = false;
+        piece.inHomeStretch = true;
+        piece.completed = true;
+      }
+    }
+
+    const piece = game.pieces.find(p => p.id === 'p0_1');
+    const finalPos = game.homeStretchForPlayer(0).slice(-1)[0];
+    piece.position = { ...finalPos };
+    piece.inHomeStretch = true;
+    piece.completed = false;
+
+    expect(game.checkWinCondition()).toBe(true);
+    expect(piece.completed).toBe(true);
+  });
 });

--- a/server/__tests__/game.test.js
+++ b/server/__tests__/game.test.js
@@ -754,4 +754,34 @@ describe('Game class', () => {
     expect(game.isActive).toBe(false);
   });
 
+  test('checkWinCondition handles pieces at final position without flag', () => {
+    const game = new Game('winCheck');
+    game.addPlayer('1', 'A');
+    game.addPlayer('2', 'B');
+    game.addPlayer('3', 'C');
+    game.addPlayer('4', 'D');
+    game.setupTeams();
+
+    // Mark all pieces from players 1 and 3 as completed
+    game.pieces
+      .filter(p => p.playerId === 1 || p.playerId === 3)
+      .forEach(p => {
+        p.inPenaltyZone = false;
+        p.inHomeStretch = true;
+        p.completed = true;
+      });
+
+    // Move one piece to the final cell but leave completed as false
+    const piece = game.pieces.find(p => p.playerId === 1 && p.pieceId === 1);
+    const finalPos = game.homeStretchForPlayer(1).slice(-1)[0];
+    piece.position = { ...finalPos };
+    piece.inHomeStretch = true;
+    piece.inPenaltyZone = false;
+    piece.completed = false;
+
+    expect(game.checkWinCondition()).toBe(true);
+    expect(piece.completed).toBe(true);
+    expect(game.gameEnded).toBe(true);
+  });
+
 });

--- a/server/game.js
+++ b/server/game.js
@@ -1098,6 +1098,23 @@ discardCard(cardIndex) {
     return stretches[playerId];
   }
 
+  // Garantir que peças no final do corredor estejam marcadas como completas
+  syncCompletedPieces() {
+    for (const piece of this.pieces) {
+      const stretch = this.homeStretchForPlayer(piece.playerId);
+      if (!stretch) continue;
+      const last = stretch[stretch.length - 1];
+      if (
+        piece.position.row === last.row &&
+        piece.position.col === last.col &&
+        !piece.completed
+      ) {
+        piece.inHomeStretch = true;
+        piece.completed = true;
+      }
+    }
+  }
+
   // Verifica se o caminho no corredor de chegada está livre entre dois índices
   isHomeStretchPathClear(piece, startIndex, endIndex) {
     const stretch = this.homeStretchForPlayer(piece.playerId);
@@ -1368,6 +1385,7 @@ discardCard(cardIndex) {
 
   checkWinCondition() {
     // Verificar se alguma dupla venceu
+    this.syncCompletedPieces();
     if (this.gameEnded) {
       return true;
     }
@@ -1578,6 +1596,7 @@ discardCard(cardIndex) {
   }
 
   getGameState() {
+    this.syncCompletedPieces();
     return {
       roomId: this.roomId,
       players: this.getPlayersInfo(),


### PR DESCRIPTION
## Summary
- sync completion flags for pieces in training game
- call this check when evaluating a win and when returning game state
- cover edge case in training tests when final square piece lacks the completed flag

## Testing
- `pytest game-ai-training/tests`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6869254fc66c832a9fdf9e68d16ddfb0