### PR TITLE
Fix missing win state on state retrieval

### DIFF
--- a/game-ai-training/game/game.js
+++ b/game-ai-training/game/game.js
@@ -1593,6 +1593,9 @@ class Game {
 
   getGameState() {
     this.syncCompletedPieces();
+    // Keep win status up to date whenever the state is requested
+    // so training code receives the correct `gameEnded` flag.
+    this.checkWinCondition();
     return {
       roomId: this.roomId,
       players: this.getPlayersInfo(),

--- a/server/game.js
+++ b/server/game.js
@@ -1597,6 +1597,11 @@ discardCard(cardIndex) {
 
   getGameState() {
     this.syncCompletedPieces();
+    // Ensure the game state reflects any newly completed pieces
+    // before returning the snapshot. This guarantees callers see
+    // an accurate `gameEnded` flag even if they query the state
+    // outside of the normal move flow.
+    this.checkWinCondition();
     return {
       roomId: this.roomId,
       players: this.getPlayersInfo(),


### PR DESCRIPTION
## Summary
- ensure `getGameState()` triggers win checks

## Testing
- `npm test`
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_686947cd9d5c832a9d3f584be2d660b3