### PR TITLE
Fix homestretch placement logic in training env

### DIFF
--- a/game-ai-training/game/game.js
+++ b/game-ai-training/game/game.js
@@ -910,21 +910,21 @@ class Game {
     const targetPosition = homeStretch[remainingSteps - 1];
     
     // Verificar se a casa está ocupada
-    const occupyingPiece = this.pieces.find(p => 
-      p.id !== piece.id && 
-      p.position.row === targetPosition.row && 
-      p.position.col === targetPosition.col
+    const occupyingPiece = this.pieces.find(p =>
+      p.id !== piece.id &&
+      p.position.row === targetPosition.row &&
+      p.position.col === targetPosition.col &&
+      !p.inPenaltyZone
     );
     
     if (occupyingPiece) {
       throw new Error("Casa de chegada já ocupada");
     }
     
+    const wasCompleted = piece.completed;
     piece.position = targetPosition;
-    
-    // Se chegou na última casa, marcar como completa
-    if (remainingSteps === homeStretch.length) {
-      piece.completed = true;
+    this.syncCompletedPieces();
+    if (!wasCompleted && piece.completed) {
       if (this.movesToFirstComplete === null) {
         this.movesToFirstComplete = this.history.length + 1;
       }
@@ -999,20 +999,19 @@ class Game {
     const targetPosition = homeStretch[newIndex];
     const occupyingPiece = this.pieces.find(p =>
       p.id !== piece.id &&
-      !p.completed &&
       p.position.row === targetPosition.row &&
-      p.position.col === targetPosition.col
+      p.position.col === targetPosition.col &&
+      !p.inPenaltyZone
     );
     
     if (occupyingPiece) {
       throw new Error("Casa de chegada já ocupada");
     }
     
+    const wasCompleted = piece.completed;
     piece.position = targetPosition;
-    
-    // Se chegou na última casa, marcar como completa
-    if (newIndex === homeStretch.length - 1) {
-      piece.completed = true;
+    this.syncCompletedPieces();
+    if (!wasCompleted && piece.completed) {
       if (this.movesToFirstComplete === null) {
         this.movesToFirstComplete = this.history.length + 1;
       }
@@ -1106,19 +1105,31 @@ class Game {
     return stretches[playerId];
   }
 
-  // Ensure pieces occupying the last home stretch square are marked completed
+  // Marcar como completas as peças posicionadas no ponto mais distante
+  // disponível de cada corredor de chegada.
   syncCompletedPieces() {
-    for (const piece of this.pieces) {
-      const stretch = this.homeStretchForPlayer(piece.playerId);
+    for (let playerId = 0; playerId < 4; playerId++) {
+      const stretch = this.homeStretchForPlayer(playerId);
       if (!stretch) continue;
-      const last = stretch[stretch.length - 1];
-      if (
-        piece.position.row === last.row &&
-        piece.position.col === last.col &&
-        !piece.completed
-      ) {
-        piece.inHomeStretch = true;
-        piece.completed = true;
+
+      for (let i = stretch.length - 1; i >= 0; i--) {
+        const pos = stretch[i];
+        const piece = this.pieces.find(
+          p =>
+            p.playerId === playerId &&
+            !p.inPenaltyZone &&
+            p.position.row === pos.row &&
+            p.position.col === pos.col
+        );
+
+        if (piece) {
+          if (!piece.completed) {
+            piece.inHomeStretch = true;
+            piece.completed = true;
+          }
+        } else {
+          break;
+        }
       }
     }
   }
@@ -1132,7 +1143,6 @@ class Game {
       const pos = stretch[i];
       const occupyingPiece = this.pieces.find(p =>
         p.id !== piece.id &&
-        !p.completed &&
         !p.inPenaltyZone &&
         p.position.row === pos.row &&
         p.position.col === pos.col

--- a/game-ai-training/tests/game_wrapper.test.js
+++ b/game-ai-training/tests/game_wrapper.test.js
@@ -14,7 +14,7 @@ function loadGameWrapper() {
 }
 
 describe('GameWrapper.isActionValid', () => {
-  test('returns true when final home square is occupied by a completed piece', () => {
+  test('returns false when final home square is occupied by a completed piece', () => {
     const GameWrapper = loadGameWrapper();
     const wrapper = new GameWrapper();
     wrapper.setupGame();
@@ -36,7 +36,7 @@ describe('GameWrapper.isActionValid', () => {
     game.players[0].cards = [{ value: 'A' }];
 
     const actionId = 0 * 10 + 2; // card index 0, piece number 2
-    expect(wrapper.isActionValid(0, actionId)).toBe(true);
+    expect(wrapper.isActionValid(0, actionId)).toBe(false);
   });
 
   test('returns false when final home square is occupied by an unfinished piece', () => {

--- a/server/__tests__/game.test.js
+++ b/server/__tests__/game.test.js
@@ -792,12 +792,20 @@ describe('Game class', () => {
     game.addPlayer('4', 'D');
     game.setupTeams();
 
+    const idx0 = [4, 3, 2, 1, 0];
+    const idx2 = [3, 2, 1, 0];
     for (const p of game.pieces) {
-      if ((p.playerId === 0 || p.playerId === 2) && p.id !== 'p2_2') {
+      if (p.playerId === 0) {
+        const index = idx0.shift();
         p.inPenaltyZone = false;
         p.inHomeStretch = true;
-        const last = game.homeStretchForPlayer(p.playerId).slice(-1)[0];
-        p.position = { ...last };
+        p.position = { ...game.homeStretchForPlayer(0)[index] };
+        p.completed = true;
+      } else if (p.playerId === 2 && p.id !== 'p2_2') {
+        const index = idx2.shift();
+        p.inPenaltyZone = false;
+        p.inHomeStretch = true;
+        p.position = { ...game.homeStretchForPlayer(2)[index] };
         p.completed = true;
       }
     }


### PR DESCRIPTION
## Summary
- mirror server homestretch rules in training code
- update GameWrapper test to expect move blocked when final cell already occupied

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686bd8895d08832a968074f1ff9a3554