### PR TITLE
Update reward threshold and plot cadence

### DIFF
--- a/game-ai-training/README.md
+++ b/game-ai-training/README.md
@@ -75,8 +75,8 @@ analysis.
 ### Dynamic Reward Adjustment
 
 The trainer watches the win rate for the current number of pieces. If it drops
-below 0.6 the heavy reward and win bonus are increased by a small multiplier.
-Once the win rate rises above roughly 0.75 the multiplier decays back toward the
+below 0.75 the heavy reward and win bonus are increased by a small multiplier.
+Once the win rate rises above roughly 0.9 the multiplier decays back toward the
 scheduled values. This automatic tuning helps the curriculum progress without
 needing to manually edit the reward configuration.
 

--- a/game-ai-training/ai/trainer.py
+++ b/game-ai-training/ai/trainer.py
@@ -107,6 +107,10 @@ class TrainingManager:
         # Reward multiplier per difficulty level
         self.level_reward_multiplier = {}
 
+    def _stats_interval(self) -> int:
+        """Return plotting interval based on current piece count."""
+        return 500 if self.pieces_per_player < 4 else 100
+
     
     def create_bots(self, num_bots=4):
         self.bots = []
@@ -558,7 +562,8 @@ class TrainingManager:
                     if (episode + 1) % self.snapshot_freq == 0:
                         self.save_snapshot(episode + 1)
 
-                    if (episode + 1) % stats_freq == 0:
+                    interval = self._stats_interval()
+                    if (episode + 1) % interval == 0:
                         self.print_statistics(episode + 1)
                         self.plot_training_progress()
 
@@ -602,7 +607,8 @@ class TrainingManager:
                     if (episode + 1) % self.snapshot_freq == 0:
                         self.save_snapshot((episode + 1) * num_envs)
 
-                    if (episode + 1) % stats_freq == 0:
+                    interval = self._stats_interval()
+                    if (episode + 1) % interval == 0:
                         self.print_statistics((episode + 1) * num_envs)
                         self.plot_training_progress()
 

--- a/game-ai-training/config.py
+++ b/game-ai-training/config.py
@@ -50,7 +50,7 @@ REWARD_SCHEDULE = [
 # If the win rate for the current difficulty drops below this threshold the
 # trainer gradually increases bonus rewards. When it climbs well above the
 # target the bonuses decay back toward the base schedule.
-WINRATE_TARGET = 0.6
+WINRATE_TARGET = 0.75
 # Maximum multiplier applied to ``HEAVY_REWARD_BASE`` and ``WIN_BONUS``
 MAX_REWARD_MULTIPLIER = 2.0
 # Minimum multiplier applied to keep rewards from shrinking too far


### PR DESCRIPTION
## Summary
- tune WINRATE_TARGET to 0.75
- generate stats/plots less frequently early on by using a dynamic interval
- clarify dynamic reward adjustment docs

## Testing
- `pip install -r game-ai-training/requirements.txt`
- `pytest game-ai-training/tests`

------
https://chatgpt.com/codex/tasks/task_e_686d7925b96c832a90dcef158cc166b8