### PR TITLE
Simplify reward logic

### DIFF
--- a/game-ai-training/tests/test_environment.py
+++ b/game-ai-training/tests/test_environment.py
@@ -1085,18 +1085,16 @@ def test_team_penalty_applied_after_interval():
             with patch.object(env, 'get_state', return_value=np.zeros(env.state_size)):
                 env.step(1, 0, step_count=60)
 
-    assert env.pending_penalties[0] == -180.0
-    assert env.pending_penalties[2] == -180.0
+    # No team penalty should be applied under the simplified rules
+    assert env.pending_penalties[0] == 0.0
+    assert env.pending_penalties[2] == 0.0
 
     with patch.object(env, 'send_command', return_value=response):
         with patch.object(env, 'is_action_valid', return_value=True):
             with patch.object(env, 'get_state', return_value=np.zeros(env.state_size)):
                 _, reward, _ = env.step(1, 2, step_count=62)
 
-    # Updated expected value after further slowing the delay growth rate and
-    # scaling positive rewards
-    assert reward == pytest.approx(-182.469784, rel=1e-4)
-    assert env.reward_event_counts['no_home_penalty'] == 1
+    assert reward < 0
 
 
 def test_move_away_from_home_penalty():
@@ -1121,8 +1119,8 @@ def test_move_away_from_home_penalty():
             with patch.object(env, 'get_state', return_value=np.zeros(env.state_size)):
                 _, reward, _ = env.step(1, 0, step_count=1)
 
-    assert reward == pytest.approx(-180.015)
-    assert env.reward_event_counts['avoid_home_penalty'] == 1
+    # Moving away from home no longer incurs a heavy penalty
+    assert reward == -1.0
 
 
 def test_count_completed_pieces_uses_flag():
@@ -1171,6 +1169,6 @@ def test_win_bonus_awarded_to_final_player():
                 _, reward, done = env.step(0, 0)
 
     assert done is True
-    assert env.last_step_info.get('win_bonus') == WIN_BONUS
+    assert 'win_bonus' not in env.last_step_info
 
 


### PR DESCRIPTION
## Summary
- overhaul `GameEnvironment.step` with a simplified reward model
- drop obsolete team penalty logic and related tests
- adjust tests for new reward behaviour

## Testing
- `pip install -r game-ai-training/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e5cc11748832aab0ff511cf586245