### PR TITLE
Add fixed opponent training option

### DIFF
--- a/game-ai-training/README.md
+++ b/game-ai-training/README.md
@@ -31,6 +31,12 @@ python3 game-ai-training/main.py --continue
 
 The trainer will load the models from `models/final` if they exist.
 
+## Training with Fixed Opponents
+
+Pass the `--fixed-model-dir` option to `main.py` to load old models as
+unchanging opponents. When set, two trainable bots rotate as partners while the
+remaining seats use the models from the provided directory.
+
 ## Training Configuration
 
 `config.py` defines hyperparameters for PPO training. A new `kl_target` value

--- a/game-ai-training/main.py
+++ b/game-ai-training/main.py
@@ -19,6 +19,12 @@ def main():
         help="Number of parallel environments to run",
     )
     parser.add_argument(
+        "--fixed-model-dir",
+        type=str,
+        default=None,
+        help="Directory containing old opponent models",
+    )
+    parser.add_argument(
         "--save-match-log",
         dest="save_match_log",
         action="store_true",
@@ -30,8 +36,12 @@ def main():
     info("Initializing training environment")
 
     # Create training manager
-    trainer = TrainingManager(num_envs=args.num_envs)
-    
+    trainer = TrainingManager(
+        num_envs=args.num_envs,
+        num_trainable_bots=2 if args.fixed_model_dir else 4,
+        fixed_model_dir=args.fixed_model_dir,
+    )
+
     # Create bots
     trainer.create_bots(num_bots=4)
     


### PR DESCRIPTION
## Summary
- extend TrainingManager with ability to load fixed PPO bots
- allow passing `--fixed-model-dir` in `main.py`
- document fixed opponent setup in training README

## Testing
- `pip install -r game-ai-training/requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686eb469a87c832a81d4e95d7bc73d20