### PR TITLE
Simplify reward logic

### DIFF
--- a/game-ai-training/README.md
+++ b/game-ai-training/README.md
@@ -46,26 +46,17 @@ than 100 update steps.
 
 ### Reward Monitoring
 
-Training logs now record the reward *contribution* of each event type in the
-current simplified system:
+Training logs record how many times each of the following events occurs:
 
-- Valid moves that do not enter the home stretch (−0.1 each)
-- Invalid moves (−0.2 each)
-- Team pieces entering the home stretch receive a bonus starting at +20 and
-  an extra +25 if the entry occurs within the first 50 turns.
-- Opponent pieces entering the home stretch (−5 each)
-- Game wins award a large bonus of around 100k points depending on how quickly
-  the match ends.
-- Episodes that end due to the 550 step limit apply a timeout penalty of
-  roughly −8k per bot so the total deduction stays near −30k.
+- A piece enters the homestretch (+1 point).
+- A piece moves from the track directly to completion (+3 points).
+- A piece already in the homestretch moves to completion (+1 point).
+- Choosing to skip a possible homestretch entry (−5 points).
+- An opponent piece enters the homestretch (−0.5 points).
 
-Completion delay penalties now shrink as a team finishes more pieces, so
-early progress reduces the negative reward for later turns. The trainer also
-records how many pieces each bot has in the home stretch and how many are
-fully completed after every episode. These metrics appear in the training
-progress plots.
-To avoid extremely large negatives, the decay penalty is clamped so it never
-drops below roughly 30k points even after very long games.
+All other rewards and penalties from earlier revisions have been removed to
+keep the signal easy to interpret. The per‑episode breakdown plot still shows
+the contribution of each event type.
 
 The entropy of the event counts is plotted to help detect reward starvation. A
 per‑episode breakdown subplot shows the reward contribution of **every** event

--- a/game-ai-training/ai/trainer.py
+++ b/game-ai-training/ai/trainer.py
@@ -535,9 +535,10 @@ class TrainingManager:
         info(
             "Reward events",
             home_entries=env.reward_event_counts['home_entry'],
-            penalty_exits=env.reward_event_counts['penalty_exit'],
-            captures=env.reward_event_counts['capture'],
-            wins=env.reward_event_counts['game_win'],
+            direct_completions=env.reward_event_counts['direct_complete'],
+            home_completions=env.reward_event_counts['home_completion'],
+            skips=env.reward_event_counts['skip_home'],
+            enemy_entries=env.reward_event_counts['enemy_home_entry'],
             entropy=f"{entropy:.3f}"
         )
 
@@ -806,11 +807,10 @@ class TrainingManager:
 
             predefined_colors = {
                 'home_entry': 'red',
-                'penalty_exit': 'blue',
-                'capture': 'green',
-                'game_win': 'purple',
-                'completion': 'yellow',
-                'timeout': 'orange',
+                'direct_complete': 'blue',
+                'home_completion': 'green',
+                'skip_home': 'orange',
+                'enemy_home_entry': 'purple',
             }
 
             color_map = {}

--- a/game-ai-training/tests/test_trainer.py
+++ b/game-ai-training/tests/test_trainer.py
@@ -14,17 +14,16 @@ class MockGameEnvironment:
         self.saved_file = None
         self.reward_event_counts = {
             'home_entry': 0,
-            'penalty_exit': 0,
-            'capture': 0,
-            'game_win': 0
+            'direct_complete': 0,
+            'home_completion': 0,
+            'skip_home': 0,
+            'enemy_home_entry': 0,
         }
         self.reward_event_totals = {
             'home_entry': 0.0,
-            'penalty_exit': 0.0,
-            'capture': 0.0,
-            'game_win': 0.0,
-            'valid_move': 0.0,
-            'invalid_move': 0.0,
+            'direct_complete': 0.0,
+            'home_completion': 0.0,
+            'skip_home': 0.0,
             'enemy_home_entry': 0.0,
         }
         self.reward_bonus_totals = {
@@ -138,7 +137,13 @@ def test_train_episode_breaks_on_no_actions():
 def test_reward_entropy_computation():
     from ai.trainer import TrainingManager
     manager = TrainingManager()
-    counts = {'home_entry': 2, 'penalty_exit': 1, 'capture': 1, 'game_win': 0}
+    counts = {
+        'home_entry': 2,
+        'direct_complete': 1,
+        'home_completion': 1,
+        'skip_home': 0,
+        'enemy_home_entry': 0,
+    }
     entropy = manager._reward_entropy(counts)
     assert entropy > 0
 


### PR DESCRIPTION
## Summary
- implement simplified reward system in the training environment
- remove old reward events from trainer and tests
- document the new scoring rules

## Testing
- `pip install -r game-ai-training/requirements.txt`
- `pytest -q game-ai-training/tests`

------
https://chatgpt.com/codex/tasks/task_e_686fb85cec60832ab2b3b722ad59942e