### PR TITLE
Tune reward scales for home entry penalties

### DIFF
--- a/game-ai-training/README.md
+++ b/game-ai-training/README.md
@@ -51,8 +51,8 @@ Training logs record how many times each of the following events occurs:
 - A piece enters the homestretch (+1 point).
 - A piece moves from the track directly to completion (+3 points).
 - A piece already in the homestretch moves to completion (+1 point).
-- Choosing to skip a possible homestretch entry (−5 points).
-- An opponent piece enters the homestretch (−0.5 points).
+- Choosing to skip a possible homestretch entry (−50 points).
+- An opponent piece enters the homestretch (−2 points).
 
 All other rewards and penalties from earlier revisions have been removed to
 keep the signal easy to interpret. The per‑episode breakdown plot still shows

--- a/game-ai-training/ai/environment.py
+++ b/game-ai-training/ai/environment.py
@@ -16,7 +16,10 @@ HOME_ENTRY_REWARD = 1.0
 DIRECT_COMPLETE_REWARD = 3.0
 HOME_COMPLETION_REWARD = 1.0
 # Increase penalties for stronger negative feedback during training
-SKIP_HOME_PENALTY = -20.0
+# Increase the cost of skipping a homestretch entry so
+# the negative reward better counterbalances the scaled
+# positive rewards used during training.
+SKIP_HOME_PENALTY = -50.0
 ENEMY_HOME_ENTRY_PENALTY = -2.0
 
 # Normalised reward weights used throughout the environment

--- a/game-ai-training/config.py
+++ b/game-ai-training/config.py
@@ -62,11 +62,13 @@ REWARD_TUNE_STEP = 0.1
 # number of pieces per player. The curriculum increases the
 # difficulty by adding more pieces, so rewards must scale up to
 # remain meaningful. Levels correspond to piece counts from 1 to 5.
+# Scale down positive reward multipliers so penalties remain
+# meaningful relative to the bonuses awarded for successful plays.
 POSITIVE_REWARD_MULTIPLIERS = {
-    1: 1250.0,
-    2: 1000.0,
-    3: 500.0,
-    4: 450.0,
-    5: 100.0,
+    1: 600.0,
+    2: 500.0,
+    3: 250.0,
+    4: 225.0,
+    5: 50.0,
 }
 


### PR DESCRIPTION
## Summary
- increase skip-home penalty for clearer negative feedback
- reduce positive reward multipliers to keep rewards balanced
- update docs for new penalty values

## Testing
- `pip install -r game-ai-training/requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686fea9f7dc0832aa9600b264ddd7c58