### PR TITLE
Improve PPO stability with advantage normalization

### DIFF
--- a/game-ai-training/README.md
+++ b/game-ai-training/README.md
@@ -77,6 +77,13 @@ Once the win rate rises above roughly 0.9 the multiplier decays back toward the
 scheduled values. This automatic tuning helps the curriculum progress without
 needing to manually edit the reward configuration.
 
+### Advantage Normalization
+
+During PPO updates the advantages are now normalised per batch. After adding any
+extra advantages, the mean is subtracted and the result is divided by its
+standard deviation. This keeps gradients well scaled when reward magnitudes
+shift during training.
+
 ## Match Logging
 
 Passing the `--save-match-log` flag to `main.py` writes the move history of

--- a/game-ai-training/ai/bot.py
+++ b/game-ai-training/ai/bot.py
@@ -158,6 +158,10 @@ class GameBot:
         returns_t = torch.FloatTensor(returns).to(self.device)
         advantages = returns_t - values_t.detach()
         advantages += extra_advs_t
+        # Normalise advantages per batch to stabilise updates
+        adv_mean = advantages.mean()
+        adv_std = advantages.std(unbiased=False)
+        advantages = (advantages - adv_mean) / (adv_std + 1e-6)
 
         logits, new_values = self.model(states_t)
         logit_mask = torch.full_like(logits, float('-inf'))

--- a/game-ai-training/ai/trainer.py
+++ b/game-ai-training/ai/trainer.py
@@ -91,7 +91,8 @@ class TrainingManager:
         # Running statistics for reward normalisation
         self.reward_mean = 0.0
         self.reward_var = 1.0
-        self.reward_alpha = 0.99
+        # Faster adaptation to changing reward scales
+        self.reward_alpha = 0.95
 
         # Snapshot training setup
         self.snapshot_dir = 'snapshots'


### PR DESCRIPTION
## Summary
- normalize advantages in `GameBot.replay`
- tune reward normalization rate in `TrainingManager`
- document advantage normalization in README

## Testing
- `pip install -r game-ai-training/requirements.txt`
- `pytest -q game-ai-training/tests`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687011a13218832a88e80db9b5fa1c00