### PR TITLE
Scale penalties with positive reward factor

### DIFF
--- a/game-ai-training/ai/environment.py
+++ b/game-ai-training/ai/environment.py
@@ -733,9 +733,10 @@ class GameEnvironment:
                 ):
                     forward = (track_idx - prev_idx) % len(self._track)
                     if forward >= prev_steps and forward <= 12:
-                        piece_reward += SKIP_HOME_PENALTY
+                        scaled_penalty = SKIP_HOME_PENALTY * self.positive_reward_scale
+                        piece_reward += scaled_penalty
                         self.reward_event_counts['skip_home'] += 1
-                        self.reward_event_totals['skip_home'] += SKIP_HOME_PENALTY
+                        self.reward_event_totals['skip_home'] += scaled_penalty
 
         for p in self.game_state.get('pieces', []):
             pid = p.get('id')
@@ -746,9 +747,10 @@ class GameEnvironment:
             if owner in my_team:
                 continue
             if not prev['in_home'] and p.get('inHomeStretch'):
-                piece_reward += ENEMY_HOME_ENTRY_PENALTY
+                scaled_penalty = ENEMY_HOME_ENTRY_PENALTY * self.positive_reward_scale
+                piece_reward += scaled_penalty
                 self.reward_event_counts['enemy_home_entry'] += 1
-                self.reward_event_totals['enemy_home_entry'] += ENEMY_HOME_ENTRY_PENALTY
+                self.reward_event_totals['enemy_home_entry'] += scaled_penalty
 
         reward += piece_reward
 

--- a/game-ai-training/tests/test_environment.py
+++ b/game-ai-training/tests/test_environment.py
@@ -5,7 +5,7 @@ import subprocess
 from pathlib import Path
 import tempfile
 import pytest
-from ai.environment import GameEnvironment
+from ai.environment import GameEnvironment, SKIP_HOME_PENALTY
 
 
 def test_reset_returns_zero_when_start_fails():
@@ -1170,5 +1170,56 @@ def test_win_bonus_awarded_to_final_player():
 
     assert done is True
     assert 'win_bonus' not in env.last_step_info
+
+
+def _simulate_skip_home(env: GameEnvironment) -> float:
+    env.game_state = {
+        'currentPlayerIndex': 0,
+        'teams': [[{'position': 0}, {'position': 2}], [{'position': 1}, {'position': 3}]],
+        'pieces': [
+            {
+                'id': 'p0_1',
+                'playerId': 0,
+                'position': {'row': 0, 'col': 0},
+                'inHomeStretch': False,
+                'inPenaltyZone': False,
+                'completed': False,
+            }
+        ],
+    }
+    env.player_team_map = {0: 0, 2: 0, 1: 1, 3: 1}
+
+    new_state = {
+        'pieces': [
+            {
+                'id': 'p0_1',
+                'playerId': 0,
+                'position': {'row': 0, 'col': 6},
+                'inHomeStretch': False,
+                'inPenaltyZone': False,
+                'completed': False,
+            }
+        ],
+        'teams': env.game_state['teams'],
+    }
+    response = {'success': True, 'gameState': new_state, 'gameEnded': False, 'winningTeam': None}
+    with patch.object(env, 'send_command', return_value=response):
+        with patch.object(env, 'is_action_valid', return_value=True):
+            with patch.object(env, 'get_state', return_value=np.zeros(env.state_size)):
+                _, reward, _ = env.step(0, 0)
+    return reward
+
+
+def test_skip_home_penalty_scales_with_piece_count():
+    env_low = GameEnvironment(pieces_per_player=5)
+    penalty_low = _simulate_skip_home(env_low)
+    expected_low = SKIP_HOME_PENALTY * env_low.positive_reward_scale
+    assert penalty_low == expected_low
+
+    env_high = GameEnvironment(pieces_per_player=1)
+    penalty_high = _simulate_skip_home(env_high)
+    expected_high = SKIP_HOME_PENALTY * env_high.positive_reward_scale
+    assert penalty_high == expected_high
+    assert penalty_high < penalty_low
 
 


### PR DESCRIPTION
## Summary
- make skip-home and enemy-home-entry penalties scale with difficulty
- test penalty scaling based on piece count

## Testing
- `pip install -r game-ai-training/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68757a6cb794832ab4f70a5747b3c344