### PR TITLE
Add completion delay penalty

### DIFF
--- a/game-ai-training/ai/environment.py
+++ b/game-ai-training/ai/environment.py
@@ -601,6 +601,8 @@ class GameEnvironment:
             decay *= max(0.0, 1.0 - fraction)
             if decay < COMPLETION_DELAY_CAP:
                 decay = COMPLETION_DELAY_CAP
+            decay *= self.positive_reward_scale
+            reward += decay
 
         while True:
             if not self.is_action_valid(player_id, action):


### PR DESCRIPTION
## Summary
- integrate completion delay decay into reward calculation
- update environment tests for new decay penalty

## Testing
- `pip install -r game-ai-training/requirements.txt`
- `pytest -q game-ai-training/tests`

------
https://chatgpt.com/codex/tasks/task_e_68757a64b7e0832a84d0aa64b803c835