### PR TITLE
Simplify reward scheme and update tests

### DIFF
--- a/game-ai-training/config.py
+++ b/game-ai-training/config.py
@@ -38,12 +38,11 @@ JSON_LOGGING = os.getenv('JSON_LOGGING', '0').lower() in ('1', 'true', 'yes')
 # different points during training to implement a simple curriculum. Each tuple
 # in the list is ``(episode_start, heavy_reward)``.
 # Increase heavy reward to give stronger incentives for impactful plays
-HEAVY_REWARD_BASE = 6000.0
-# The heavy reward decreases over time so early training emphasises key moves
+# With the simplified reward system heavy rewards are disabled.
+HEAVY_REWARD_BASE = 0.0
+# Curriculum stages can still adjust the weight but default to zero.
 REWARD_SCHEDULE = [
     (0, HEAVY_REWARD_BASE),
-    (1000, HEAVY_REWARD_BASE * 0.75),
-    (3000, HEAVY_REWARD_BASE * 0.5),
 ]
 
 # Dynamic reward tuning

--- a/game-ai-training/tests/test_environment.py
+++ b/game-ai-training/tests/test_environment.py
@@ -9,7 +9,8 @@ from ai.environment import (
     GameEnvironment,
     COMPLETION_DELAY_BASE,
     COMPLETION_DELAY_CAP,
-    SKIP_HOME_PENALTY
+    SKIP_HOME_PENALTY,
+    WIN_BONUS
 )
 
 
@@ -1184,7 +1185,7 @@ def test_win_bonus_awarded_to_final_player():
                 _, reward, done = env.step(0, 0)
 
     assert done is True
-    assert 'win_bonus' not in env.last_step_info
+    assert env.last_step_info.get('win_bonus') == WIN_BONUS
 
 
 def _simulate_skip_home(env: GameEnvironment) -> float:
@@ -1228,12 +1229,18 @@ def _simulate_skip_home(env: GameEnvironment) -> float:
 def test_skip_home_penalty_scales_with_piece_count():
     env_low = GameEnvironment(pieces_per_player=5)
     penalty_low = _simulate_skip_home(env_low)
-    expected_low = SKIP_HOME_PENALTY * env_low.positive_reward_scale
+    expected_low = (
+        SKIP_HOME_PENALTY * env_low.positive_reward_scale
+        + COMPLETION_DELAY_BASE * env_low.positive_reward_scale
+    )
     assert penalty_low == expected_low
 
     env_high = GameEnvironment(pieces_per_player=1)
     penalty_high = _simulate_skip_home(env_high)
-    expected_high = SKIP_HOME_PENALTY * env_high.positive_reward_scale
+    expected_high = (
+        SKIP_HOME_PENALTY * env_high.positive_reward_scale
+        + COMPLETION_DELAY_BASE * env_high.positive_reward_scale
+    )
     assert penalty_high == expected_high
     assert penalty_high < penalty_low
 


### PR DESCRIPTION
## Summary
- simplify reward constants in GameEnvironment
- disable heavy reward schedule
- award win bonus when a player wins
- update tests for new reward logic

## Testing
- `pip install torch==2.1.0+cpu -f https://download.pytorch.org/whl/cpu/torch_stable.html numpy>=1.21.0 matplotlib>=3.5.0`
- `pytest -q game-ai-training/tests`

------
https://chatgpt.com/codex/tasks/task_e_68768751545c832abff27d72c1be265b