### PR TITLE
Tune rewards and expand episode logging

### DIFF
--- a/game-ai-training/README.md
+++ b/game-ai-training/README.md
@@ -51,7 +51,7 @@ Training logs record how many times each of the following events occurs:
 - A piece enters the homestretch (+1 point).
 - A piece moves from the track directly to completion (+3 points).
 - A piece already in the homestretch moves to completion (+1 point).
-- Choosing to skip a possible homestretch entry (−50 points).
+- Choosing to skip a possible homestretch entry (−10 points).
 - An opponent piece enters the homestretch (−2 points).
 
 All other rewards and penalties from earlier revisions have been removed to
@@ -63,7 +63,7 @@ per‑episode breakdown subplot shows the reward contribution of **every** event
 type. Positive values stack upward while negative values stack below zero. Each
 reward type uses a distinct color from Matplotlib's `tab20` palette so negative
 events are no longer lumped into a single “other” category.
-Heavy reward tracking from earlier versions has been removed.
+A small heavy reward now boosts impactful plays to help guide the bots.
 
 Every 100 episodes the trainer now logs the cumulative reward totals for each
 event type. These summaries are useful when sharing progress logs for further

--- a/game-ai-training/ai/environment.py
+++ b/game-ai-training/ai/environment.py
@@ -15,11 +15,10 @@ from config import HEAVY_REWARD_BASE
 HOME_ENTRY_REWARD = 10.0
 DIRECT_COMPLETE_REWARD = 50.0
 HOME_COMPLETION_REWARD = 30.0
-# Increase penalties for stronger negative feedback during training
-# Increase the cost of skipping a homestretch entry so
-# the negative reward better counterbalances the scaled
-# positive rewards used during training.
-SKIP_HOME_PENALTY = -20.0
+# Increase penalties for stronger negative feedback during training.
+# Skipping a homestretch entry now carries a smaller cost so it does not
+# overwhelm the positive heavy rewards applied elsewhere.
+SKIP_HOME_PENALTY = -10.0
 ENEMY_HOME_ENTRY_PENALTY = 0.0
 
 # Normalised reward weights used throughout the environment

--- a/game-ai-training/ai/trainer.py
+++ b/game-ai-training/ai/trainer.py
@@ -531,6 +531,11 @@ class TrainingManager:
         entropy = self._reward_entropy(env.reward_event_counts)
         self.training_stats['reward_entropies'].append(entropy)
         event_details = {k: v for k, v in env.reward_event_counts.items()}
+        for k, v in env.reward_event_totals.items():
+            event_details[f"{k}_reward"] = round(v, 2)
+        for k, v in env.reward_bonus_totals.items():
+            event_details[f"{k}_bonus"] = round(v, 2)
+        event_details['heavy_reward_events'] = getattr(env, 'heavy_reward_events', 0)
         event_details['entropy'] = f"{entropy:.3f}"
         info("Reward events", **event_details)
 

--- a/game-ai-training/config.py
+++ b/game-ai-training/config.py
@@ -37,9 +37,10 @@ JSON_LOGGING = os.getenv('JSON_LOGGING', '0').lower() in ('1', 'true', 'yes')
 # penalty zone with a capture. ``REWARD_SCHEDULE`` can override this value at
 # different points during training to implement a simple curriculum. Each tuple
 # in the list is ``(episode_start, heavy_reward)``.
-# Increase heavy reward to give stronger incentives for impactful plays
-# With the simplified reward system heavy rewards are disabled.
-HEAVY_REWARD_BASE = 0.0
+# Increase heavy reward to give stronger incentives for impactful plays.
+# A small positive value helps bots prioritise key actions without
+# overwhelming the simpler reward structure.
+HEAVY_REWARD_BASE = 2.0
 # Curriculum stages can still adjust the weight but default to zero.
 REWARD_SCHEDULE = [
     (0, HEAVY_REWARD_BASE),


### PR DESCRIPTION
## Summary
- enable heavy rewards with a small base value
- soften skip-home penalty
- log per-episode reward totals and heavy reward events
- document updated reward numbers

## Testing
- `pip install -r game-ai-training/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876e1f1bedc832a8b338474aef3449b