### PR TITLE
feat: improve hand visibility and piece styling

### DIFF
--- a/public/css/game.css
+++ b/public/css/game.css
@@ -205,6 +205,19 @@
     overflow-x: auto;
 }
 
+.player-hand.floating {
+    position: fixed;
+    bottom: 10px;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 1000;
+    cursor: grab;
+}
+
+.player-hand.floating.dragging {
+    cursor: grabbing;
+}
+
 #cards-container {
     display: flex;
     justify-content: center;

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -17,6 +17,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const winnersDiv = document.getElementById('winners');
     const finalStatsDiv = document.getElementById('final-stats');
     const lastMoveDiv = document.getElementById('last-move');
+    const playerHand = document.querySelector('.player-hand');
     
     // Elementos do diálogo de movimento especial (carta 7)
     const specialMoveChoice = document.getElementById('special-move-choice');
@@ -34,7 +35,38 @@ document.addEventListener('DOMContentLoaded', () => {
     const cancelJokerMoveBtn = document.getElementById('cancel-joker-move');
 
     const statsPanel = document.getElementById('stats-panel');
-    
+
+    let isDraggingHand = false;
+    let handOffsetX = 0;
+    let handOffsetY = 0;
+
+    if (playerHand) {
+      playerHand.addEventListener('mousedown', e => {
+        if (!playerHand.classList.contains('floating')) return;
+        isDraggingHand = true;
+        const rect = playerHand.getBoundingClientRect();
+        handOffsetX = e.clientX - rect.left;
+        handOffsetY = e.clientY - rect.top;
+        playerHand.style.bottom = '';
+        playerHand.style.transform = '';
+        playerHand.style.left = `${rect.left}px`;
+        playerHand.style.top = `${rect.top}px`;
+        playerHand.classList.add('dragging');
+      });
+
+      document.addEventListener('mousemove', e => {
+        if (!isDraggingHand) return;
+        playerHand.style.left = `${e.clientX - handOffsetX}px`;
+        playerHand.style.top = `${e.clientY - handOffsetY}px`;
+      });
+
+      document.addEventListener('mouseup', () => {
+        if (!isDraggingHand) return;
+        isDraggingHand = false;
+        playerHand.classList.remove('dragging');
+      });
+    }
+
     // Botões do diálogo de fim de jogo
     const rematchBtn = document.getElementById('rematch-btn');
     const exitBtn = document.getElementById('exit-btn');
@@ -110,15 +142,29 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function adjustBoardSize() {
-        const info = document.querySelector('.game-info');
-        const hand = document.querySelector('.player-hand');
+      const info = document.querySelector('.game-info');
+      const hand = playerHand;
 
       const cssMax = Math.min(window.innerWidth * 0.8, window.innerHeight * 0.65);
       let size = cssMax;
 
       if (info && hand) {
-        const available = window.innerHeight - info.offsetHeight - hand.offsetHeight - 32; // margem
-        size = Math.min(cssMax, available);
+        const availableWithHand = window.innerHeight - info.offsetHeight - hand.offsetHeight - 32;
+        if (availableWithHand < 0) {
+          hand.classList.add('floating');
+          hand.style.bottom = '10px';
+          hand.style.left = '50%';
+          hand.style.transform = 'translateX(-50%)';
+          const available = window.innerHeight - info.offsetHeight - 16;
+          size = Math.min(cssMax, available);
+        } else {
+          hand.classList.remove('floating');
+          hand.style.left = '';
+          hand.style.top = '';
+          hand.style.bottom = '';
+          hand.style.transform = '';
+          size = Math.min(cssMax, availableWithHand);
+        }
       }
 
       board.style.width = `${size}px`;
@@ -843,7 +889,6 @@ function updatePlayerLabels() {
       if (shouldHighlight) {
         pieceElement.classList.add('my-piece');
       }
-      pieceElement.textContent = piece.pieceId;
       pieceElement.dataset.id = piece.id;
       pieceElement.style.transform = `rotate(${-rotation}deg)`;
       pieceElement.addEventListener('click', e => {

--- a/public/js/replay.js
+++ b/public/js/replay.js
@@ -172,7 +172,6 @@ document.addEventListener('DOMContentLoaded', () => {
       if (!el) {
         el = document.createElement('div');
         el.className = `piece player${piece.playerId}`;
-        el.textContent = piece.pieceId;
         pieceElements[piece.id] = el;
       }
       cell.appendChild(el);


### PR DESCRIPTION
## Summary
- allow player hand to float and be dragged on small screens
- hide numeric labels on board pieces for a cleaner look

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0643d01fc832a8352afa2193e7203