### PR TITLE
Allow splitting 7-card move with home stretch pieces

### DIFF
--- a/public/js/game.js
+++ b/public/js/game.js
@@ -1296,15 +1296,15 @@ function makeMove() {
         const movable = gameState.pieces.filter(p => {
             if (!canControlPiece(playerPosition, p.playerId)) return false;
             if (p.inPenaltyZone || p.completed) return false;
-            // Allow pieces already in the home stretch to be considered for
-            // splitting the movement. The server will validate whether the
-            // desired move is legal.
+            // Pieces in the home stretch must have at least one legal move
+            // available to be considered for the split.
+            if (p.inHomeStretch) {
+                return canMoveInHomeStretch(p);
+            }
             return true;
         });
 
-        const movableTrack = movable.filter(p => !p.inHomeStretch);
-
-        if (movableTrack.length <= 1) {
+        if (movable.length <= 1) {
             socket.emit('makeSpecialMove', {
                 roomId,
                 moves: [{ pieceId: selectedPieceId, steps: 7 }],


### PR DESCRIPTION
## Summary
- Fix client logic to only auto-play a seven when no other movable pieces exist
- Count home stretch pieces that can move so players can split seven-card moves

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b06b1abd18832a8c1ed276ccba2f47