### PR TITLE
Tighten mobile layout and fix special move hand refresh

### DIFF
--- a/public/css/game.css
+++ b/public/css/game.css
@@ -15,6 +15,8 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
+    flex-wrap: wrap;
+    gap: 0.75rem;
     padding: 0.65rem 0.9rem;
     background: linear-gradient(135deg, rgba(17, 19, 36, 0.85), rgba(11, 14, 29, 0.95));
     border-radius: 18px;
@@ -260,6 +262,8 @@
     justify-content: center;
     gap: 1rem;
     flex-wrap: wrap;
+    width: 100%;
+    max-width: 100%;
     overflow: visible;
     row-gap: 0.75rem;
     margin-top: 1rem;
@@ -657,6 +661,53 @@
 
     .card {
         margin: 0.35rem;
+    }
+}
+
+/* Ajustes extras para aproveitar melhor o espaço em telas pequenas */
+@media (max-width: 700px) {
+    .game-container {
+        gap: 0.75rem;
+        padding: 0.85rem;
+    }
+
+    .game-info {
+        padding: 0.55rem 0.75rem;
+        gap: 0.5rem;
+    }
+
+    .room-code {
+        font-size: 0.85rem;
+    }
+
+    .teams-info {
+        gap: 0.25rem;
+    }
+
+    .team-line {
+        font-size: 0.85rem;
+        padding: 0.2rem 0.35rem;
+    }
+
+    .turn-info {
+        min-width: 0;
+        width: 100%;
+        align-items: flex-start;
+        gap: 0.15rem;
+    }
+
+    .turn-info h3 {
+        font-size: 0.95rem;
+    }
+
+    #turn-message {
+        width: 100%;
+        font-size: 0.9rem;
+        padding: 0.45rem 0.6rem;
+    }
+
+    .board-container {
+        padding: 0.85rem 0.9rem;
     }
 }
 

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -1093,10 +1093,9 @@ function updateCards(cards) {
   });
 
   // Ajusta o tamanho das cartas conforme o espaço disponível
-  cardsContainer.classList.remove('compact');
-  if (cardsContainer.scrollWidth > cardsContainer.clientWidth) {
-    cardsContainer.classList.add('compact');
-  }
+  const shouldCompact =
+    cards.length >= 6 || cardsContainer.scrollWidth > cardsContainer.clientWidth;
+  cardsContainer.classList.toggle('compact', shouldCompact);
 
   // Recalcula o tamanho do tabuleiro após renderizar a mão,
   // garantindo que haja espaço para visualizar as cartas

--- a/server/server.js
+++ b/server/server.js
@@ -840,6 +840,11 @@ socket.on('confirmHomeEntry', ({ roomId, pieceId, cardIndex, enterHome }) => {
     try {
       const currentPlayer = game.getCurrentPlayer();
       const moveResult = game.makeSpecialMove(moves);
+
+      // Atualizar a mão do jogador imediatamente após jogar a carta 7
+      socket.emit('updateCards', {
+        cards: currentPlayer.cards
+      });
       if (moveResult.moves) {
         const msgs = [];
         moveResult.moves.forEach(m => {
@@ -946,6 +951,11 @@ socket.on('confirmHomeEntry', ({ roomId, pieceId, cardIndex, enterHome }) => {
 
     try {
       const moveResult = game.resumeSpecialMove(enterHome);
+
+      // Garantir que a mão seja atualizada após concluir o movimento especial
+      socket.emit('updateCards', {
+        cards: currentPlayer.cards
+      });
 
       if (moveResult.moves) {
         const msgs = [];


### PR DESCRIPTION
## Summary
- reduce header spacing and padding on small screens so more of the board is visible
- ensure the player hand fills available width without overflowing on small viewports
- trigger compact card sizing when six or more cards are in hand to avoid horizontal overflow
- refresh the current player's hand immediately after resolving card 7 special moves so it stays in sync

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f5852dcd4832aa3bb108e35283103)