### PR TITLE
Persist and restore curriculum telemetry, add analysis helper, and update tests

### DIFF
--- a/game-ai-training/README.md
+++ b/game-ai-training/README.md
@@ -30,6 +30,9 @@ python3 game-ai-training/main.py --continue
 ```
 
 The trainer will load the models from `models/final` if they exist.
+When `training_stats.json` exists in the same directory, the trainer also
+restores curriculum telemetry (including piece count and stage progress) so a
+continued run does not reset back to one piece.
 
 ## Training with Fixed Opponents
 
@@ -66,6 +69,15 @@ Every 100 episodes the trainer now logs the cumulative reward totals for each
 event type. These summaries are useful when sharing progress logs for further
 analysis.
 
+The saved `training_stats.json` file now also includes per-episode curriculum
+telemetry fields that are useful for stage-aware analysis:
+
+- `pieces_per_player`
+- `stage_games`
+- `had_winner`
+- `timed_out`
+- `trainable_win`
+
 ### Dynamic Reward Adjustment
 
 The trainer watches the win rate for the current number of pieces. If it drops
@@ -88,6 +100,21 @@ every game played at each save interval to the `logs/` directory. The log files
 follow the pattern `episode_<N>_env_<ID>.log` where `<N>` is the episode number
 and `<ID>` identifies the environment when multiple environments run in
 parallel.
+
+## Training Stats Analysis Helper
+
+Use `analyze_training_stats.py` to build a stage-aware summary from a saved
+`training_stats.json` file:
+
+```bash
+python3 game-ai-training/analyze_training_stats.py models/final/training_stats.json
+```
+
+You can change the tail window used for trend metrics:
+
+```bash
+python3 game-ai-training/analyze_training_stats.py training_stats.json --window 1000
+```
 
 ## Multi-GPU Support
 

--- a/game-ai-training/ai/trainer.py
+++ b/game-ai-training/ai/trainer.py
@@ -62,7 +62,13 @@ class TrainingManager:
             'reward_entropies': [],
             'reward_breakdown_history': [],
             'completed_pieces': [],
-            'homestretch_pieces': []
+            'homestretch_pieces': [],
+            # Episode-level curriculum telemetry for stage-aware analytics.
+            'pieces_per_player': [],
+            'stage_games': [],
+            'had_winner': [],
+            'timed_out': [],
+            'trainable_win': [],
         }
 
         # Optional external list storing per-episode reward contributions
@@ -458,6 +464,7 @@ class TrainingManager:
             bot.games_played += 1
         
         # Check for winners
+        winning_team = []
         if env.game_state.get('gameEnded', False):
             winning_team = env.game_state.get('winningTeam', [])
             if winning_team:
@@ -485,6 +492,7 @@ class TrainingManager:
             game=self.stage_games,
             win_rate=f"{win_rate:.2f}"
         )
+        promoted = False
         if (
             self.stage_games >= 5000
             and win_rate >= 0.55
@@ -505,6 +513,7 @@ class TrainingManager:
             self.stage_games = 0
             self.stage_winning_games = 0
             self.recent_outcomes.clear()
+            promoted = True
             info(
                 "Increased difficulty",
                 pieces=self.pieces_per_player,
@@ -539,6 +548,26 @@ class TrainingManager:
         if ep_total < -10000:
             ep_total = -10000
         self.training_stats['episode_rewards'].append(ep_total)
+        self.training_stats['pieces_per_player'].append(
+            self.pieces_per_player - 1 if promoted else self.pieces_per_player
+        )
+        self.training_stats['stage_games'].append(
+            5000 if promoted else self.stage_games
+        )
+        had_winner = bool(winning_team)
+        self.training_stats['had_winner'].append(int(had_winner))
+        self.training_stats['timed_out'].append(
+            int(not env.game_state.get('gameEnded', False))
+        )
+        trainable_won = 0
+        if had_winner:
+            for player in winning_team:
+                player_pos = player.get('position', -1)
+                if 0 <= player_pos < len(self.bots):
+                    if getattr(self.bots[player_pos], "trainable", True):
+                        trainable_won = 1
+                        break
+        self.training_stats['trainable_win'].append(trainable_won)
         entropy = self._reward_entropy(env.reward_event_counts)
         self.training_stats['reward_entropies'].append(entropy)
         event_details = {k: v for k, v in env.reward_event_counts.items()}
@@ -901,6 +930,81 @@ class TrainingManager:
             if os.path.exists(model_path):
                 bot.load_model(model_path)
                 info("Loaded model", bot=bot.bot_id)
+
+        stats_path = os.path.join(base_path, "training_stats.json")
+        if os.path.exists(stats_path):
+            try:
+                with open(stats_path, "r", encoding="utf-8") as fh:
+                    saved_stats = json.load(fh)
+
+                default_stats = {
+                    'episode_rewards': [],
+                    'kl_divergences': [],
+                    'clip_fractions': [],
+                    'entropy_avgs': [],
+                    'games_played': 0,
+                    'reward_entropies': [],
+                    'reward_breakdown_history': [],
+                    'completed_pieces': [],
+                    'homestretch_pieces': [],
+                    'pieces_per_player': [],
+                    'stage_games': [],
+                    'had_winner': [],
+                    'timed_out': [],
+                    'trainable_win': [],
+                    'bonus_breakdown_history': [],
+                }
+
+                merged_stats = dict(default_stats)
+                for key, value in saved_stats.items():
+                    merged_stats[key] = value
+
+                # Keep `games_played` consistent with per-episode arrays.
+                merged_stats['games_played'] = len(merged_stats.get('episode_rewards', []))
+                self.training_stats = merged_stats
+                self.reward_breakdown_history = self.training_stats['reward_breakdown_history']
+                self.bonus_breakdown_history = self.training_stats['bonus_breakdown_history']
+
+                pieces_series = self.training_stats.get('pieces_per_player', [])
+                if pieces_series:
+                    self.pieces_per_player = max(1, int(pieces_series[-1]))
+                else:
+                    # Best-effort fallback for older checkpoints without telemetry.
+                    total_games = self.training_stats['games_played']
+                    self.pieces_per_player = 1 + (total_games // 5000)
+                    if self.pieces_per_player > 5:
+                        self.pieces_per_player = 5
+
+                stage_series = self.training_stats.get('stage_games', [])
+                if stage_series:
+                    self.stage_games = max(0, int(stage_series[-1]))
+                else:
+                    self.stage_games = self.training_stats['games_played'] % 5000
+
+                self.turn_limit = 100 * self.pieces_per_player
+                for env in [self.env] + self.envs:
+                    env.set_piece_count(self.pieces_per_player)
+                    env.set_turn_limit(self.turn_limit)
+
+                self.recent_outcomes.clear()
+                had_winner_series = self.training_stats.get('had_winner', [])
+                if had_winner_series:
+                    for value in had_winner_series[-self.recent_outcomes.maxlen:]:
+                        self.recent_outcomes.append(1 if value else 0)
+
+                self.stage_start_wins = {bot.bot_id: bot.wins for bot in self.bots}
+                self.stage_start_games = {
+                    bot.bot_id: bot.games_played for bot in self.bots
+                }
+
+                info(
+                    "Restored training state",
+                    games=self.training_stats['games_played'],
+                    pieces=self.pieces_per_player,
+                    stage_games=self.stage_games,
+                )
+            except Exception:
+                warning("Failed to restore training_stats.json; resuming with fresh stats")
 
     def save_snapshot(self, episode: int) -> None:
         """Save the best-performing bot as a frozen snapshot."""

--- a/game-ai-training/analyze_training_stats.py
+++ b/game-ai-training/analyze_training_stats.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Analyze training_stats.json with stage-aware curriculum metrics.
+
+Usage examples:
+  python3 game-ai-training/analyze_training_stats.py models/final/training_stats.json
+  python3 game-ai-training/analyze_training_stats.py training_stats.json --window 1000
+"""
+
+import argparse
+import json
+from typing import Dict, List, Tuple
+
+import numpy as np
+
+
+def _to_float_array(values) -> np.ndarray:
+    if values is None:
+        return np.array([], dtype=float)
+    return np.array(values, dtype=float)
+
+
+def _safe_mean(arr: np.ndarray):
+    return float(np.mean(arr)) if arr.size else None
+
+
+def _safe_std(arr: np.ndarray):
+    return float(np.std(arr)) if arr.size else None
+
+
+def _safe_slope(arr: np.ndarray):
+    """Return linear slope per episode for the provided series."""
+    if arr.size < 2:
+        return None
+    x = np.arange(arr.size, dtype=float)
+    slope, _ = np.polyfit(x, arr, 1)
+    return float(slope)
+
+
+def _window_tail(arr: np.ndarray, window: int) -> np.ndarray:
+    if not arr.size:
+        return arr
+    return arr[-min(window, arr.size):]
+
+
+def _derive_piece_series(data: Dict, episodes: int) -> np.ndarray:
+    """Return piece count per episode.
+
+    Prefers the explicit `pieces_per_player` telemetry and falls back to a
+    simple curriculum estimate when unavailable.
+    """
+    pieces = data.get("pieces_per_player")
+    if isinstance(pieces, list) and len(pieces) == episodes:
+        arr = np.array(pieces, dtype=int)
+        arr[arr < 1] = 1
+        return arr
+
+    # Fallback for older runs without telemetry.
+    inferred = np.ones(episodes, dtype=int)
+    if episodes > 5000:
+        inferred[5000:] = 2
+    if episodes > 10000:
+        inferred[10000:] = 3
+    return inferred
+
+
+def _stage_ranges(piece_series: np.ndarray) -> List[Tuple[int, int, int]]:
+    """Return contiguous ranges as (start, end, pieces)."""
+    if piece_series.size == 0:
+        return []
+    ranges = []
+    start = 0
+    current = int(piece_series[0])
+    for idx in range(1, piece_series.size):
+        val = int(piece_series[idx])
+        if val != current:
+            ranges.append((start, idx, current))
+            start = idx
+            current = val
+    ranges.append((start, piece_series.size, current))
+    return ranges
+
+
+def _build_summary(data: Dict, window: int) -> Dict:
+    rewards = _to_float_array(data.get("episode_rewards"))
+    entropy = _to_float_array(data.get("reward_entropies"))
+    completed = _to_float_array(data.get("completed_pieces"))
+    had_winner = _to_float_array(data.get("had_winner"))
+    timed_out = _to_float_array(data.get("timed_out"))
+    trainable_win = _to_float_array(data.get("trainable_win"))
+
+    episodes = int(rewards.size)
+    pieces = _derive_piece_series(data, episodes)
+
+    completed_total = (
+        completed.sum(axis=1)
+        if completed.ndim == 2 and completed.shape[0] == episodes
+        else np.array([], dtype=float)
+    )
+    completion_ratio = (
+        completed_total / np.maximum(1.0, 4.0 * pieces)
+        if completed_total.size
+        else np.array([], dtype=float)
+    )
+
+    out = {
+        "episodes": episodes,
+        "window": window,
+        "global": {
+            "reward_mean": _safe_mean(rewards),
+            "reward_std": _safe_std(rewards),
+            "reward_last_window_mean": _safe_mean(_window_tail(rewards, window)),
+            "reward_last_window_slope_per_ep": _safe_slope(_window_tail(rewards, window)),
+            "entropy_mean": _safe_mean(entropy),
+            "entropy_last_window_mean": _safe_mean(_window_tail(entropy, window)),
+            "completed_total_mean": _safe_mean(completed_total),
+            "completed_total_last_window_mean": _safe_mean(_window_tail(completed_total, window)),
+            "completion_ratio_mean": _safe_mean(completion_ratio),
+            "completion_ratio_last_window_mean": _safe_mean(_window_tail(completion_ratio, window)),
+            "completion_ratio_last_window_slope_per_ep": _safe_slope(_window_tail(completion_ratio, window)),
+            "had_winner_rate": _safe_mean(had_winner),
+            "timeout_rate": _safe_mean(timed_out),
+            "trainable_win_rate_all_eps": _safe_mean(trainable_win),
+        },
+        "stage_metrics": [],
+    }
+
+    if had_winner.size and trainable_win.size and had_winner.size == trainable_win.size:
+        decisive = had_winner > 0.5
+        if decisive.any():
+            out["global"]["trainable_win_rate_decisive_only"] = float(np.mean(trainable_win[decisive]))
+        else:
+            out["global"]["trainable_win_rate_decisive_only"] = None
+    else:
+        out["global"]["trainable_win_rate_decisive_only"] = None
+
+    for start, end, piece_count in _stage_ranges(pieces):
+        rr = rewards[start:end]
+        ee = entropy[start:end] if entropy.size == episodes else np.array([], dtype=float)
+        cc = completed_total[start:end] if completed_total.size == episodes else np.array([], dtype=float)
+        cr = completion_ratio[start:end] if completion_ratio.size == episodes else np.array([], dtype=float)
+        hw = had_winner[start:end] if had_winner.size == episodes else np.array([], dtype=float)
+        to = timed_out[start:end] if timed_out.size == episodes else np.array([], dtype=float)
+        tw = trainable_win[start:end] if trainable_win.size == episodes else np.array([], dtype=float)
+
+        entry = {
+            "stage_start": int(start),
+            "stage_end": int(end),
+            "pieces_per_player": int(piece_count),
+            "episodes_in_stage": int(end - start),
+            "reward_mean": _safe_mean(rr),
+            "reward_last_window_mean": _safe_mean(_window_tail(rr, window)),
+            "reward_last_window_slope_per_ep": _safe_slope(_window_tail(rr, window)),
+            "entropy_mean": _safe_mean(ee),
+            "entropy_last_window_mean": _safe_mean(_window_tail(ee, window)),
+            "completed_total_mean": _safe_mean(cc),
+            "completed_total_last_window_mean": _safe_mean(_window_tail(cc, window)),
+            "completion_ratio_mean": _safe_mean(cr),
+            "completion_ratio_last_window_mean": _safe_mean(_window_tail(cr, window)),
+            "completion_ratio_last_window_slope_per_ep": _safe_slope(_window_tail(cr, window)),
+            "had_winner_rate": _safe_mean(hw),
+            "timeout_rate": _safe_mean(to),
+            "trainable_win_rate_all_eps": _safe_mean(tw),
+        }
+
+        if hw.size and tw.size and hw.size == tw.size:
+            decisive = hw > 0.5
+            if decisive.any():
+                entry["trainable_win_rate_decisive_only"] = float(np.mean(tw[decisive]))
+            else:
+                entry["trainable_win_rate_decisive_only"] = None
+        else:
+            entry["trainable_win_rate_decisive_only"] = None
+
+        out["stage_metrics"].append(entry)
+
+    return out
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Analyze jogo training_stats.json")
+    parser.add_argument("path", help="Path to training_stats.json")
+    parser.add_argument(
+        "--window",
+        type=int,
+        default=1000,
+        help="Window size for tail means and slope calculations (default: 1000)",
+    )
+    args = parser.parse_args()
+
+    with open(args.path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+
+    summary = _build_summary(data, window=max(10, args.window))
+    print(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/game-ai-training/tests/test_trainer.py
+++ b/game-ai-training/tests/test_trainer.py
@@ -1,4 +1,5 @@
 import sys
+import json
 import numpy as np
 import pytest
 from unittest.mock import patch, MagicMock
@@ -65,6 +66,12 @@ class MockGameEnvironment:
     def set_win_bonus(self, value):
         self.win_bonus = value
 
+    def set_piece_count(self, value):
+        self.pieces_per_player = value
+
+    def set_turn_limit(self, value):
+        self.turn_limit = value
+
 
 class DummyGameBot:
     def __init__(self, player_id, state_size, action_size, device=None, bot_id=None):
@@ -91,6 +98,14 @@ class DummyGameBot:
         pass
 
     def update_target_network(self):
+        pass
+
+    def load_model(self, filepath, reset_stats=False):
+        # Simulate persisted counters being restored with model weights.
+        self.wins = 3
+        self.games_played = 7
+
+    def save_model(self, filepath):
         pass
 
 
@@ -172,3 +187,45 @@ def test_adjust_reward_multiplier_updates_env():
     expected = HEAVY_REWARD_BASE * (1 + REWARD_TUNE_STEP)
     assert pytest.approx(env.heavy_reward, rel=1e-6) == expected
     assert manager.level_reward_multiplier[manager.pieces_per_player] == 1 + REWARD_TUNE_STEP
+
+
+def test_load_models_restores_training_state(tmp_path):
+    torch_mock = MagicMock()
+    sys.modules['torch'] = torch_mock
+    sys.modules['torch.nn'] = MagicMock()
+    sys.modules['torch.optim'] = MagicMock()
+
+    from ai.trainer import TrainingManager
+
+    model_dir = tmp_path / "final"
+    model_dir.mkdir(parents=True, exist_ok=True)
+    for idx in range(4):
+        (model_dir / f"bot_{idx}.pth").write_text("stub", encoding="utf-8")
+
+    saved_stats = {
+        "episode_rewards": [1.0, 2.0, 3.0],
+        "reward_entropies": [0.1, 0.2, 0.3],
+        "pieces_per_player": [1, 1, 2],
+        "stage_games": [1, 2, 3],
+        "had_winner": [1, 0, 1],
+        "timed_out": [0, 1, 0],
+        "trainable_win": [1, 0, 1],
+        "reward_breakdown_history": [],
+        "bonus_breakdown_history": [],
+    }
+    (model_dir / "training_stats.json").write_text(
+        json.dumps(saved_stats), encoding="utf-8"
+    )
+
+    with patch('ai.trainer.GameBot', DummyGameBot):
+        manager = TrainingManager()
+        manager.env = MockGameEnvironment()
+        manager.envs = [manager.env]
+        manager.create_bots(num_bots=4)
+        manager.load_models(str(model_dir))
+
+        assert manager.training_stats["games_played"] == 3
+        assert manager.pieces_per_player == 2
+        assert manager.stage_games == 3
+        assert manager.turn_limit == 200
+        assert list(manager.recent_outcomes) == [1, 0, 1]


### PR DESCRIPTION
### Motivation

- Ensure continuing a training run restores curriculum progress (piece count and stage progress) so resumed training doesn't reset difficulty.
- Produce stage-aware telemetry for easier analysis of curriculum-driven training and make that telemetry consumable by tools.

### Description

- Extend `TrainingManager.training_stats` with per-episode curriculum fields: `pieces_per_player`, `stage_games`, `had_winner`, `timed_out`, and `trainable_win` and record them after each episode in `ai/trainer.py`.
- Add saving and robust loading of `training_stats.json` in `TrainingManager.save_models`/`load_models`, including merging defaults, computing sensible fallbacks for older checkpoints, restoring `pieces_per_player`, `stage_games`, `turn_limit`, and recent outcome history, and reseeding environments.
- Add `game-ai-training/analyze_training_stats.py`, a standalone CLI that builds stage-aware summaries (windowed means, slopes, completion ratios, and per-stage metrics) from a saved `training_stats.json`.
- Update `README.md` with notes about saving/restoring curriculum telemetry, the new `analyze_training_stats.py` usage, and other training behavior descriptions; and update tests and test mocks to exercise the new load/restore behavior.

### Testing

- Ran the project unit tests with `pytest` targeting `game-ai-training/tests`, including the new `test_load_models_restores_training_state`; all tests passed.
- The new test `test_load_models_restores_training_state` verifies that `load_models` reads `training_stats.json`, restores `games_played`, `pieces_per_player`, `stage_games`, and `turn_limit`, and rebuilds `recent_outcomes` successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7edd213f8832aa6341bf1853caa1b)