### PR TITLE
Add escalating long-game penalty and rebalance reward weights; tune reward tuning source

### DIFF
--- a/game-ai-training/ai/environment.py
+++ b/game-ai-training/ai/environment.py
@@ -14,6 +14,9 @@ from config import (
     REWARD_WEIGHTS,
     REWARD_CLIP_RANGE,
     STEP_PENALTY_BASE,
+    LONG_GAME_PENALTY_START,
+    LONG_GAME_PENALTY_INTERVAL,
+    LONG_GAME_PENALTY_BASE,
     FAST_FINISH_BONUS_SCALE,
 )
 
@@ -130,6 +133,7 @@ class GameEnvironment:
             'home_entry_progress': 0,
             'capture': 0,
             'safe_move': 0,
+            'long_game': 0,
             'win': 0,
             'loss': 0,
         }
@@ -141,6 +145,7 @@ class GameEnvironment:
             'home_entry_progress': 0.0,
             'capture': 0.0,
             'safe_move': 0.0,
+            'long_game': 0.0,
             'win': 0.0,
             'loss': 0.0,
         }
@@ -715,6 +720,21 @@ class GameEnvironment:
         self.reward_event_totals['step_cost'] = (
             self.reward_event_totals.get('step_cost', 0.0) + step_cost
         )
+        # Escalating anti-stall penalty for long games. This starts after a
+        # realistic match length and increases in fixed turn buckets.
+        turn_index = int(step_count)
+        if self.game_state:
+            turn_index = max(turn_index, int(self.game_state.get('turnCount', turn_index)))
+        if turn_index >= LONG_GAME_PENALTY_START:
+            tiers = ((turn_index - LONG_GAME_PENALTY_START) // LONG_GAME_PENALTY_INTERVAL) + 1
+            long_game_penalty = (
+                LONG_GAME_PENALTY_BASE
+                * float(tiers)
+                * max(1.0, self.pieces_per_player / 2.0)
+            )
+            weighted_reward += long_game_penalty
+            self.reward_event_counts['long_game'] += 1
+            self.reward_event_totals['long_game'] += long_game_penalty
 
 
 

--- a/game-ai-training/ai/trainer.py
+++ b/game-ai-training/ai/trainer.py
@@ -522,7 +522,10 @@ class TrainingManager:
             if decisive_trainable_window
             else 0.0
         )
-        self._adjust_reward_multiplier(decisive_rate, env)
+        # Tune rewards against the trainable bots' decisive win rate so the
+        # curriculum reacts to "closing games" performance, not just whether
+        # any team finished.
+        self._adjust_reward_multiplier(trainable_win_rate_decisive, env)
         info(
             "Curriculum progress",
             pieces=self.pieces_per_player,

--- a/game-ai-training/config.py
+++ b/game-ai-training/config.py
@@ -61,21 +61,29 @@ REWARD_TUNE_STEP = 0.1
 # Event-based reward weights used by ``GameEnvironment``. The environment
 # computes a weighted sum and then clips the total to reduce reward spikes.
 REWARD_WEIGHTS = {
-    # Completing a piece remains the core objective signal.
-    'home_completion': 50.0,
+    # Completing a piece remains a strong objective signal, but lower than
+    # before to reduce farming of intermediate rewards without closing games.
+    'home_completion': 35.0,
     # Discourage skipping a valid home entry.
     'skip_home': -1.0,
     # Small tactical bonuses to improve credit assignment.
-    'home_entry_progress': 2.0,
-    'capture': 6.0,
+    'home_entry_progress': 1.0,
+    'capture': 4.0,
     'safe_move': 1.0,
     # Team outcome signal.
-    'win': 20.0,
-    'loss': -10.0,
+    'win': 60.0,
+    'loss': -25.0,
 }
 
 # Small per-step penalty to encourage faster game resolution.
 STEP_PENALTY_BASE = -0.01
+
+# Additional penalty for long-running games. Applied in increasing tiers every
+# ``LONG_GAME_PENALTY_INTERVAL`` turns once ``LONG_GAME_PENALTY_START`` is
+# reached, so stalling policies become progressively less attractive.
+LONG_GAME_PENALTY_START = 250
+LONG_GAME_PENALTY_INTERVAL = 50
+LONG_GAME_PENALTY_BASE = -0.02
 
 # Extra bonus awarded on wins that finish well before the turn limit.
 FAST_FINISH_BONUS_SCALE = 15.0


### PR DESCRIPTION
### Motivation

- Discourage stalling and long-running games by applying an escalating penalty once games exceed a realistic turn threshold. 
- Rebalance event reward magnitudes to reduce intermediate-reward farming and strengthen decisive-game signals. 
- Use the trainable bots' decisive win rate to guide dynamic reward tuning so curriculum adapts to closing-game performance rather than any-team wins. 

### Description

- Added configuration parameters `LONG_GAME_PENALTY_START`, `LONG_GAME_PENALTY_INTERVAL`, and `LONG_GAME_PENALTY_BASE` to `config.py` and documented their purpose. 
- Rebalanced `REWARD_WEIGHTS` in `config.py` by lowering `home_completion`, `home_entry_progress`, and `capture` values and increasing `win` and `loss` magnitudes. 
- Implemented an escalating long-game penalty in `GameEnvironment` that applies tiered penalties once `turnCount` (or step count) reaches `LONG_GAME_PENALTY_START`, and added `long_game` to `reward_event_counts` and `reward_event_totals`. 
- Changed the trainer logic in `TrainingManager` to call `_adjust_reward_multiplier` with the trainable bots' decisive win rate (`trainable_win_rate_decisive`) instead of the overall decisive rate. 

### Testing

- No automated tests were run during this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e90feabbd0832a91897ad314a55cbd)