### PR TITLE
Define late_game_factor to prevent NameError in environment step rewards

### DIFF
--- a/game-ai-training/ai/environment.py
+++ b/game-ai-training/ai/environment.py
@@ -713,6 +713,10 @@ class GameEnvironment:
                 prev_completed[t_idx] += count
 
         weighted_reward = 0.0
+        # Keep late-game scaling neutral by default. Capture/progress rewards
+        # are multiplied by this value below, and defining it here prevents
+        # runtime NameError when stepping environments.
+        late_game_factor = 1.0
         # Apply a small per-step time cost so policies are encouraged to finish
         # games efficiently instead of only avoiding hard penalties.
         step_cost = STEP_PENALTY_BASE * max(1.0, self.pieces_per_player / 2.0)


### PR DESCRIPTION
### Motivation
- The training process crashed with a `NameError` because `late_game_factor` was referenced in reward calculations inside `GameEnvironment.step` but was not defined.
- The intent is to restore runtime stability while preserving current reward behavior.

### Description
- Added a local definition `late_game_factor = 1.0` near the start of `GameEnvironment.step` in `game-ai-training/ai/environment.py` so subsequent reward uses have a valid value.
- The factor uses a neutral default (`1.0`) to keep existing reward scaling unchanged.
- No other logic or reward weights were modified.

### Testing
- Ran `pytest -q game-ai-training/tests/test_environment.py` and it passed with `3 passed`.
- No additional automated test failures were observed for the modified code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e91b3394c0832a883666a1b5aa3d85)