### PR TITLE
Add reward shaping (piece/near-finish), telemetry, and training stability tweaks

### DIFF
--- a/game-ai-training/ai/bot.py
+++ b/game-ai-training/ai/bot.py
@@ -189,6 +189,7 @@ class GameBot:
 
             self.optimizer.zero_grad()
             loss.backward()
+            torch.nn.utils.clip_grad_norm_(self.model.parameters(), max_norm=0.5)
             self.optimizer.step()
 
             self.losses.append(float(loss.item()))

--- a/game-ai-training/ai/environment.py
+++ b/game-ai-training/ai/environment.py
@@ -18,6 +18,8 @@ from config import (
     LONG_GAME_PENALTY_INTERVAL,
     LONG_GAME_PENALTY_BASE,
     FAST_FINISH_BONUS_SCALE,
+    PIECE_COMPLETION_BONUS,
+    NEAR_FINISH_BONUS,
 )
 
 # Simplified reward system used for initial curriculum training
@@ -34,7 +36,7 @@ INVALID_MOVE_PENALTY = 0.0
 WIN_BONUS = REWARD_WEIGHTS.get('win', 20.0)
 # Base timeout penalty; TrainingManager scales this by current piece count so
 # unresolved high-difficulty games receive stronger negative feedback.
-TIMEOUT_PENALTY = -4.0
+TIMEOUT_PENALTY = -12.0
 
 # Deprecated reward configuration retained for backward compatibility
 HOME_ENTRY_REWARDS = []
@@ -129,6 +131,8 @@ class GameEnvironment:
         # Track how often each reward type occurs for analysis
         self.reward_event_counts = {
             'home_completion': 0,
+            'piece_completion_bonus': 0,
+            'near_finish': 0,
             'skip_home': 0,
             'home_entry_progress': 0,
             'capture': 0,
@@ -141,6 +145,8 @@ class GameEnvironment:
         # Track the total reward contributed by each event type
         self.reward_event_totals = {
             'home_completion': 0.0,
+            'piece_completion_bonus': 0.0,
+            'near_finish': 0.0,
             'skip_home': 0.0,
             'home_entry_progress': 0.0,
             'capture': 0.0,
@@ -713,6 +719,10 @@ class GameEnvironment:
                 prev_completed[t_idx] += count
 
         weighted_reward = 0.0
+        # Keep late-game scaling neutral by default. Capture/progress rewards
+        # are multiplied by this value below, and defining it here prevents
+        # runtime NameError when stepping environments.
+        late_game_factor = 1.0
         # Apply a small per-step time cost so policies are encouraged to finish
         # games efficiently instead of only avoiding hard penalties.
         step_cost = STEP_PENALTY_BASE * max(1.0, self.pieces_per_player / 2.0)
@@ -853,6 +863,9 @@ class GameEnvironment:
                 piece_reward += PIECE_COMPLETION_REWARD
                 self.reward_event_counts['home_completion'] += 1
                 self.reward_event_totals['home_completion'] += PIECE_COMPLETION_REWARD
+                piece_reward += PIECE_COMPLETION_BONUS
+                self.reward_event_counts['piece_completion_bonus'] += 1
+                self.reward_event_totals['piece_completion_bonus'] += PIECE_COMPLETION_BONUS
             prev_steps = self._steps_to_entrance(prev.get('pos') or {}, owner)
             new_steps = self._steps_to_entrance(new.get('position') or {}, owner)
             if prev_steps >= 0 and new_steps >= 0 and new_steps < prev_steps:
@@ -894,6 +907,18 @@ class GameEnvironment:
             if t_idx is not None and 0 <= t_idx < len(new_completed):
                 new_completed[t_idx] += count
 
+        my_idx = self.player_team_map.get(player_id, team_idx)
+        if 0 <= my_idx < len(new_completed):
+            my_team_size = len(teams_now[my_idx]) if my_idx < len(teams_now) else 0
+            near_finish_target = max(0, my_team_size * self.pieces_per_player - 1)
+            if (
+                near_finish_target > 0
+                and prev_completed[my_idx] < near_finish_target <= new_completed[my_idx]
+            ):
+                weighted_reward += NEAR_FINISH_BONUS
+                self.reward_event_counts['near_finish'] += 1
+                self.reward_event_totals['near_finish'] += NEAR_FINISH_BONUS
+
         if not done and teams_now:
             winner = self._check_team_completion(teams_now, new_completed)
             if winner is not None:
@@ -909,7 +934,6 @@ class GameEnvironment:
                     winning_idx = idx
                     break
             if winning_idx is not None:
-                my_idx = self.player_team_map.get(player_id, 0)
                 if winning_idx == my_idx:
                     win_reward = self.win_bonus if self.win_bonus != 0 else REWARD_WEIGHTS.get('win', 20.0)
                     self.reward_event_counts['win'] += 1

--- a/game-ai-training/ai/trainer.py
+++ b/game-ai-training/ai/trainer.py
@@ -78,6 +78,8 @@ class TrainingManager:
             'had_winner': [],
             'timed_out': [],
             'trainable_win': [],
+            'terminal_turns': [],
+            'near_finish_any_team': [],
         }
 
         # Optional external list storing per-episode reward contributions
@@ -514,6 +516,18 @@ class TrainingManager:
             if self.recent_timeouts
             else 0.0
         )
+        recent_terminal_turns = self.training_stats.get('terminal_turns', [])[-1000:]
+        median_terminal_turns = (
+            float(np.median(recent_terminal_turns))
+            if recent_terminal_turns
+            else 0.0
+        )
+        recent_near_finish = self.training_stats.get('near_finish_any_team', [])[-1000:]
+        near_finish_rate = (
+            float(sum(recent_near_finish) / len(recent_near_finish))
+            if recent_near_finish
+            else 0.0
+        )
         decisive_trainable_window = [
             win for win, had_winner in zip(self.recent_trainable_wins, self.recent_outcomes) if had_winner
         ]
@@ -533,6 +547,8 @@ class TrainingManager:
             decisive_rate=f"{decisive_rate:.2f}",
             timeout_rate=f"{timeout_rate:.2f}",
             trainable_win_rate_decisive=f"{trainable_win_rate_decisive:.2f}",
+            median_terminal_turns=f"{median_terminal_turns:.1f}",
+            near_finish_rate=f"{near_finish_rate:.2f}",
         )
         promoted = False
         if (
@@ -611,6 +627,30 @@ class TrainingManager:
                         trainable_won = 1
                         break
         self.training_stats['trainable_win'].append(trainable_won)
+        turn_count = int(env.game_state.get('turnCount', step_count))
+        if had_winner:
+            self.training_stats['terminal_turns'].append(turn_count)
+        team_completed = []
+        teams_now = env.game_state.get('teams', []) if env.game_state else []
+        player_to_team = {}
+        for idx, team in enumerate(teams_now):
+            for pl in team:
+                pos = pl.get('position')
+                if pos is not None:
+                    player_to_team[int(pos)] = idx
+        if teams_now:
+            team_completed = [0] * len(teams_now)
+            for pid, count in enumerate(completed_counts):
+                t_idx = player_to_team.get(pid)
+                if t_idx is not None and 0 <= t_idx < len(team_completed):
+                    team_completed[t_idx] += int(count)
+        near_finish_any = 0
+        for idx, team in enumerate(teams_now):
+            required = max(0, len(team) * self.pieces_per_player - 1)
+            if required > 0 and idx < len(team_completed) and team_completed[idx] >= required:
+                near_finish_any = 1
+                break
+        self.training_stats['near_finish_any_team'].append(near_finish_any)
         self.recent_timeouts.append(timed_out)
         self.recent_trainable_wins.append(trainable_won)
         entropy = self._reward_entropy(env.reward_event_counts)
@@ -997,6 +1037,8 @@ class TrainingManager:
                     'had_winner': [],
                     'timed_out': [],
                     'trainable_win': [],
+                    'terminal_turns': [],
+                    'near_finish_any_team': [],
                     'bonus_breakdown_history': [],
                 }
 

--- a/game-ai-training/config.py
+++ b/game-ai-training/config.py
@@ -3,13 +3,13 @@ TRAINING_CONFIG = {
     'num_episodes': 5000,
     'save_frequency': 500,
     'stats_frequency': 10,
-    'learning_rate': 3e-4,
+    'learning_rate': 1e-4,
     'batch_size': 64,
     'memory_size': 10000,
     'gamma': 0.95,
     'hidden_size': 512,
     'train_freq': 4,
-    'ppo_clip': 0.1,
+    'ppo_clip': 0.08,
     # Slight entropy bonus to maintain exploration without destabilising updates.
     'entropy_weight': 0.005,
     # Target KL divergence used for monitoring training stability.
@@ -75,6 +75,14 @@ REWARD_WEIGHTS = {
     'loss': -25.0,
 }
 
+# Extra piece completion bonus applied in addition to the base completion
+# reward. Helps agents value converting progress into fully completed pieces.
+PIECE_COMPLETION_BONUS = 12.0
+
+# Bonus granted when a team reaches "one move from victory" by completing all
+# but one piece. This creates a bridge between shaping rewards and final wins.
+NEAR_FINISH_BONUS = 10.0
+
 # Small per-step penalty to encourage faster game resolution.
 STEP_PENALTY_BASE = -0.01
 
@@ -89,7 +97,7 @@ LONG_GAME_PENALTY_BASE = -0.02
 FAST_FINISH_BONUS_SCALE = 15.0
 
 # Clip range for the per-step weighted reward sum.
-REWARD_CLIP_RANGE = (-100.0, 100.0)
+REWARD_CLIP_RANGE = (-150.0, 150.0)
 
 # Multiplier applied to positive rewards based on the current
 # number of pieces per player. The curriculum increases the

--- a/game-ai-training/tests/test_environment.py
+++ b/game-ai-training/tests/test_environment.py
@@ -2,7 +2,7 @@ import numpy as np
 from unittest.mock import patch
 import pytest
 from ai.environment import GameEnvironment, PIECE_COMPLETION_REWARD, SKIP_HOME_PENALTY
-from config import STEP_PENALTY_BASE
+from config import STEP_PENALTY_BASE, PIECE_COMPLETION_BONUS
 
 
 def test_reset_returns_zero_when_start_fails():
@@ -42,8 +42,9 @@ def test_piece_completion_reward():
             with patch.object(env, 'get_state', return_value=np.zeros(env.state_size)):
                 _, reward, _ = env.step(0, 0)
 
-    assert reward == pytest.approx(PIECE_COMPLETION_REWARD + step_cost)
+    assert reward == pytest.approx(PIECE_COMPLETION_REWARD + PIECE_COMPLETION_BONUS + step_cost)
     assert env.reward_event_counts['home_completion'] == 1
+    assert env.reward_event_counts['piece_completion_bonus'] == 1
 
 
 def test_skip_home_penalty():


### PR DESCRIPTION
### Motivation
- Improve reward shaping to better bridge piece completion and game-end signals so agents convert progress into wins. 
- Add telemetry for episode terminal timing and near-finish events to help curriculum decisions and debugging. 
- Improve training stability by reducing learning rate, tightening PPO clip, expanding reward clipping range, and clipping model gradients.

### Description
- Added new reward constants `PIECE_COMPLETION_BONUS` and `NEAR_FINISH_BONUS` to `config.py` and exposed them to the environment, and increased `REWARD_CLIP_RANGE` and adjusted `learning_rate` and `ppo_clip` in `TRAINING_CONFIG`.
- Increased base `TIMEOUT_PENALTY` in `environment.py` and integrated `PIECE_COMPLETION_BONUS` into piece completion handling so `piece_reward` now includes the extra bonus and increments `reward_event_counts`/`reward_event_totals` for `piece_completion_bonus`.
- Implemented a near-finish detection that grants `NEAR_FINISH_BONUS` when a team reaches all-but-one pieces and records `near_finish` counts and totals.
- Added a defensive `late_game_factor = 1.0` initialization to avoid `NameError` and kept existing capture/progress/safe_move scaling behavior.
- Extended environment telemetry structures with `near_finish` event counters/totals and updated `reward_event_totals` keys and `reward_bonus_totals` usage.
- Training telemetry: added `terminal_turns` and `near_finish_any_team` series to `TrainingManager`, persisted them when loading stats, computed median terminal turns and near-finish rate for logging, and record per-episode `terminal_turns` and `near_finish_any_team` values when episodes finish.
- Stability tweak in `ai/bot.py`: added gradient clipping via `torch.nn.utils.clip_grad_norm_(self.model.parameters(), max_norm=0.5)` before optimizer step to reduce large updates.
- Updated unit test `tests/test_environment.py` to assert the new `PIECE_COMPLETION_BONUS` is applied and that the `piece_completion_bonus` event is counted.

### Testing
- Ran unit tests for the environment: `pytest game-ai-training/tests/test_environment.py` and the updated tests passed.
- Ran project test suite with `pytest -q` locally; no regressions reported for the modified environment test (tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e91b3394c0832a883666a1b5aa3d85)