### PR TITLE
Add anti-stall/repetition penalties, entropy schedule, and stage-5 curriculum controls

### DIFF
--- a/game-ai-training/ai/bot.py
+++ b/game-ai-training/ai/bot.py
@@ -199,6 +199,10 @@ class GameBot:
     def update_target_network(self):
         pass
 
+    def set_entropy_weight(self, value: float) -> None:
+        """Update entropy regularization strength used in PPO loss."""
+        self.entropy_weight = float(value)
+
     def save_model(self, filepath: str) -> None:
         torch.save({
             'model_state_dict': self.model.state_dict(),

--- a/game-ai-training/ai/environment.py
+++ b/game-ai-training/ai/environment.py
@@ -20,6 +20,14 @@ from config import (
     FAST_FINISH_BONUS_SCALE,
     PIECE_COMPLETION_BONUS,
     NEAR_FINISH_BONUS,
+    URGENCY_PENALTY_START_FRAC,
+    URGENCY_PENALTY_BASE,
+    HOME_ENTRY_PROGRESS_CAP,
+    CAPTURE_REWARD_CAP,
+    NO_PROGRESS_WINDOW,
+    NO_PROGRESS_PENALTY,
+    REPEATED_STATE_THRESHOLD,
+    REPEATED_STATE_PENALTY,
 )
 
 # Simplified reward system used for initial curriculum training
@@ -192,6 +200,33 @@ class GameEnvironment:
         self.last_step_info: Dict[str, float] = {}
         # Cache legal actions so state encoding can include action metadata.
         self.last_valid_actions: Dict[int, List[int]] = {}
+        # Episode-level anti-stall telemetry.
+        self.state_visit_counts: Dict[str, int] = {}
+        self.total_state_visits = 0
+        self.unique_state_visits = 0
+        self.no_progress_penalty_events = 0
+        self.repeated_state_penalty_events = 0
+
+    def _state_signature(self) -> str:
+        """Return a stable, compact signature for repetition checks."""
+        if not self.game_state:
+            return ""
+        pieces = self.game_state.get('pieces', [])
+        compact = []
+        for p in pieces:
+            pos = p.get('position') or {}
+            compact.append(
+                (
+                    p.get('id'),
+                    p.get('playerId'),
+                    int(bool(p.get('completed'))),
+                    int(bool(p.get('inHomeStretch'))),
+                    pos.get('row'),
+                    pos.get('col'),
+                )
+            )
+        compact.sort()
+        return json.dumps(compact, separators=(',', ':'))
 
     def _generate_track(self) -> List[Dict[str, int]]:
         """Replicate the board track coordinates from the Node game."""
@@ -745,6 +780,19 @@ class GameEnvironment:
             weighted_reward += long_game_penalty
             self.reward_event_counts['long_game'] += 1
             self.reward_event_totals['long_game'] += long_game_penalty
+        # Ramping urgency penalty near the turn budget to prioritise closing.
+        if self.turn_limit > 0:
+            frac_used = turn_index / max(1.0, float(self.turn_limit))
+            if frac_used >= URGENCY_PENALTY_START_FRAC:
+                urgency = (
+                    URGENCY_PENALTY_BASE
+                    * (1.0 + (frac_used - URGENCY_PENALTY_START_FRAC) / max(1e-6, (1.0 - URGENCY_PENALTY_START_FRAC)))
+                    * max(1.0, self.pieces_per_player / 2.0)
+                )
+                weighted_reward += urgency
+                self.reward_event_totals['urgency'] = (
+                    self.reward_event_totals.get('urgency', 0.0) + urgency
+                )
 
 
 
@@ -876,12 +924,19 @@ class GameEnvironment:
 
         if capture_occurred:
             cap = REWARD_WEIGHTS.get('capture', 6.0) * late_game_factor
+            remaining_capture = max(0.0, CAPTURE_REWARD_CAP - self.reward_event_totals.get('capture', 0.0))
+            cap = min(cap, remaining_capture)
             self.reward_event_counts['capture'] += 1
             self.reward_event_totals['capture'] += cap
             weighted_reward += cap
 
         if progress_reward > 0:
             progress_reward *= late_game_factor
+            remaining_progress = max(
+                0.0,
+                HOME_ENTRY_PROGRESS_CAP - self.reward_event_totals.get('home_entry_progress', 0.0),
+            )
+            progress_reward = min(progress_reward, remaining_progress)
             self.reward_event_counts['home_entry_progress'] += 1
             self.reward_event_totals['home_entry_progress'] += progress_reward
             weighted_reward += progress_reward
@@ -964,6 +1019,38 @@ class GameEnvironment:
                     self.reward_event_totals['loss'] += loss_penalty
                     weighted_reward += loss_penalty
 
+        progress_happened = (
+            piece_reward > 0
+            or progress_reward > 0
+            or capture_occurred
+            or self.reward_event_counts.get('near_finish', 0) > 0
+        )
+        if not progress_happened:
+            player_tracker = self.no_progress_steps[player_id]
+            player_tracker['general'] += 1
+            if player_tracker['general'] % NO_PROGRESS_WINDOW == 0:
+                weighted_reward += NO_PROGRESS_PENALTY
+                self.no_progress_penalty_events += 1
+                self.reward_event_totals['no_progress'] = (
+                    self.reward_event_totals.get('no_progress', 0.0) + NO_PROGRESS_PENALTY
+                )
+        else:
+            self.no_progress_steps[player_id]['general'] = 0
+
+        sig = self._state_signature()
+        if sig:
+            visits = self.state_visit_counts.get(sig, 0) + 1
+            self.state_visit_counts[sig] = visits
+            self.total_state_visits += 1
+            if visits == 1:
+                self.unique_state_visits += 1
+            elif visits >= REPEATED_STATE_THRESHOLD:
+                weighted_reward += REPEATED_STATE_PENALTY
+                self.repeated_state_penalty_events += 1
+                self.reward_event_totals['repeated_state'] = (
+                    self.reward_event_totals.get('repeated_state', 0.0) + REPEATED_STATE_PENALTY
+                )
+
         low, high = REWARD_CLIP_RANGE
         reward = float(np.clip(weighted_reward, low, high))
 
@@ -1016,6 +1103,11 @@ class GameEnvironment:
             {'general': 0, 'since_two': 0} for _ in range(4)
         ]
         self.last_step_info = {}
+        self.state_visit_counts = {}
+        self.total_state_visits = 0
+        self.unique_state_visits = 0
+        self.no_progress_penalty_events = 0
+        self.repeated_state_penalty_events = 0
 
     def set_heavy_reward(self, value: float) -> None:
         """Update the weight applied to major reward events."""

--- a/game-ai-training/ai/trainer.py
+++ b/game-ai-training/ai/trainer.py
@@ -25,6 +25,11 @@ from config import (
     MIN_REWARD_MULTIPLIER,
     REWARD_TUNE_STEP,
     TURN_LIMIT_SCHEDULE,
+    ENTROPY_WEIGHT_SCHEDULE,
+    STAGE5_MIX_FROM_GAME,
+    STAGE5_MIX_LOWER_STAGE_RATIO,
+    STAGE5_ROLLBACK_MIN_GAMES,
+    STAGE5_ROLLBACK_DECISIVE_RATE,
 )
 from json_logger import info, warning
 import random
@@ -80,6 +85,10 @@ class TrainingManager:
             'trainable_win': [],
             'terminal_turns': [],
             'near_finish_any_team': [],
+            'near_finish_timeout': [],
+            'no_progress_penalties': [],
+            'state_repeat_penalties': [],
+            'unique_state_ratio': [],
         }
 
         # Optional external list storing per-episode reward contributions
@@ -132,6 +141,7 @@ class TrainingManager:
 
         # Reward multiplier per difficulty level
         self.level_reward_multiplier = {}
+        self.curriculum_rollback_count = 0
 
     def _stats_interval(self) -> int:
         """Return plotting interval based on current piece count."""
@@ -300,6 +310,28 @@ class TrainingManager:
         env.set_heavy_reward(weight * multiplier)
         env.set_win_bonus(WIN_BONUS * multiplier)
 
+    def _apply_entropy_schedule(self) -> None:
+        """Adjust trainable bots' entropy weight based on stage difficulty."""
+        target = ENTROPY_WEIGHT_SCHEDULE.get(
+            self.pieces_per_player,
+            TRAINING_CONFIG.get('entropy_weight', 0.005),
+        )
+        for bot in self.trainable_bots:
+            if hasattr(bot, "set_entropy_weight"):
+                bot.set_entropy_weight(target)
+            else:
+                bot.entropy_weight = target
+
+    def _episode_piece_count(self) -> int:
+        """Use occasional easier games in stage 5 as a curriculum bridge."""
+        if (
+            self.pieces_per_player == 5
+            and self.stage_games >= STAGE5_MIX_FROM_GAME
+            and random.random() < STAGE5_MIX_LOWER_STAGE_RATIO
+        ):
+            return 4
+        return self.pieces_per_player
+
     def _adjust_reward_multiplier(self, win_rate: float, env: GameEnvironment) -> None:
         """Update the reward multiplier based on the observed win rate."""
         level = self.pieces_per_player
@@ -361,6 +393,10 @@ class TrainingManager:
 
         # Randomize bot seating for this episode
         self._shuffle_bots()
+        self._apply_entropy_schedule()
+        episode_pieces = self._episode_piece_count()
+        env.set_piece_count(episode_pieces)
+        env.set_turn_limit(self._turn_limit_for_pieces(episode_pieces))
 
         if self.latest_snapshot and episode_num % 4 != 0:
             opponents = [i for i in range(len(self.bots)) if i != self.train_focus_idx]
@@ -385,7 +421,7 @@ class TrainingManager:
         step_records = []
         
         step_count = 0
-        max_steps = self.turn_limit
+        max_steps = self._turn_limit_for_pieces(episode_pieces)
         
         while step_count < max_steps:
             # Get current player from game state
@@ -470,7 +506,9 @@ class TrainingManager:
                 break
 
         if not env.game_state.get('gameEnded', False):
-            timeout_penalty = TIMEOUT_PENALTY * max(1, self.pieces_per_player)
+            timeout_penalty = TIMEOUT_PENALTY * max(1, episode_pieces)
+            if env.reward_event_counts.get('near_finish', 0) > 0:
+                timeout_penalty *= 1.5
             for i in range(len(episode_rewards)):
                 episode_rewards[i] += timeout_penalty
             env.reward_event_counts['timeout'] = (
@@ -550,6 +588,28 @@ class TrainingManager:
             median_terminal_turns=f"{median_terminal_turns:.1f}",
             near_finish_rate=f"{near_finish_rate:.2f}",
         )
+        if (
+            self.pieces_per_player == 5
+            and self.stage_games >= STAGE5_ROLLBACK_MIN_GAMES
+            and decisive_rate < STAGE5_ROLLBACK_DECISIVE_RATE
+        ):
+            self.pieces_per_player = 4
+            self.turn_limit = self._turn_limit_for_pieces(self.pieces_per_player)
+            for rollback_env in [self.env] + self.envs:
+                rollback_env.set_piece_count(self.pieces_per_player)
+                rollback_env.set_turn_limit(self.turn_limit)
+            self.stage_games = 0
+            self.stage_winning_games = 0
+            self.recent_outcomes.clear()
+            self.recent_timeouts.clear()
+            self.recent_trainable_wins.clear()
+            self.curriculum_rollback_count += 1
+            warning(
+                "Curriculum rollback triggered",
+                pieces=self.pieces_per_player,
+                decisive_rate=f"{decisive_rate:.2f}",
+                rollbacks=self.curriculum_rollback_count,
+            )
         promoted = False
         if (
             self.stage_games >= 5000
@@ -608,9 +668,7 @@ class TrainingManager:
         if ep_total < -10000:
             ep_total = -10000
         self.training_stats['episode_rewards'].append(ep_total)
-        self.training_stats['pieces_per_player'].append(
-            self.pieces_per_player - 1 if promoted else self.pieces_per_player
-        )
+        self.training_stats['pieces_per_player'].append(episode_pieces)
         self.training_stats['stage_games'].append(
             5000 if promoted else self.stage_games
         )
@@ -651,6 +709,20 @@ class TrainingManager:
                 near_finish_any = 1
                 break
         self.training_stats['near_finish_any_team'].append(near_finish_any)
+        self.training_stats['near_finish_timeout'].append(
+            int(bool(timed_out and near_finish_any))
+        )
+        self.training_stats['no_progress_penalties'].append(
+            int(getattr(env, 'no_progress_penalty_events', 0))
+        )
+        self.training_stats['state_repeat_penalties'].append(
+            int(getattr(env, 'repeated_state_penalty_events', 0))
+        )
+        total_visits = float(getattr(env, 'total_state_visits', 0) or 0.0)
+        unique_visits = float(getattr(env, 'unique_state_visits', 0) or 0.0)
+        self.training_stats['unique_state_ratio'].append(
+            (unique_visits / total_visits) if total_visits > 0 else 1.0
+        )
         self.recent_timeouts.append(timed_out)
         self.recent_trainable_wins.append(trainable_won)
         entropy = self._reward_entropy(env.reward_event_counts)
@@ -1039,6 +1111,10 @@ class TrainingManager:
                     'trainable_win': [],
                     'terminal_turns': [],
                     'near_finish_any_team': [],
+                    'near_finish_timeout': [],
+                    'no_progress_penalties': [],
+                    'state_repeat_penalties': [],
+                    'unique_state_ratio': [],
                     'bonus_breakdown_history': [],
                 }
 
@@ -1068,7 +1144,7 @@ class TrainingManager:
                 else:
                     self.stage_games = self.training_stats['games_played'] % 5000
 
-                self.turn_limit = 100 * self.pieces_per_player
+                self.turn_limit = self._turn_limit_for_pieces(self.pieces_per_player)
                 for env in [self.env] + self.envs:
                     env.set_piece_count(self.pieces_per_player)
                     env.set_turn_limit(self.turn_limit)

--- a/game-ai-training/config.py
+++ b/game-ai-training/config.py
@@ -22,6 +22,16 @@ TRAINING_CONFIG = {
     'lr_final': 1e-5
 }
 
+# Piece-dependent entropy regularization. Harder stages use lower entropy so
+# the policy can consolidate and stop dithering in long games.
+ENTROPY_WEIGHT_SCHEDULE = {
+    1: 0.005,
+    2: 0.004,
+    3: 0.003,
+    4: 0.0025,
+    5: 0.0015,
+}
+
 # Paths
 MODEL_DIR = 'models'
 PLOT_DIR = 'plots'
@@ -57,6 +67,12 @@ MAX_REWARD_MULTIPLIER = 2.0
 MIN_REWARD_MULTIPLIER = 0.5
 # Step size used when adjusting the reward multiplier up or down
 REWARD_TUNE_STEP = 0.1
+
+# Curriculum bridge/rollback controls for the final stage.
+STAGE5_MIX_FROM_GAME = 1000
+STAGE5_MIX_LOWER_STAGE_RATIO = 0.25
+STAGE5_ROLLBACK_MIN_GAMES = 2500
+STAGE5_ROLLBACK_DECISIVE_RATE = 0.08
 
 # Event-based reward weights used by ``GameEnvironment``. The environment
 # computes a weighted sum and then clips the total to reduce reward spikes.
@@ -95,6 +111,21 @@ LONG_GAME_PENALTY_BASE = -0.02
 
 # Extra bonus awarded on wins that finish well before the turn limit.
 FAST_FINISH_BONUS_SCALE = 15.0
+
+# Additional late-game urgency signal: penalty ramps up after
+# ``URGENCY_PENALTY_START_FRAC`` of the turn budget has been consumed.
+URGENCY_PENALTY_START_FRAC = 0.70
+URGENCY_PENALTY_BASE = -0.15
+
+# Cap loopable shaping rewards to reduce farming behavior.
+HOME_ENTRY_PROGRESS_CAP = 120.0
+CAPTURE_REWARD_CAP = 180.0
+
+# Anti-stall penalties.
+NO_PROGRESS_WINDOW = 24
+NO_PROGRESS_PENALTY = -0.8
+REPEATED_STATE_THRESHOLD = 3
+REPEATED_STATE_PENALTY = -0.6
 
 # Clip range for the per-step weighted reward sum.
 REWARD_CLIP_RANGE = (-150.0, 150.0)

--- a/game-ai-training/tests/test_trainer.py
+++ b/game-ai-training/tests/test_trainer.py
@@ -227,5 +227,5 @@ def test_load_models_restores_training_state(tmp_path):
         assert manager.training_stats["games_played"] == 3
         assert manager.pieces_per_player == 2
         assert manager.stage_games == 3
-        assert manager.turn_limit == 200
+        assert manager.turn_limit == 280
         assert list(manager.recent_outcomes) == [1, 0, 1]


### PR DESCRIPTION
### Motivation

- Reduce long-game stalling and reward-farming by introducing urgency and anti-stall penalties and by capping loopable shaping rewards.
- Make entropy regularisation stage-aware so harder curriculum stages consolidate policies with less exploration.
- Add stage-5 curriculum mixing and automatic rollback to improve stability when the hardest stage is failing.

### Description

- Added new configuration constants in `config.py` for entropy schedule (`ENTROPY_WEIGHT_SCHEDULE`), urgency and anti-stall controls (`URGENCY_PENALTY_START_FRAC`, `URGENCY_PENALTY_BASE`, `NO_PROGRESS_WINDOW`, `NO_PROGRESS_PENALTY`, `REPEATED_STATE_THRESHOLD`, `REPEATED_STATE_PENALTY`), caps (`HOME_ENTRY_PROGRESS_CAP`, `CAPTURE_REWARD_CAP`), and stage-5 controls (`STAGE5_MIX_FROM_GAME`, `STAGE5_MIX_LOWER_STAGE_RATIO`, `STAGE5_ROLLBACK_MIN_GAMES`, `STAGE5_ROLLBACK_DECISIVE_RATE`).
- Environment changes in `GameEnvironment` implement a compact `_state_signature` for repetition detection, per-episode `state_visit_counts` telemetry, `total_state_visits`/`unique_state_visits`, repeated-state penalty application, no-progress penalty windowing, capping of captured/home-entry rewards, and a ramping `urgency` penalty near the turn budget; resets and telemetry are cleared in `reset_reward_events`.
- Bot change: added `GameBot.set_entropy_weight` to allow runtime adjustment of the PPO entropy regulariser.
- Trainer changes in `TrainingManager` include `_apply_entropy_schedule` to set entropy per difficulty, `_episode_piece_count` to optionally mix easier games during stage 5, applying entropy and episode-piece counting at episode start, using episode-specific turn limits in the episode loop and timeout penalties, adding stage-5 rollback logic that demotes from 5 to 4 pieces when decisive-rate criteria fail, and additional telemetry fields (e.g. `no_progress_penalties`, `state_repeat_penalties`, `unique_state_ratio`, `near_finish_timeout`).
- Miscellaneous: save/load and snapshot glue adjusted to restore turn limits using `_turn_limit_for_pieces` and training stats handling updated accordingly.
- Test update: the expected `turn_limit` in `tests/test_trainer.py::test_load_models_restores_training_state` was updated to reflect the `TURN_LIMIT_SCHEDULE` lookup (expected value `280`).

### Testing

- Ran the unit test `tests/test_trainer.py::test_load_models_restores_training_state` after the change and it passed with the updated expected turn limit.
- Ran the repository unit test suite with `pytest` and verified that updated trainer/environment tests and related unit tests passed (no regressions observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9954ed7b8832abfbd5d601239e981)