### PR TITLE
Curriculum stability: confirmation windows, stage5 turn boost, and checkpointing by games_played

### DIFF
--- a/game-ai-training/ai/trainer.py
+++ b/game-ai-training/ai/trainer.py
@@ -30,6 +30,9 @@ from config import (
     STAGE5_MIX_LOWER_STAGE_RATIO,
     STAGE5_ROLLBACK_MIN_GAMES,
     STAGE5_ROLLBACK_DECISIVE_RATE,
+    STAGE_PROMOTION_CONFIRM_WINDOWS,
+    STAGE5_ROLLBACK_CONFIRM_WINDOWS,
+    STAGE5_TURN_LIMIT_BOOST,
 )
 from json_logger import info, warning
 import random
@@ -142,6 +145,8 @@ class TrainingManager:
         # Reward multiplier per difficulty level
         self.level_reward_multiplier = {}
         self.curriculum_rollback_count = 0
+        self.promotion_streak = 0
+        self.rollback_streak = 0
 
     def _stats_interval(self) -> int:
         """Return plotting interval based on current piece count."""
@@ -150,7 +155,10 @@ class TrainingManager:
     def _turn_limit_for_pieces(self, pieces: int) -> int:
         """Return turn limit for the given curriculum stage."""
         pieces = max(1, min(5, int(pieces)))
-        return int(TURN_LIMIT_SCHEDULE.get(pieces, 120 * pieces))
+        limit = int(TURN_LIMIT_SCHEDULE.get(pieces, 120 * pieces))
+        if pieces == 5:
+            limit += int(STAGE5_TURN_LIMIT_BOOST)
+        return limit
 
     
     def create_bots(self, num_bots=4):
@@ -593,6 +601,13 @@ class TrainingManager:
             and self.stage_games >= STAGE5_ROLLBACK_MIN_GAMES
             and decisive_rate < STAGE5_ROLLBACK_DECISIVE_RATE
         ):
+            self.rollback_streak += 1
+        else:
+            self.rollback_streak = 0
+        if (
+            self.pieces_per_player == 5
+            and self.rollback_streak >= STAGE5_ROLLBACK_CONFIRM_WINDOWS
+        ):
             self.pieces_per_player = 4
             self.turn_limit = self._turn_limit_for_pieces(self.pieces_per_player)
             for rollback_env in [self.env] + self.envs:
@@ -603,6 +618,8 @@ class TrainingManager:
             self.recent_outcomes.clear()
             self.recent_timeouts.clear()
             self.recent_trainable_wins.clear()
+            self.rollback_streak = 0
+            self.promotion_streak = 0
             self.curriculum_rollback_count += 1
             warning(
                 "Curriculum rollback triggered",
@@ -614,6 +631,13 @@ class TrainingManager:
         if (
             self.stage_games >= 5000
             and decisive_rate >= 0.55
+            and self.pieces_per_player < 5
+        ):
+            self.promotion_streak += 1
+        else:
+            self.promotion_streak = 0
+        if (
+            self.promotion_streak >= STAGE_PROMOTION_CONFIRM_WINDOWS
             and self.pieces_per_player < 5
         ):
             self.pieces_per_player += 1
@@ -633,6 +657,8 @@ class TrainingManager:
             self.recent_outcomes.clear()
             self.recent_timeouts.clear()
             self.recent_trainable_wins.clear()
+            self.promotion_streak = 0
+            self.rollback_streak = 0
             promoted = True
             info(
                 "Increased difficulty",
@@ -770,6 +796,17 @@ class TrainingManager:
 
         info("Starting training", episodes=num_episodes, envs=num_envs)
 
+        def _next_checkpoint(target: int, interval: int) -> int:
+            """Return the next positive multiple of interval strictly above target."""
+            if interval <= 0:
+                return 0
+            return ((max(0, int(target)) // interval) + 1) * interval
+
+        initial_games = int(self.training_stats.get('games_played', 0))
+        next_snapshot_at = _next_checkpoint(initial_games, self.snapshot_freq)
+        next_save_at = _next_checkpoint(initial_games, save_freq)
+        next_stats_at = _next_checkpoint(initial_games, self._stats_interval())
+
         if num_envs <= 1:
             # Start the single environment
             if not self.env.start_node_game():
@@ -778,23 +815,28 @@ class TrainingManager:
 
             try:
                 for episode in range(num_episodes):
-                    self._apply_reward_schedule(episode, self.env)
+                    current_games = int(self.training_stats.get('games_played', 0))
+                    self._apply_reward_schedule(current_games, self.env)
                     self.train_episode(self.env)
+                    total_games = int(self.training_stats.get('games_played', 0))
 
-                    if (episode + 1) % self.snapshot_freq == 0:
-                        self.save_snapshot(episode + 1)
+                    if next_snapshot_at > 0 and total_games >= next_snapshot_at:
+                        self.save_snapshot(total_games)
+                        next_snapshot_at += self.snapshot_freq
 
                     interval = self._stats_interval()
-                    if (episode + 1) % interval == 0:
-                        self.print_statistics(episode + 1)
+                    while next_stats_at > 0 and total_games >= next_stats_at:
+                        self.print_statistics(total_games)
                         self.plot_training_progress()
+                        next_stats_at += interval
 
-                    if (episode + 1) % save_freq == 0:
-                        self.save_models(f"{MODEL_DIR}/episode_{episode + 1}")
+                    if next_save_at > 0 and total_games >= next_save_at:
+                        self.save_models(f"{MODEL_DIR}/episode_{total_games}")
+                        next_save_at += save_freq
                         if save_match_log:
                             log_file = os.path.join(
                                 LOG_DIR,
-                                f"episode_{episode + 1}_env_{self.env.env_id}.log"
+                                f"episode_{total_games}_env_{self.env.env_id}.log"
                             )
                             self.env.save_history(log_file)
 
@@ -821,28 +863,31 @@ class TrainingManager:
 
             try:
                 for episode in range(num_episodes):
+                    current_games = int(self.training_stats.get('games_played', 0))
                     for env in self.envs:
-                        self._apply_reward_schedule(episode, env)
+                        self._apply_reward_schedule(current_games, env)
                     with ThreadPoolExecutor(max_workers=num_envs) as executor:
                         list(executor.map(self.train_episode, self.envs))
+                    total_games = int(self.training_stats.get('games_played', 0))
 
-                    if (episode + 1) % self.snapshot_freq == 0:
-                        self.save_snapshot((episode + 1) * num_envs)
+                    if next_snapshot_at > 0 and total_games >= next_snapshot_at:
+                        self.save_snapshot(total_games)
+                        next_snapshot_at += self.snapshot_freq
 
                     interval = self._stats_interval()
-                    if (episode + 1) % interval == 0:
-                        self.print_statistics((episode + 1) * num_envs)
+                    while next_stats_at > 0 and total_games >= next_stats_at:
+                        self.print_statistics(total_games)
                         self.plot_training_progress()
+                        next_stats_at += interval
 
-                    if (episode + 1) % save_freq == 0:
-                        self.save_models(
-                            f"{MODEL_DIR}/episode_{(episode + 1) * num_envs}"
-                        )
+                    if next_save_at > 0 and total_games >= next_save_at:
+                        self.save_models(f"{MODEL_DIR}/episode_{total_games}")
+                        next_save_at += save_freq
                         if save_match_log:
                             for env in self.envs:
                                 log_file = os.path.join(
                                     LOG_DIR,
-                                    f"episode_{(episode + 1) * num_envs}_env_{env.env_id}.log"
+                                    f"episode_{total_games}_env_{env.env_id}.log"
                                 )
                                 env.save_history(log_file)
 

--- a/game-ai-training/config.py
+++ b/game-ai-training/config.py
@@ -73,6 +73,9 @@ STAGE5_MIX_FROM_GAME = 1000
 STAGE5_MIX_LOWER_STAGE_RATIO = 0.25
 STAGE5_ROLLBACK_MIN_GAMES = 2500
 STAGE5_ROLLBACK_DECISIVE_RATE = 0.08
+STAGE_PROMOTION_CONFIRM_WINDOWS = 3
+STAGE5_ROLLBACK_CONFIRM_WINDOWS = 4
+STAGE5_TURN_LIMIT_BOOST = 200
 
 # Event-based reward weights used by ``GameEnvironment``. The environment
 # computes a weighted sum and then clips the total to reduce reward spikes.


### PR DESCRIPTION
### Motivation
- Reduce noisy oscillations when promoting or rolling back curriculum stages by requiring consecutive confirmation windows before changing piece count.  
- Slightly relax final-stage pacing by adding a turn-limit boost for stage 5 to give agents more time for decisive play.  
- Make snapshot/save/statistics scheduling align with the actual number of games played rather than loop episode indices so checkpoints remain consistent across restarts and multi-env runs.

### Description
- Added new configuration keys `STAGE_PROMOTION_CONFIRM_WINDOWS`, `STAGE5_ROLLBACK_CONFIRM_WINDOWS`, and `STAGE5_TURN_LIMIT_BOOST` and applied them in `config.py`.  
- Introduced `promotion_streak` and `rollback_streak` counters and changed the promotion/rollback logic to require consecutive confirmation windows and reset streaks appropriately in `trainer.py`.  
- Applied the `STAGE5_TURN_LIMIT_BOOST` in `_turn_limit_for_pieces` so stage 5 gets additional turns and updated environment piece/turn adjustments when promoting or rolling back.  
- Reworked snapshot/save/statistics checkpointing to compute the next checkpoint from `training_stats['games_played']` using a new helper `_next_checkpoint`, switch scheduling to the `games_played` counter, and update filenames to use total games played; also switched calls to `_apply_reward_schedule` to use current games played.

### Testing
- Ran the project's unit test suite with `pytest` and the tests completed successfully.  
- Performed a small smoke training run (`train(num_episodes=10, num_envs=1)`) to verify checkpointing, promotion/rollback counters, and snapshot/save behavior, and the run completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f39ced6600832a9969b90ae7cde79e)