### PR TITLE
Tune training hyperparameters and increase default parallel environments

### DIFF
--- a/game-ai-training/config.py
+++ b/game-ai-training/config.py
@@ -3,11 +3,11 @@ TRAINING_CONFIG = {
     'num_episodes': 5000,
     'save_frequency': 500,
     'stats_frequency': 10,
-    'learning_rate': 1e-4,
-    'batch_size': 64,
-    'memory_size': 10000,
+    'learning_rate': 7e-5,
+    'batch_size': 128,
+    'memory_size': 50000,
     'gamma': 0.95,
-    'hidden_size': 512,
+    'hidden_size': 1024,
     'train_freq': 4,
     'ppo_clip': 0.08,
     # Slight entropy bonus to maintain exploration without destabilising updates.
@@ -19,7 +19,7 @@ TRAINING_CONFIG = {
     # Defaulting to a relatively high value keeps updates infrequent
     # but allows quick overrides in custom configs.
     'update_target_freq': 1000,
-    'lr_final': 1e-5
+    'lr_final': 7e-6
 }
 
 # Piece-dependent entropy regularization. Harder stages use lower entropy so

--- a/game-ai-training/main.py
+++ b/game-ai-training/main.py
@@ -15,8 +15,8 @@ def main():
     parser.add_argument(
         "--num_envs",
         type=int,
-        default=1,
-        help="Number of parallel environments to run",
+        default=4,
+        help="Number of parallel environments to run (default tuned for multi-GPU hosts)",
     )
     parser.add_argument(
         "--fixed-model-dir",


### PR DESCRIPTION
### Motivation

- Improve training stability and convergence by reducing learning rates and increasing model capacity and replay memory.
- Increase throughput on multi-GPU/multi-core hosts by running more environments in parallel by default.

### Description

- Adjusted `TRAINING_CONFIG` hyperparameters: `learning_rate` set to `7e-5`, `batch_size` set to `128`, and `memory_size` set to `50000`.
- Increased model capacity by changing `hidden_size` from `512` to `1024` and lowered final learning rate `lr_final` to `7e-6`.
- Left other RL-specific knobs unchanged (e.g. `gamma`, `ppo_clip`, `entropy_weight`, `kl_target`, and `update_target_freq`).
- Changed the default `--num_envs` in `main.py` from `1` to `4` and updated the help text to indicate the default is tuned for multi-GPU hosts.

### Testing

- Ran the project's automated test suite with `pytest -q` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4c0e9e6e8832a8e96ac5ebc619c06)