### PR TITLE
Shape rewards for smart 7/8 card play and disable periodic plotting

### DIFF
--- a/game-ai-training/README.md
+++ b/game-ai-training/README.md
@@ -59,16 +59,18 @@ Training logs record how many times each of the following events occurs:
 - Completing a piece (+50 points).
 - Choosing to skip a possible homestretch entry (−1 point).
 
-All other rewards and penalties from earlier revisions have been removed to
-keep the signal easy to interpret. The per‑episode breakdown plot still shows
-the contribution of each event type.
+Additional tactical shaping rewards guide card-specific play without relying on
+periodic plot image checks. The trainer still records per-event reward totals in
+`training_stats.json`, but it no longer saves training-progress plot images at
+statistics intervals or at the end of training.
 
-The entropy of the event counts is plotted to help detect reward starvation. A
-per‑episode breakdown subplot shows the reward contribution of **every** event
-type. Positive values stack upward while negative values stack below zero. Each
-reward type uses a distinct color from Matplotlib's `tab20` palette so negative
-events are no longer lumped into a single “other” category.
-A small heavy reward now boosts impactful plays to help guide the bots.
+Seven-card bonuses now require concrete impact: capturing, entering the home
+stretch, or completing a piece. Low-impact seven plays receive a small smart-card
+misuse penalty instead of generic movement shaping. Eight-card plays receive
+extra reward when they capture or newly place a piece within reach of the home
+stretch; otherwise they receive the same small penalty. A one-turn setup bonus
+multiplies the next home-entry reward when the previous play by that player was
+an 8 that moved the piece from outside entry reach to within entry reach.
 
 Every 100 episodes the trainer now logs the cumulative reward totals for each
 event type. These summaries are useful when sharing progress logs for further

--- a/game-ai-training/ai/environment.py
+++ b/game-ai-training/ai/environment.py
@@ -34,12 +34,16 @@ from config import (
 PIECE_COMPLETION_REWARD = 50.0
 # Only penalty currently applied when a bot rejects a homestretch entry
 SKIP_HOME_PENALTY = -1.0
-# Extra shaping for learning the 7-card split mechanic. The base bonus rewards
-# using a 7 as a true split, while the stronger bonuses emphasize splits that
-# convert outside pieces into the home stretch or finish pieces already there.
+# Extra shaping for learning card-specific tactics. Seven-card rewards only
+# apply when the card creates concrete impact; otherwise the move receives a
+# small penalty so bots learn not to burn sevens on low-value movement.
 SEVEN_SPLIT_REWARD = 4.0
 SEVEN_SPLIT_HOME_ENTRY_REWARD = 10.0
 SEVEN_SPLIT_COMPLETION_REWARD = 18.0
+SMART_CARD_MISUSE_PENALTY = -1.0
+EIGHT_CARD_REACH_REWARD = 6.0
+EIGHT_CARD_CAPTURE_BONUS = 4.0
+EIGHT_HOME_ENTRY_MULTIPLIER = 4.0
 
 # The following constants remain for compatibility but do not affect rewards
 HOME_ENTRY_REWARD = 0.0
@@ -146,6 +150,7 @@ class GameEnvironment:
         self.reward_event_counts = {
             'home_completion': 0,
             'piece_completion_bonus': 0,
+            'home_entry': 0,
             'near_finish': 0,
             'skip_home': 0,
             'home_entry_progress': 0,
@@ -154,6 +159,11 @@ class GameEnvironment:
             'seven_split': 0,
             'seven_split_home_entry': 0,
             'seven_split_completion': 0,
+            'seven_card_penalty': 0,
+            'eight_card_reach': 0,
+            'eight_card_capture': 0,
+            'eight_card_penalty': 0,
+            'eight_home_entry_boost': 0,
             'long_game': 0,
             'win': 0,
             'loss': 0,
@@ -163,6 +173,7 @@ class GameEnvironment:
         self.reward_event_totals = {
             'home_completion': 0.0,
             'piece_completion_bonus': 0.0,
+            'home_entry': 0.0,
             'near_finish': 0.0,
             'skip_home': 0.0,
             'home_entry_progress': 0.0,
@@ -171,6 +182,11 @@ class GameEnvironment:
             'seven_split': 0.0,
             'seven_split_home_entry': 0.0,
             'seven_split_completion': 0.0,
+            'seven_card_penalty': 0.0,
+            'eight_card_reach': 0.0,
+            'eight_card_capture': 0.0,
+            'eight_card_penalty': 0.0,
+            'eight_home_entry_boost': 0.0,
             'long_game': 0.0,
             'win': 0.0,
             'loss': 0.0,
@@ -212,6 +228,10 @@ class GameEnvironment:
         self.last_step_info: Dict[str, float] = {}
         # Cache legal actions so state encoding can include action metadata.
         self.last_valid_actions: Dict[int, List[int]] = {}
+        # Tracks one-turn 8-card setup opportunities by player. A setup is
+        # consumed on that player's next action so it cannot be farmed by
+        # repeatedly moving away and back.
+        self.pending_eight_setups: List[Optional[Dict[str, Any]]] = [None] * 4
         # Episode-level anti-stall telemetry.
         self.state_visit_counts: Dict[str, int] = {}
         self.total_state_visits = 0
@@ -285,6 +305,27 @@ class GameEnvironment:
         """Return ``True`` if ``pos`` lies within the player's entry zone."""
         steps = self._steps_to_entrance(pos, player_id)
         return 0 <= steps <= 10
+
+    def _within_home_entry_reach(self, piece: Dict[str, Any]) -> bool:
+        """Return whether a piece can enter home stretch with a common forward card."""
+        if (
+            piece.get('inPenaltyZone', piece.get('in_penalty'))
+            or piece.get('inHomeStretch', piece.get('in_home'))
+            or piece.get('completed')
+        ):
+            return False
+        owner = int(piece.get('playerId', piece.get('player_id', -1)))
+        if not (0 <= owner < len(self._entrances)):
+            return False
+        pos = piece.get('position') or piece.get('pos') or {}
+        steps_to_entry = self._steps_to_entrance(pos, owner)
+        if steps_to_entry < 0:
+            return False
+        for card_steps in (1, 2, 3, 4, 5, 6, 7, 9, 10):
+            remaining = card_steps - steps_to_entry
+            if 1 <= remaining <= 5:
+                return True
+        return False
 
     def _is_start_square(self, pos: Dict[str, int], player_id: int) -> bool:
         """Return ``True`` if ``pos`` is the starting square for ``player_id``."""
@@ -758,6 +799,8 @@ class GameEnvironment:
                         'in_home': p.get('inHomeStretch'),
                         'in_penalty': p.get('inPenaltyZone'),
                         'completed': p.get('completed'),
+                        'playerId': pid,
+                        'within_home_reach': self._within_home_entry_reach(p),
                     }
 
         for pid, count in enumerate(prev_completed_players):
@@ -907,8 +950,14 @@ class GameEnvironment:
             else:
                 opponent_team.extend(seats)
 
-        capture_occurred = bool(response.get('captures'))
+        captures = response.get('captures') or []
+        capture_occurred = bool(captures)
+        played_card_value = response.get('playedCardValue')
         special_move = response.get('specialMove') if isinstance(response, dict) else None
+        if isinstance(special_move, dict) and special_move.get('cardValue'):
+            played_card_value = special_move.get('cardValue')
+        seven_card_played = played_card_value == '7'
+        eight_card_played = played_card_value == '8'
         seven_split_played = bool(
             isinstance(special_move, dict)
             and special_move.get('cardValue') == '7'
@@ -920,6 +969,9 @@ class GameEnvironment:
         seven_split_reward = 0.0
         seven_split_home_entries = 0
         seven_split_completions = 0
+        home_entry_reward = 0.0
+        home_entry_piece_ids: List[str] = []
+        eight_new_reach_count = 0
         new_pieces = {p['id']: p for p in self.game_state.get('pieces', [])}
         for pid, prev in prev_pieces.items():
             new = new_pieces.get(pid)
@@ -937,8 +989,28 @@ class GameEnvironment:
                 self.reward_event_totals['piece_completion_bonus'] += PIECE_COMPLETION_BONUS
                 if seven_split_played and prev.get('in_home'):
                     seven_split_completions += 1
-            if seven_split_played and not prev.get('in_home') and new.get('inHomeStretch'):
+            entered_home = not prev.get('in_home') and new.get('inHomeStretch')
+            if entered_home:
+                home_entry_piece_ids.append(pid)
+                entry_reward = REWARD_WEIGHTS.get('home_entry', 0.0)
+                pending_setup = self.pending_eight_setups[player_id]
+                if (
+                    pending_setup
+                    and pending_setup.get('piece_id') == pid
+                    and pending_setup.get('from_out_of_reach')
+                ):
+                    boosted_reward = entry_reward * EIGHT_HOME_ENTRY_MULTIPLIER
+                    boost_delta = boosted_reward - entry_reward
+                    entry_reward = boosted_reward
+                    self.reward_event_counts['eight_home_entry_boost'] += 1
+                    self.reward_event_totals['eight_home_entry_boost'] += boost_delta
+                home_entry_reward += entry_reward
+                self.reward_event_counts['home_entry'] += 1
+                self.reward_event_totals['home_entry'] += entry_reward
+            if seven_split_played and entered_home:
                 seven_split_home_entries += 1
+            if eight_card_played and not prev.get('within_home_reach') and self._within_home_entry_reach(new):
+                eight_new_reach_count += 1
             prev_steps = self._steps_to_entrance(prev.get('pos') or {}, owner)
             new_steps = self._steps_to_entrance(new.get('position') or {}, owner)
             if prev_steps >= 0 and new_steps >= 0 and new_steps < prev_steps:
@@ -971,10 +1043,14 @@ class GameEnvironment:
             self.reward_event_totals['safe_move'] += safe_reward
             weighted_reward += safe_reward
 
-        if seven_split_played:
-            seven_split_reward += SEVEN_SPLIT_REWARD
-            self.reward_event_counts['seven_split'] += 1
-            self.reward_event_totals['seven_split'] += SEVEN_SPLIT_REWARD
+        if home_entry_reward > 0:
+            weighted_reward += home_entry_reward
+
+        if seven_card_played and (capture_occurred or home_entry_piece_ids or piece_reward > 0):
+            if seven_split_played:
+                seven_split_reward += SEVEN_SPLIT_REWARD
+                self.reward_event_counts['seven_split'] += 1
+                self.reward_event_totals['seven_split'] += SEVEN_SPLIT_REWARD
             if seven_split_home_entries > 0:
                 entry_reward = SEVEN_SPLIT_HOME_ENTRY_REWARD * seven_split_home_entries
                 seven_split_reward += entry_reward
@@ -986,6 +1062,44 @@ class GameEnvironment:
                 self.reward_event_counts['seven_split_completion'] += seven_split_completions
                 self.reward_event_totals['seven_split_completion'] += completion_reward
             weighted_reward += seven_split_reward
+        elif seven_card_played:
+            # Low-impact sevens should not earn generic progress/safety shaping;
+            # make the net outcome the normal step cost plus the smart-card
+            # penalty so the policy learns to save sevens for concrete impact.
+            weighted_reward -= progress_reward + safe_reward
+            weighted_reward += SMART_CARD_MISUSE_PENALTY
+            self.reward_event_counts['seven_card_penalty'] += 1
+            self.reward_event_totals['seven_card_penalty'] += SMART_CARD_MISUSE_PENALTY
+
+        if eight_card_played:
+            if capture_occurred:
+                eight_capture_bonus = EIGHT_CARD_CAPTURE_BONUS * len(captures)
+                weighted_reward += eight_capture_bonus
+                self.reward_event_counts['eight_card_capture'] += len(captures)
+                self.reward_event_totals['eight_card_capture'] += eight_capture_bonus
+            if eight_new_reach_count > 0:
+                reach_reward = EIGHT_CARD_REACH_REWARD * eight_new_reach_count
+                weighted_reward += reach_reward
+                self.reward_event_counts['eight_card_reach'] += eight_new_reach_count
+                self.reward_event_totals['eight_card_reach'] += reach_reward
+            if not capture_occurred and eight_new_reach_count == 0:
+                weighted_reward += SMART_CARD_MISUSE_PENALTY
+                self.reward_event_counts['eight_card_penalty'] += 1
+                self.reward_event_totals['eight_card_penalty'] += SMART_CARD_MISUSE_PENALTY
+
+        if eight_card_played and eight_new_reach_count > 0:
+            setup_piece_id = None
+            for pid, prev in prev_pieces.items():
+                new = new_pieces.get(pid)
+                if new and not prev.get('within_home_reach') and self._within_home_entry_reach(new):
+                    setup_piece_id = pid
+                    break
+            self.pending_eight_setups[player_id] = {
+                'piece_id': setup_piece_id,
+                'from_out_of_reach': True,
+            }
+        else:
+            self.pending_eight_setups[player_id] = None
 
         weighted_reward += piece_reward
 
@@ -1063,7 +1177,9 @@ class GameEnvironment:
         progress_happened = (
             piece_reward > 0
             or progress_reward > 0
+            or home_entry_reward > 0
             or seven_split_reward > 0
+            or eight_new_reach_count > 0
             or capture_occurred
             or self.reward_event_counts.get('near_finish', 0) > 0
         )
@@ -1139,6 +1255,7 @@ class GameEnvironment:
         for key in self.heavy_reward_breakdown:
             self.heavy_reward_breakdown[key] = 0
         self.pending_penalties = [0.0] * 4
+        self.pending_eight_setups = [None] * 4
         self.next_penalty_check = 60
         self.completion_delay_turns = [0, 0]
         self.no_progress_steps = [

--- a/game-ai-training/ai/trainer.py
+++ b/game-ai-training/ai/trainer.py
@@ -149,7 +149,7 @@ class TrainingManager:
         self.rollback_streak = 0
 
     def _stats_interval(self) -> int:
-        """Return plotting interval based on current piece count."""
+        """Return statistics logging interval based on current piece count."""
         return 500 if self.pieces_per_player < 4 else 100
 
     def _turn_limit_for_pieces(self, pieces: int) -> int:
@@ -827,7 +827,6 @@ class TrainingManager:
                     interval = self._stats_interval()
                     while next_stats_at > 0 and total_games >= next_stats_at:
                         self.print_statistics(total_games)
-                        self.plot_training_progress()
                         next_stats_at += interval
 
                     if next_save_at > 0 and total_games >= next_save_at:
@@ -842,7 +841,6 @@ class TrainingManager:
 
                 info("Training completed")
                 self.save_models(f"{MODEL_DIR}/final")
-                self.plot_training_progress()
 
             finally:
                 self.env.close()
@@ -877,7 +875,6 @@ class TrainingManager:
                     interval = self._stats_interval()
                     while next_stats_at > 0 and total_games >= next_stats_at:
                         self.print_statistics(total_games)
-                        self.plot_training_progress()
                         next_stats_at += interval
 
                     if next_save_at > 0 and total_games >= next_save_at:
@@ -893,7 +890,6 @@ class TrainingManager:
 
                 info("Training completed")
                 self.save_models(f"{MODEL_DIR}/final")
-                self.plot_training_progress()
 
             finally:
                 for env in self.envs:

--- a/game-ai-training/config.py
+++ b/game-ai-training/config.py
@@ -85,6 +85,9 @@ REWARD_WEIGHTS = {
     'home_completion': 35.0,
     # Discourage skipping a valid home entry.
     'skip_home': -1.0,
+    # Reward entering the home stretch; this is boosted when it follows
+    # an 8-card setup that newly put the piece within entry reach.
+    'home_entry': 8.0,
     # Small tactical bonuses to improve credit assignment.
     'home_entry_progress': 1.0,
     'capture': 4.0,

--- a/game-ai-training/game/game_wrapper.js
+++ b/game-ai-training/game/game_wrapper.js
@@ -720,7 +720,8 @@ class GameWrapper {
                 captures: result && result.captures ? result.captures : [],
                 gameState: this.getGameState(),
                 gameEnded,
-                winningTeam
+                winningTeam,
+                playedCardValue: playedCard ? playedCard.value : null
             };
 
             if (gameEnded) {

--- a/game-ai-training/tests/test_environment.py
+++ b/game-ai-training/tests/test_environment.py
@@ -8,8 +8,11 @@ from ai.environment import (
     SEVEN_SPLIT_HOME_ENTRY_REWARD,
     SEVEN_SPLIT_REWARD,
     SKIP_HOME_PENALTY,
+    SMART_CARD_MISUSE_PENALTY,
+    EIGHT_CARD_REACH_REWARD,
+    EIGHT_HOME_ENTRY_MULTIPLIER,
 )
-from config import STEP_PENALTY_BASE, PIECE_COMPLETION_BONUS
+from config import STEP_PENALTY_BASE, PIECE_COMPLETION_BONUS, REWARD_WEIGHTS
 
 
 def test_reset_returns_zero_when_start_fails():
@@ -168,7 +171,12 @@ def test_seven_split_home_entry_reward():
             with patch.object(env, 'get_state', return_value=np.zeros(env.state_size)):
                 _, reward, _ = env.step(60, 0)
 
-    expected = step_cost + SEVEN_SPLIT_REWARD + SEVEN_SPLIT_HOME_ENTRY_REWARD
+    expected = (
+        step_cost
+        + REWARD_WEIGHTS['home_entry']
+        + SEVEN_SPLIT_REWARD
+        + SEVEN_SPLIT_HOME_ENTRY_REWARD
+    )
     assert reward == pytest.approx(expected)
     assert env.reward_event_counts['seven_split'] == 1
     assert env.reward_event_counts['seven_split_home_entry'] == 1
@@ -247,3 +255,133 @@ def test_seven_split_completion_reward_stacks_with_completion_reward():
     assert reward == pytest.approx(expected)
     assert env.reward_event_counts['seven_split'] == 1
     assert env.reward_event_counts['seven_split_completion'] == 1
+
+
+def test_unimpactful_seven_gets_penalty_without_split_bonus():
+    env = GameEnvironment()
+    step_cost = STEP_PENALTY_BASE * max(1.0, env.pieces_per_player / 2.0)
+    env.game_state = {
+        'pieces': [
+            {
+                'id': 'p0_1',
+                'playerId': 0,
+                'completed': False,
+                'inHomeStretch': False,
+                'inPenaltyZone': False,
+                'position': {'row': 0, 'col': 10},
+            },
+        ],
+        'teams': [[{'position': 0}, {'position': 2}], [{'position': 1}, {'position': 3}]],
+    }
+    env.player_team_map = {0: 0, 2: 0, 1: 1, 3: 1}
+    response = {
+        'success': True,
+        'specialMove': {
+            'cardValue': '7',
+            'split': True,
+            'moves': [{'pieceId': 'p0_1', 'steps': 7}],
+        },
+        'gameState': {
+            'pieces': [
+                {
+                    'id': 'p0_1',
+                    'playerId': 0,
+                    'completed': False,
+                    'inHomeStretch': False,
+                    'inPenaltyZone': False,
+                    'position': {'row': 0, 'col': 17},
+                },
+            ],
+            'teams': env.game_state['teams'],
+        },
+        'gameEnded': False,
+        'winningTeam': None,
+    }
+
+    with patch.object(env, 'send_command', return_value=response):
+        with patch.object(env, 'is_action_valid', return_value=True):
+            with patch.object(env, 'get_state', return_value=np.zeros(env.state_size)):
+                _, reward, _ = env.step(60, 0)
+
+    assert reward == pytest.approx(step_cost + SMART_CARD_MISUSE_PENALTY)
+    assert env.reward_event_counts['seven_split'] == 0
+    assert env.reward_event_counts['seven_card_penalty'] == 1
+
+
+def test_eight_setup_rewards_reach_and_boosts_next_home_entry():
+    env = GameEnvironment()
+    step_cost = STEP_PENALTY_BASE * max(1.0, env.pieces_per_player / 2.0)
+    env.game_state = {
+        'pieces': [
+            {
+                'id': 'p0_1',
+                'playerId': 0,
+                'completed': False,
+                'inHomeStretch': False,
+                'inPenaltyZone': False,
+                'position': {'row': 0, 'col': 12},
+            },
+        ],
+        'teams': [[{'position': 0}, {'position': 2}], [{'position': 1}, {'position': 3}]],
+    }
+    env.player_team_map = {0: 0, 2: 0, 1: 1, 3: 1}
+    eight_response = {
+        'success': True,
+        'playedCardValue': '8',
+        'gameState': {
+            'pieces': [
+                {
+                    'id': 'p0_1',
+                    'playerId': 0,
+                    'completed': False,
+                    'inHomeStretch': False,
+                    'inPenaltyZone': False,
+                    'position': {'row': 0, 'col': 4},
+                },
+            ],
+            'teams': env.game_state['teams'],
+        },
+        'gameEnded': False,
+        'winningTeam': None,
+    }
+
+    with patch.object(env, 'send_command', return_value=eight_response):
+        with patch.object(env, 'is_action_valid', return_value=True):
+            with patch.object(env, 'get_state', return_value=np.zeros(env.state_size)):
+                _, eight_reward, _ = env.step(0, 0)
+
+    assert eight_reward == pytest.approx(
+        step_cost + REWARD_WEIGHTS['home_entry_progress'] + EIGHT_CARD_REACH_REWARD
+    )
+    assert env.pending_eight_setups[0]['piece_id'] == 'p0_1'
+
+    env.game_state = eight_response['gameState']
+    entry_response = {
+        'success': True,
+        'playedCardValue': '2',
+        'gameState': {
+            'pieces': [
+                {
+                    'id': 'p0_1',
+                    'playerId': 0,
+                    'completed': False,
+                    'inHomeStretch': True,
+                    'inPenaltyZone': False,
+                    'position': {'row': 1, 'col': 4},
+                },
+            ],
+            'teams': env.game_state['teams'],
+        },
+        'gameEnded': False,
+        'winningTeam': None,
+    }
+
+    with patch.object(env, 'send_command', return_value=entry_response):
+        with patch.object(env, 'is_action_valid', return_value=True):
+            with patch.object(env, 'get_state', return_value=np.zeros(env.state_size)):
+                _, entry_reward, _ = env.step(0, 0)
+
+    expected_entry = step_cost + REWARD_WEIGHTS['home_entry'] * EIGHT_HOME_ENTRY_MULTIPLIER
+    assert entry_reward == pytest.approx(expected_entry)
+    assert env.reward_event_counts['eight_home_entry_boost'] == 1
+    assert env.pending_eight_setups[0] is None


### PR DESCRIPTION
### Motivation
- Remove automatic plot image generation during periodic stats to simplify training I/O and logs. 
- Make 7-card and 8-card rewards more tactical so bots are penalised for low-impact uses and rewarded for plays that enable concrete progress. 
- Encourage using an 8 to set up a real home-entry on the next turn by providing a one-turn boosted home-entry reward when an 8 newly places a piece within entry reach. 

### Description
- Disabled periodic plot saving by removing calls to `plot_training_progress()` from the stats checkpoint loop and final save in `game-ai-training/ai/trainer.py`. 
- Added new reward constants and counters in `game-ai-training/ai/environment.py` (`SMART_CARD_MISUSE_PENALTY`, `EIGHT_CARD_REACH_REWARD`, `EIGHT_CARD_CAPTURE_BONUS`, `EIGHT_HOME_ENTRY_MULTIPLIER`) and a `home_entry` reward event tracked in the environment and `REWARD_WEIGHTS` in `game-ai-training/config.py`. 
- Implemented card-aware shaping in `GameEnvironment.step`: detect played card via `playedCardValue` (now provided by the Node wrapper), apply a small penalty when a 7 is played without capturing/entering/completing, give extra rewards for 8 when it captures or newly places a piece within reach, and record one-turn `pending_eight_setups` so a subsequent home-entry can be multiplied. 
- Added helper `_within_home_entry_reach()` and bookkeeping (`pending_eight_setups`, new reward event counters/totals) and updated reward accumulation logic to ensure progress/shaping doesn't enable looping. 
- Passed `playedCardValue` from `game-ai-training/game/game_wrapper.js` responses so the Python environment can identify non-special card plays. 
- Updated documentation in `game-ai-training/README.md` to reflect the removal of periodic plot images and the new 7/8 shaping rules. 
- Added and adjusted unit tests in `game-ai-training/tests/test_environment.py` to cover: impactful seven rewards, low-impact seven penalty, 8-card reach reward and the one-turn boosted home-entry; also adjusted expected values to use `REWARD_WEIGHTS` where appropriate. 

### Testing
- Ran Python syntax checks: `python3 -m py_compile game-ai-training/ai/environment.py game-ai-training/ai/trainer.py` and they passed. 
- Ran the environment and training tests: `pytest game-ai-training/tests -q` and all tests passed. 
- Ran the JavaScript unit suite: `npm test -- --runInBand` from `game-ai-training` and all Jest suites passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fccc2dd698832a9b32451172107885)