### PR TITLE
Penalize smart-card discards when a bot is stuck in the penalty zone

### DIFF
--- a/game-ai-training/ai/environment.py
+++ b/game-ai-training/ai/environment.py
@@ -44,6 +44,8 @@ SMART_CARD_MISUSE_PENALTY = -1.0
 EIGHT_CARD_REACH_REWARD = 6.0
 EIGHT_CARD_CAPTURE_BONUS = 4.0
 EIGHT_HOME_ENTRY_MULTIPLIER = 4.0
+STUCK_SMART_CARD_DISCARD_PENALTY = -3.0
+STUCK_SMART_CARD_VALUES = {'JOKER', '8', '7'}
 
 # The following constants remain for compatibility but do not affect rewards
 HOME_ENTRY_REWARD = 0.0
@@ -164,6 +166,7 @@ class GameEnvironment:
             'eight_card_capture': 0,
             'eight_card_penalty': 0,
             'eight_home_entry_boost': 0,
+            'stuck_smart_card_discard': 0,
             'long_game': 0,
             'win': 0,
             'loss': 0,
@@ -187,6 +190,7 @@ class GameEnvironment:
             'eight_card_capture': 0.0,
             'eight_card_penalty': 0.0,
             'eight_home_entry_boost': 0.0,
+            'stuck_smart_card_discard': 0.0,
             'long_game': 0.0,
             'win': 0.0,
             'loss': 0.0,
@@ -702,6 +706,30 @@ class GameEnvironment:
             return [70 + i for i in range(max_discards)]
         return []
     
+    def _stuck_in_penalty_without_play_options(self, player_id: int) -> bool:
+        """Return True when a player has only forced discards from penalty zone."""
+        if not self.game_state:
+            return False
+
+        pieces = [
+            piece for piece in self.game_state.get('pieces', [])
+            if piece.get('playerId') == player_id and not piece.get('completed')
+        ]
+        if not pieces or not all(piece.get('inPenaltyZone', piece.get('in_penalty')) for piece in pieces):
+            return False
+
+        player = None
+        for candidate in self.game_state.get('players', []):
+            if candidate.get('position') == player_id:
+                player = candidate
+                break
+        if player is None and player_id < len(self.game_state.get('players', [])):
+            player = self.game_state.get('players', [])[player_id]
+
+        cards = (player or {}).get('cards') or []
+        exit_cards = {'A', 'K', 'Q', 'J'}
+        return not any(card.get('value') in exit_cards for card in cards if isinstance(card, dict))
+
     def get_valid_actions(self, player_id: int) -> List[int]:
         """Get valid actions for current player"""
         response = self.send_command({
@@ -807,6 +835,8 @@ class GameEnvironment:
             t_idx = self.player_team_map.get(pid)
             if t_idx is not None and 0 <= t_idx < len(prev_completed):
                 prev_completed[t_idx] += count
+
+        stuck_in_penalty_before = self._stuck_in_penalty_without_play_options(player_id)
 
         weighted_reward = 0.0
         # Keep late-game scaling neutral by default. Capture/progress rewards
@@ -958,6 +988,16 @@ class GameEnvironment:
             played_card_value = special_move.get('cardValue')
         seven_card_played = played_card_value == '7'
         eight_card_played = played_card_value == '8'
+        stuck_smart_card_discard = (
+            response.get('action') == 'discard'
+            and stuck_in_penalty_before
+            and played_card_value in STUCK_SMART_CARD_VALUES
+        )
+        if stuck_smart_card_discard:
+            weighted_reward += STUCK_SMART_CARD_DISCARD_PENALTY
+            self.reward_event_counts['stuck_smart_card_discard'] += 1
+            self.reward_event_totals['stuck_smart_card_discard'] += STUCK_SMART_CARD_DISCARD_PENALTY
+
         seven_split_played = bool(
             isinstance(special_move, dict)
             and special_move.get('cardValue') == '7'

--- a/game-ai-training/tests/test_environment.py
+++ b/game-ai-training/tests/test_environment.py
@@ -8,6 +8,7 @@ from ai.environment import (
     SEVEN_SPLIT_HOME_ENTRY_REWARD,
     SEVEN_SPLIT_REWARD,
     SKIP_HOME_PENALTY,
+    STUCK_SMART_CARD_DISCARD_PENALTY,
     SMART_CARD_MISUSE_PENALTY,
     EIGHT_CARD_REACH_REWARD,
     EIGHT_HOME_ENTRY_MULTIPLIER,
@@ -385,3 +386,100 @@ def test_eight_setup_rewards_reach_and_boosts_next_home_entry():
     assert entry_reward == pytest.approx(expected_entry)
     assert env.reward_event_counts['eight_home_entry_boost'] == 1
     assert env.pending_eight_setups[0] is None
+
+
+def test_stuck_penalty_zone_joker_discard_gets_smart_card_penalty():
+    env = GameEnvironment()
+    step_cost = STEP_PENALTY_BASE * max(1.0, env.pieces_per_player / 2.0)
+    env.game_state = {
+        'currentPlayerIndex': 0,
+        'players': [
+            {'position': 0, 'cards': [{'value': 'JOKER'}, {'value': '8'}, {'value': '7'}]},
+        ],
+        'pieces': [
+            {
+                'id': 'p0_1',
+                'playerId': 0,
+                'completed': False,
+                'inHomeStretch': False,
+                'inPenaltyZone': True,
+                'position': {'row': 2, 'col': 8},
+            },
+            {
+                'id': 'p0_2',
+                'playerId': 0,
+                'completed': False,
+                'inHomeStretch': False,
+                'inPenaltyZone': True,
+                'position': {'row': 1, 'col': 8},
+            },
+        ],
+        'teams': [[{'position': 0}, {'position': 2}], [{'position': 1}, {'position': 3}]],
+    }
+    env.player_team_map = {0: 0, 2: 0, 1: 1, 3: 1}
+    response = {
+        'success': True,
+        'action': 'discard',
+        'playedCardValue': 'JOKER',
+        'gameState': {
+            'players': [{'position': 0, 'cards': [{'value': '8'}, {'value': '7'}]}],
+            'pieces': env.game_state['pieces'],
+            'teams': env.game_state['teams'],
+        },
+        'gameEnded': False,
+        'winningTeam': None,
+    }
+
+    with patch.object(env, 'send_command', return_value=response):
+        with patch.object(env, 'is_action_valid', return_value=True):
+            with patch.object(env, 'get_state', return_value=np.zeros(env.state_size)):
+                _, reward, _ = env.step(70, 0)
+
+    assert reward == pytest.approx(step_cost + STUCK_SMART_CARD_DISCARD_PENALTY)
+    assert env.reward_event_counts['stuck_smart_card_discard'] == 1
+    assert env.reward_event_totals['stuck_smart_card_discard'] == pytest.approx(
+        STUCK_SMART_CARD_DISCARD_PENALTY
+    )
+
+
+def test_stuck_penalty_zone_smart_discard_not_penalized_when_exit_card_available():
+    env = GameEnvironment()
+    step_cost = STEP_PENALTY_BASE * max(1.0, env.pieces_per_player / 2.0)
+    env.game_state = {
+        'currentPlayerIndex': 0,
+        'players': [
+            {'position': 0, 'cards': [{'value': 'JOKER'}, {'value': 'A'}]},
+        ],
+        'pieces': [
+            {
+                'id': 'p0_1',
+                'playerId': 0,
+                'completed': False,
+                'inHomeStretch': False,
+                'inPenaltyZone': True,
+                'position': {'row': 2, 'col': 8},
+            },
+        ],
+        'teams': [[{'position': 0}, {'position': 2}], [{'position': 1}, {'position': 3}]],
+    }
+    env.player_team_map = {0: 0, 2: 0, 1: 1, 3: 1}
+    response = {
+        'success': True,
+        'action': 'discard',
+        'playedCardValue': 'JOKER',
+        'gameState': {
+            'players': [{'position': 0, 'cards': [{'value': 'A'}]}],
+            'pieces': env.game_state['pieces'],
+            'teams': env.game_state['teams'],
+        },
+        'gameEnded': False,
+        'winningTeam': None,
+    }
+
+    with patch.object(env, 'send_command', return_value=response):
+        with patch.object(env, 'is_action_valid', return_value=True):
+            with patch.object(env, 'get_state', return_value=np.zeros(env.state_size)):
+                _, reward, _ = env.step(70, 0)
+
+    assert reward == pytest.approx(step_cost)
+    assert env.reward_event_counts['stuck_smart_card_discard'] == 0


### PR DESCRIPTION
### Motivation
- Prevent bots from safely discarding high-value smart cards (JOKER, 8, 7) when they are trapped with all pieces in the penalty zone and no exit card, by giving a training penalty so policies learn not to waste tactical cards.

### Description
- Add `STUCK_SMART_CARD_DISCARD_PENALTY` and `STUCK_SMART_CARD_VALUES` to the reward config and register a new `stuck_smart_card_discard` event in `game-ai-training/ai/environment.py`.
- Implement a helper `_stuck_in_penalty_without_play_options(player_id)` that detects when a player has only forced discards available (all active pieces in penalty and no exit card in hand) and compute/apply the penalty when the environment observes a qualifying discard response.
- Increment `reward_event_counts` and `reward_event_totals` for the new penalty and apply the penalty to `weighted_reward` in the step logic.
- Add unit tests in `game-ai-training/tests/test_environment.py` covering a forced smart-card discard penalty and the case where an exit card prevents the penalty.

### Testing
- Ran `pytest game-ai-training/tests` which executed the environment and trainer tests; all tests passed (18 passed, 27 warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fddf4fca9c832a951d6e7b2bc5388b)