### PR TITLE
Introduce speed-based closing rewards, near-finish conversion bonus, and team terminal credit

### DIFF
--- a/game-ai-training/README.md
+++ b/game-ai-training/README.md
@@ -83,7 +83,8 @@ see whether incentivized events are increasing and discouraged actions are
 decreasing.
 
 The saved `training_stats.json` file now also includes per-episode curriculum
-telemetry fields that are useful for stage-aware analysis:
+telemetry fields that are useful for stage-aware analysis and speed-focused
+experiments:
 
 - `pieces_per_player`
 - `stage_games`
@@ -94,6 +95,8 @@ telemetry fields that are useful for stage-aware analysis:
 - `team_0_win` / `team_1_win`
 - `trainable_team_win_rate_window` / `fixed_team_win_rate_window`
 - `team_win_rate_diff_window`
+- `terminal_turns`
+- `near_finish_any_team` / `near_finish_timeout`
 - `reward_count_history`
 - `reward_event_best_stats`
 
@@ -106,13 +109,23 @@ scheduled values. This automatic tuning helps the curriculum progress without
 needing to manually edit the reward configuration.
 
 Timeout handling is also stage-aware: unresolved games now apply a negative
-timeout penalty that is scaled by the current piece count, and the turn limit
-uses a per-stage schedule from `config.py` to reduce premature truncation at
-higher piece counts.
+timeout penalty that is scaled by the current piece count and by a dynamic
+speed multiplier. The turn limit uses a per-stage schedule from `config.py` to
+reduce premature truncation at higher piece counts.
 
-To encourage faster resolution, the environment now applies a small per-step
-time cost and an additional fast-finish bonus when a winning team completes the
-game well before the current turn limit.
+To encourage faster resolution after the 7-card and 8-card tactical curriculum
+has plateaued, the speed preset now starts long-game pressure earlier, applies
+a stronger urgency penalty late in the turn budget, and grants a larger
+fast-finish bonus when a winning team completes the game well before the
+current turn limit. The trainer raises or lowers a separate speed multiplier
+when recent timeout rate or median terminal turn count shows that bots are
+not closing games quickly enough. Teammates on the winning team also receive
+terminal credit, so setup moves that enable the final action are reinforced.
+
+Near-finish rewards are counted exactly once per crossing and are now paired
+with a configurable conversion bonus when the team turns a near-finish state
+into a win within the conversion window. This makes the closing objective
+explicit without increasing 7-card or 8-card tactical weights again.
 
 ### Advantage Normalization
 

--- a/game-ai-training/ai/environment.py
+++ b/game-ai-training/ai/environment.py
@@ -20,6 +20,8 @@ from config import (
     FAST_FINISH_BONUS_SCALE,
     PIECE_COMPLETION_BONUS,
     NEAR_FINISH_BONUS,
+    NEAR_FINISH_CONVERSION_WINDOW,
+    NEAR_FINISH_CONVERSION_BONUS,
     URGENCY_PENALTY_START_FRAC,
     URGENCY_PENALTY_BASE,
     HOME_ENTRY_PROGRESS_CAP,
@@ -147,6 +149,7 @@ class GameEnvironment:
         # Reward scale no longer depends on piece count
         # Use a constant factor of ``1.0`` for all situations
         self.positive_reward_scale = 1.0
+        self.speed_reward_multiplier = 1.0
 
         # Track how often each reward type occurs for analysis
         self.reward_event_counts = {
@@ -154,6 +157,7 @@ class GameEnvironment:
             'piece_completion_bonus': 0,
             'home_entry': 0,
             'near_finish': 0,
+            'near_finish_conversion': 0,
             'skip_home': 0,
             'home_entry_progress': 0,
             'capture': 0,
@@ -178,6 +182,7 @@ class GameEnvironment:
             'piece_completion_bonus': 0.0,
             'home_entry': 0.0,
             'near_finish': 0.0,
+            'near_finish_conversion': 0.0,
             'skip_home': 0.0,
             'home_entry_progress': 0.0,
             'capture': 0.0,
@@ -236,6 +241,7 @@ class GameEnvironment:
         # consumed on that player's next action so it cannot be farmed by
         # repeatedly moving away and back.
         self.pending_eight_setups: List[Optional[Dict[str, Any]]] = [None] * 4
+        self.near_finish_turns: Dict[int, int] = {}
         # Episode-level anti-stall telemetry.
         self.state_visit_counts: Dict[str, int] = {}
         self.total_state_visits = 0
@@ -861,6 +867,7 @@ class GameEnvironment:
                 LONG_GAME_PENALTY_BASE
                 * float(tiers)
                 * max(1.0, self.pieces_per_player / 2.0)
+                * self.speed_reward_multiplier
             )
             weighted_reward += long_game_penalty
             self.reward_event_counts['long_game'] += 1
@@ -873,6 +880,7 @@ class GameEnvironment:
                     URGENCY_PENALTY_BASE
                     * (1.0 + (frac_used - URGENCY_PENALTY_START_FRAC) / max(1e-6, (1.0 - URGENCY_PENALTY_START_FRAC)))
                     * max(1.0, self.pieces_per_player / 2.0)
+                    * self.speed_reward_multiplier
                 )
                 weighted_reward += urgency
                 self.reward_event_totals['urgency'] = (
@@ -1168,6 +1176,7 @@ class GameEnvironment:
                 weighted_reward += NEAR_FINISH_BONUS
                 self.reward_event_counts['near_finish'] += 1
                 self.reward_event_totals['near_finish'] += NEAR_FINISH_BONUS
+                self.near_finish_turns.setdefault(my_idx, turn_index)
 
         if not done and teams_now:
             winner = self._check_team_completion(teams_now, new_completed)
@@ -1194,7 +1203,7 @@ class GameEnvironment:
                     turn_count = float(self.game_state.get('turnCount', step_count))
                     if self.turn_limit > 0:
                         speed_fraction = max(0.0, (self.turn_limit - turn_count) / self.turn_limit)
-                        fast_finish_bonus = FAST_FINISH_BONUS_SCALE * speed_fraction
+                        fast_finish_bonus = FAST_FINISH_BONUS_SCALE * speed_fraction * self.speed_reward_multiplier
                     else:
                         fast_finish_bonus = 0.0
                     if fast_finish_bonus > 0:
@@ -1208,6 +1217,24 @@ class GameEnvironment:
                             + fast_finish_bonus
                         )
                         self.last_step_info['fast_finish_bonus'] = fast_finish_bonus
+                    near_finish_turn = self.near_finish_turns.get(winning_idx)
+                    if near_finish_turn is not None:
+                        turns_to_convert = max(0, int(turn_count) - int(near_finish_turn))
+                        if turns_to_convert <= NEAR_FINISH_CONVERSION_WINDOW:
+                            remaining = max(
+                                0.0,
+                                (NEAR_FINISH_CONVERSION_BONUS * self.speed_reward_multiplier)
+                                * (1.0 - turns_to_convert / max(1.0, NEAR_FINISH_CONVERSION_WINDOW)),
+                            )
+                            if remaining > 0:
+                                weighted_reward += remaining
+                                self.reward_event_counts['near_finish_conversion'] += 1
+                                self.reward_event_totals['near_finish_conversion'] += remaining
+                                self.reward_bonus_totals['near_finish_conversion_bonus'] = (
+                                    self.reward_bonus_totals.get('near_finish_conversion_bonus', 0.0)
+                                    + remaining
+                                )
+                                self.last_step_info['near_finish_conversion_bonus'] = remaining
                 else:
                     loss_penalty = REWARD_WEIGHTS.get('loss', -10.0)
                     self.reward_event_counts['loss'] += 1
@@ -1296,6 +1323,7 @@ class GameEnvironment:
             self.heavy_reward_breakdown[key] = 0
         self.pending_penalties = [0.0] * 4
         self.pending_eight_setups = [None] * 4
+        self.near_finish_turns = {}
         self.next_penalty_check = 60
         self.completion_delay_turns = [0, 0]
         self.no_progress_steps = [
@@ -1315,6 +1343,10 @@ class GameEnvironment:
     def set_win_bonus(self, value: float) -> None:
         """Update the win bonus applied when a team wins."""
         self.win_bonus = float(value)
+
+    def set_speed_reward_multiplier(self, value: float) -> None:
+        """Update speed-related reward and penalty scaling."""
+        self.speed_reward_multiplier = max(0.1, float(value))
 
     def set_turn_limit(self, turns: int) -> None:
         """Update the maximum turns per episode."""

--- a/game-ai-training/ai/trainer.py
+++ b/game-ai-training/ai/trainer.py
@@ -24,6 +24,12 @@ from config import (
     MAX_REWARD_MULTIPLIER,
     MIN_REWARD_MULTIPLIER,
     REWARD_TUNE_STEP,
+    TIMEOUT_TUNE_TARGET,
+    SLOW_TERMINAL_TURN_FRAC,
+    MAX_SPEED_REWARD_MULTIPLIER,
+    MIN_SPEED_REWARD_MULTIPLIER,
+    SPEED_TUNE_STEP,
+    TEAM_TERMINAL_CREDIT_RATIO,
     TURN_LIMIT_SCHEDULE,
     ENTROPY_WEIGHT_SCHEDULE,
     STAGE5_MIX_FROM_GAME,
@@ -153,6 +159,7 @@ class TrainingManager:
 
         # Reward multiplier per difficulty level
         self.level_reward_multiplier = {}
+        self.level_speed_reward_multiplier = {}
         self.curriculum_rollback_count = 0
         self.promotion_streak = 0
         self.rollback_streak = 0
@@ -428,6 +435,9 @@ class TrainingManager:
         multiplier = self.level_reward_multiplier.get(self.pieces_per_player, 1.0)
         env.set_heavy_reward(weight * multiplier)
         env.set_win_bonus(WIN_BONUS * multiplier)
+        speed_multiplier = self.level_speed_reward_multiplier.get(self.pieces_per_player, 1.0)
+        if hasattr(env, 'set_speed_reward_multiplier'):
+            env.set_speed_reward_multiplier(speed_multiplier)
 
     def _apply_entropy_schedule(self) -> None:
         """Adjust trainable bots' entropy weight based on stage difficulty."""
@@ -451,22 +461,51 @@ class TrainingManager:
             return 4
         return self.pieces_per_player
 
-    def _adjust_reward_multiplier(self, win_rate: float, env: GameEnvironment) -> None:
-        """Update the reward multiplier based on the observed win rate."""
+    def _adjust_reward_multiplier(
+        self,
+        win_rate: float,
+        env: GameEnvironment,
+        timeout_rate: float = 0.0,
+        median_terminal_turns: float = 0.0,
+    ) -> None:
+        """Update reward multipliers based on win rate and closing speed."""
         level = self.pieces_per_player
         factor = self.level_reward_multiplier.get(level, 1.0)
+        speed_factor = self.level_speed_reward_multiplier.get(level, 1.0)
+        reasons = []
+
         if win_rate < WINRATE_TARGET:
             factor = min(factor + REWARD_TUNE_STEP, MAX_REWARD_MULTIPLIER)
-        elif win_rate > WINRATE_TARGET + 0.15:
+            reasons.append('low_trainable_win_rate')
+        elif win_rate > WINRATE_TARGET + 0.15 and timeout_rate <= TIMEOUT_TUNE_TARGET:
             factor = max(factor - REWARD_TUNE_STEP, MIN_REWARD_MULTIPLIER)
+            reasons.append('high_trainable_win_rate')
+
+        turn_budget = float(max(1, self._turn_limit_for_pieces(level)))
+        slow_terminal = bool(median_terminal_turns and median_terminal_turns >= turn_budget * SLOW_TERMINAL_TURN_FRAC)
+        if timeout_rate > TIMEOUT_TUNE_TARGET or slow_terminal:
+            speed_factor = min(speed_factor + SPEED_TUNE_STEP, MAX_SPEED_REWARD_MULTIPLIER)
+            if timeout_rate > TIMEOUT_TUNE_TARGET:
+                reasons.append('high_timeout_rate')
+            if slow_terminal:
+                reasons.append('slow_terminal_turns')
+        elif timeout_rate < TIMEOUT_TUNE_TARGET * 0.5 and not slow_terminal and win_rate >= WINRATE_TARGET:
+            speed_factor = max(speed_factor - SPEED_TUNE_STEP, MIN_SPEED_REWARD_MULTIPLIER)
+            reasons.append('stable_fast_closes')
+
         self.level_reward_multiplier[level] = factor
-        # Immediately apply the updated multiplier so the next episode reflects
+        self.level_speed_reward_multiplier[level] = speed_factor
+        # Immediately apply the updated multipliers so the next episode reflects
         # the change.
         self._apply_reward_schedule(self.training_stats['games_played'], env)
         info(
             "Reward multiplier adjusted",
             difficulty=level,
             multiplier=f"{factor:.2f}",
+            speed_multiplier=f"{speed_factor:.2f}",
+            timeout_rate=f"{timeout_rate:.2f}",
+            median_terminal_turns=f"{median_terminal_turns:.1f}",
+            reasons=sorted(set(reasons)) or ['unchanged'],
             heavy_reward=env.heavy_reward,
             win_bonus=env.win_bonus,
         )
@@ -574,6 +613,7 @@ class TrainingManager:
             if done and info_dict:
                 bonus += info_dict.get('win_bonus', 0.0)
                 bonus += info_dict.get('final_move_bonus', 0.0)
+                bonus += info_dict.get('near_finish_conversion_bonus', 0.0)
             reward += 0.01 * getattr(current_bot, 'last_entropy', 0.0)
             norm_reward = self._normalize_reward(reward)
 
@@ -592,8 +632,42 @@ class TrainingManager:
             # Update tracking
             states[current_player] = state
             actions[current_player] = action
-            episode_rewards[current_player] += reward + bonus
-            step_records.append((abs(reward + bonus), current_player, action, reward + bonus))
+            step_reward = reward + bonus
+            episode_rewards[current_player] += step_reward
+            if done and game_won:
+                winners = env.game_state.get('winningTeam') or []
+                winning_positions = [
+                    pl.get('position') for pl in winners if isinstance(pl, dict)
+                ]
+                team_credit = (
+                    (getattr(env, 'win_bonus', WIN_BONUS) or WIN_BONUS)
+                    * TEAM_TERMINAL_CREDIT_RATIO
+                )
+                for winner_pos in winning_positions:
+                    if winner_pos == current_player or not isinstance(winner_pos, int):
+                        continue
+                    if not (0 <= winner_pos < len(self.bots)):
+                        continue
+                    teammate_bot = self.bots[winner_pos]
+                    if not getattr(teammate_bot, 'trainable', True):
+                        continue
+                    episode_rewards[winner_pos] += team_credit
+                    env.reward_bonus_totals['team_terminal_credit_bonus'] = (
+                        env.reward_bonus_totals.get('team_terminal_credit_bonus', 0.0)
+                        + team_credit
+                    )
+                    if states[winner_pos] is not None and actions[winner_pos] is not None:
+                        teammate_next_state = env.get_state(winner_pos)
+                        teammate_bot.remember(
+                            states[winner_pos],
+                            actions[winner_pos],
+                            self._normalize_reward(team_credit),
+                            teammate_next_state,
+                            True,
+                            True,
+                            team_credit,
+                        )
+            step_records.append((abs(step_reward), current_player, action, step_reward))
             
             # Train bot
             current_bot.step_count += 1
@@ -625,7 +699,11 @@ class TrainingManager:
                 break
 
         if not env.game_state.get('gameEnded', False):
-            timeout_penalty = TIMEOUT_PENALTY * max(1, episode_pieces)
+            timeout_penalty = (
+                TIMEOUT_PENALTY
+                * max(1, episode_pieces)
+                * self.level_speed_reward_multiplier.get(self.pieces_per_player, 1.0)
+            )
             if env.reward_event_counts.get('near_finish', 0) > 0:
                 timeout_penalty *= 1.5
             for i in range(len(episode_rewards)):
@@ -696,7 +774,12 @@ class TrainingManager:
         # Tune rewards against the trainable bots' decisive win rate so the
         # curriculum reacts to "closing games" performance, not just whether
         # any team finished.
-        self._adjust_reward_multiplier(trainable_win_rate_decisive, env)
+        self._adjust_reward_multiplier(
+            trainable_win_rate_decisive,
+            env,
+            timeout_rate=timeout_rate,
+            median_terminal_turns=median_terminal_turns,
+        )
         info(
             "Curriculum progress",
             pieces=self.pieces_per_player,

--- a/game-ai-training/config.py
+++ b/game-ai-training/config.py
@@ -68,6 +68,19 @@ MIN_REWARD_MULTIPLIER = 0.5
 # Step size used when adjusting the reward multiplier up or down
 REWARD_TUNE_STEP = 0.1
 
+
+# Dynamic speed/closing tuning. These multipliers scale win-speed bonuses,
+# late-game urgency, long-game penalties, and unresolved timeout penalties.
+TIMEOUT_TUNE_TARGET = 0.25
+SLOW_TERMINAL_TURN_FRAC = 0.75
+MAX_SPEED_REWARD_MULTIPLIER = 2.0
+MIN_SPEED_REWARD_MULTIPLIER = 0.75
+SPEED_TUNE_STEP = 0.1
+
+# Terminal team credit for teammates who contributed earlier in the episode but
+# were not the actor on the final move.
+TEAM_TERMINAL_CREDIT_RATIO = 0.5
+
 # Curriculum bridge/rollback controls for the final stage.
 STAGE5_MIX_FROM_GAME = 1000
 STAGE5_MIX_LOWER_STAGE_RATIO = 0.25
@@ -105,23 +118,29 @@ PIECE_COMPLETION_BONUS = 12.0
 # but one piece. This creates a bridge between shaping rewards and final wins.
 NEAR_FINISH_BONUS = 10.0
 
+# Bonus for converting a near-finish state into a win soon after reaching it.
+NEAR_FINISH_CONVERSION_WINDOW = 32
+NEAR_FINISH_CONVERSION_BONUS = 18.0
+
 # Small per-step penalty to encourage faster game resolution.
 STEP_PENALTY_BASE = -0.01
 
 # Additional penalty for long-running games. Applied in increasing tiers every
 # ``LONG_GAME_PENALTY_INTERVAL`` turns once ``LONG_GAME_PENALTY_START`` is
 # reached, so stalling policies become progressively less attractive.
-LONG_GAME_PENALTY_START = 250
+LONG_GAME_PENALTY_START = 220
 LONG_GAME_PENALTY_INTERVAL = 50
 LONG_GAME_PENALTY_BASE = -0.02
 
 # Extra bonus awarded on wins that finish well before the turn limit.
-FAST_FINISH_BONUS_SCALE = 15.0
+FAST_FINISH_BONUS_SCALE = 25.0
 
 # Additional late-game urgency signal: penalty ramps up after
 # ``URGENCY_PENALTY_START_FRAC`` of the turn budget has been consumed.
+# Speed pressure is intentionally stronger than the baseline tactical-card
+# curriculum so policies that already find good plays learn to close sooner.
 URGENCY_PENALTY_START_FRAC = 0.70
-URGENCY_PENALTY_BASE = -0.15
+URGENCY_PENALTY_BASE = -0.20
 
 # Cap loopable shaping rewards to reduce farming behavior.
 HOME_ENTRY_PROGRESS_CAP = 120.0
@@ -134,7 +153,7 @@ REPEATED_STATE_THRESHOLD = 3
 REPEATED_STATE_PENALTY = -0.6
 
 # Clip range for the per-step weighted reward sum.
-REWARD_CLIP_RANGE = (-150.0, 150.0)
+REWARD_CLIP_RANGE = (-180.0, 180.0)
 
 # Multiplier applied to positive rewards based on the current
 # number of pieces per player. The curriculum increases the

--- a/game-ai-training/tests/test_environment.py
+++ b/game-ai-training/tests/test_environment.py
@@ -13,7 +13,13 @@ from ai.environment import (
     EIGHT_CARD_REACH_REWARD,
     EIGHT_HOME_ENTRY_MULTIPLIER,
 )
-from config import STEP_PENALTY_BASE, PIECE_COMPLETION_BONUS, REWARD_WEIGHTS
+from config import (
+    STEP_PENALTY_BASE,
+    PIECE_COMPLETION_BONUS,
+    REWARD_WEIGHTS,
+    NEAR_FINISH_BONUS,
+    NEAR_FINISH_CONVERSION_BONUS,
+)
 
 
 def test_reset_returns_zero_when_start_fails():
@@ -483,3 +489,148 @@ def test_stuck_penalty_zone_smart_discard_not_penalized_when_exit_card_available
 
     assert reward == pytest.approx(step_cost)
     assert env.reward_event_counts['stuck_smart_card_discard'] == 0
+
+
+def test_near_finish_reward_matches_logged_total():
+    env = GameEnvironment(pieces_per_player=1)
+    step_cost = STEP_PENALTY_BASE * max(1.0, env.pieces_per_player / 2.0)
+    env.game_state = {
+        'turnCount': 5,
+        'pieces': [
+            {
+                'id': 'p0_1',
+                'playerId': 0,
+                'completed': False,
+                'inHomeStretch': True,
+                'inPenaltyZone': False,
+                'position': {'row': 4, 'col': 4},
+            },
+            {
+                'id': 'p2_1',
+                'playerId': 2,
+                'completed': False,
+                'inHomeStretch': False,
+                'inPenaltyZone': False,
+                'position': {'row': 18, 'col': 10},
+            },
+        ],
+        'teams': [[{'position': 0}, {'position': 2}], [{'position': 1}, {'position': 3}]],
+    }
+    env.player_team_map = {0: 0, 2: 0, 1: 1, 3: 1}
+
+    response = {
+        'success': True,
+        'gameState': {
+            'turnCount': 6,
+            'pieces': [
+                {
+                    'id': 'p0_1',
+                    'playerId': 0,
+                    'completed': True,
+                    'inHomeStretch': True,
+                    'inPenaltyZone': False,
+                    'position': {'row': 5, 'col': 4},
+                },
+                {
+                    'id': 'p2_1',
+                    'playerId': 2,
+                    'completed': False,
+                    'inHomeStretch': False,
+                    'inPenaltyZone': False,
+                    'position': {'row': 18, 'col': 10},
+                },
+            ],
+            'teams': env.game_state['teams'],
+        },
+        'gameEnded': False,
+        'winningTeam': None,
+    }
+
+    with patch.object(env, 'send_command', return_value=response):
+        with patch.object(env, 'is_action_valid', return_value=True):
+            with patch.object(env, 'get_state', return_value=np.zeros(env.state_size)):
+                _, reward, _ = env.step(0, 0, step_count=5)
+
+    expected = step_cost + PIECE_COMPLETION_REWARD + PIECE_COMPLETION_BONUS + NEAR_FINISH_BONUS
+    assert reward == pytest.approx(expected)
+    assert env.reward_event_counts['near_finish'] == 1
+    assert env.reward_event_totals['near_finish'] == pytest.approx(NEAR_FINISH_BONUS)
+    assert env.near_finish_turns[0] == 5
+
+
+def test_near_finish_conversion_bonus_rewards_fast_close():
+    env = GameEnvironment(pieces_per_player=1)
+    step_cost = STEP_PENALTY_BASE * max(1.0, env.pieces_per_player / 2.0)
+    env.turn_limit = 100
+    env.near_finish_turns[0] = 10
+    env.game_state = {
+        'turnCount': 12,
+        'pieces': [
+            {
+                'id': 'p0_1',
+                'playerId': 0,
+                'completed': True,
+                'inHomeStretch': True,
+                'inPenaltyZone': False,
+                'position': {'row': 5, 'col': 4},
+            },
+            {
+                'id': 'p2_1',
+                'playerId': 2,
+                'completed': False,
+                'inHomeStretch': True,
+                'inPenaltyZone': False,
+                'position': {'row': 17, 'col': 14},
+            },
+        ],
+        'teams': [[{'position': 0}, {'position': 2}], [{'position': 1}, {'position': 3}]],
+    }
+    env.player_team_map = {0: 0, 2: 0, 1: 1, 3: 1}
+
+    response = {
+        'success': True,
+        'gameState': {
+            'turnCount': 12,
+            'pieces': [
+                {
+                    'id': 'p0_1',
+                    'playerId': 0,
+                    'completed': True,
+                    'inHomeStretch': True,
+                    'inPenaltyZone': False,
+                    'position': {'row': 5, 'col': 4},
+                },
+                {
+                    'id': 'p2_1',
+                    'playerId': 2,
+                    'completed': True,
+                    'inHomeStretch': True,
+                    'inPenaltyZone': False,
+                    'position': {'row': 19, 'col': 14},
+                },
+            ],
+            'teams': env.game_state['teams'],
+        },
+        'gameEnded': True,
+        'winningTeam': [{'position': 0}, {'position': 2}],
+    }
+
+    with patch.object(env, 'send_command', return_value=response):
+        with patch.object(env, 'is_action_valid', return_value=True):
+            with patch.object(env, 'get_state', return_value=np.zeros(env.state_size)):
+                _, reward, done = env.step(0, 2, step_count=12)
+
+    expected_conversion = NEAR_FINISH_CONVERSION_BONUS * (1.0 - 2.0 / 32.0)
+    expected_fast_finish = 25.0 * 0.88
+    expected = (
+        step_cost
+        + PIECE_COMPLETION_REWARD
+        + PIECE_COMPLETION_BONUS
+        + REWARD_WEIGHTS['win']
+        + expected_fast_finish
+        + expected_conversion
+    )
+    assert done
+    assert reward == pytest.approx(expected)
+    assert env.reward_event_counts['near_finish_conversion'] == 1
+    assert env.reward_event_totals['near_finish_conversion'] == pytest.approx(expected_conversion)

--- a/game-ai-training/tests/test_trainer.py
+++ b/game-ai-training/tests/test_trainer.py
@@ -37,6 +37,8 @@ class MockGameEnvironment:
             'final_move_bonus': 0.0,
         }
         self.heavy_reward = 1.0
+        self.win_bonus = 60.0
+        self.speed_reward_multiplier = 1.0
 
     def reset(self, bot_names=None):
         self.game_state = {
@@ -77,11 +79,44 @@ class MockGameEnvironment:
     def set_win_bonus(self, value):
         self.win_bonus = value
 
+    def set_speed_reward_multiplier(self, value):
+        self.speed_reward_multiplier = value
+
     def set_piece_count(self, value):
         self.pieces_per_player = value
 
     def set_turn_limit(self, value):
         self.turn_limit = value
+
+
+class TwoTurnTeamWinEnvironment(MockGameEnvironment):
+    def __init__(self):
+        super().__init__()
+        self.turn = 0
+
+    def reset(self, bot_names=None):
+        super().reset(bot_names=bot_names)
+        self.turn = 0
+        self.game_state['currentPlayerIndex'] = 2
+        return np.zeros(self.state_size)
+
+    def step(self, action, player_id, step_count=0):
+        self.turn += 1
+        if self.turn == 1:
+            self.game_state = {
+                'currentPlayerIndex': 0,
+                'gameEnded': False,
+                'winningTeam': None,
+                'teams': [[{'position': 0}, {'position': 2}], [{'position': 1}, {'position': 3}]],
+            }
+            return np.zeros(self.state_size), 0.0, False
+        self.game_state = {
+            'currentPlayerIndex': 0,
+            'gameEnded': True,
+            'winningTeam': [{'position': 0}, {'position': 2}],
+            'teams': [[{'position': 0}, {'position': 2}], [{'position': 1}, {'position': 3}]],
+        }
+        return np.zeros(self.state_size), 0.0, True
 
 
 class DummyGameBot:
@@ -98,12 +133,13 @@ class DummyGameBot:
         self.update_target_freq = 1
         self.train_freq = 1
         self.step_count = 0
+        self.memories = []
 
     def act(self, state, valid_actions):
         return valid_actions[0]
 
     def remember(self, *args, **kwargs):
-        pass
+        self.memories.append((args, kwargs))
 
     def replay(self):
         pass
@@ -137,6 +173,31 @@ def test_train_episode_increments_wins():
             initial_wins = manager.bots[0].wins
             manager.train_episode()
             assert manager.bots[0].wins == initial_wins + 1
+
+
+def test_team_terminal_credit_rewards_winning_teammate():
+    torch_mock = MagicMock()
+    sys.modules['torch'] = torch_mock
+    sys.modules['torch.nn'] = MagicMock()
+    sys.modules['torch.optim'] = MagicMock()
+
+    from ai.trainer import TrainingManager
+    from config import TEAM_TERMINAL_CREDIT_RATIO
+
+    with patch('ai.trainer.GameBot', DummyGameBot):
+        manager = TrainingManager()
+        env = TwoTurnTeamWinEnvironment()
+        manager.env = env
+        manager.create_bots(num_bots=4)
+
+        with patch.object(manager, '_shuffle_bots', lambda: None):
+            rewards = manager.train_episode()
+
+        expected_credit = 60.0 * TEAM_TERMINAL_CREDIT_RATIO
+        assert rewards[2] == pytest.approx(expected_credit)
+        assert manager.bots[2].total_reward == pytest.approx(expected_credit)
+        assert env.reward_bonus_totals['team_terminal_credit_bonus'] == pytest.approx(expected_credit)
+        assert manager.bots[2].memories
 
 
 def test_train_episode_breaks_on_no_actions():
@@ -224,6 +285,19 @@ def test_adjust_reward_multiplier_updates_env():
     expected = HEAVY_REWARD_BASE * (1 + REWARD_TUNE_STEP)
     assert pytest.approx(env.heavy_reward, rel=1e-6) == expected
     assert manager.level_reward_multiplier[manager.pieces_per_player] == 1 + REWARD_TUNE_STEP
+
+
+def test_adjust_reward_multiplier_responds_to_timeouts_and_slow_games():
+    from ai.trainer import TrainingManager
+    from config import SPEED_TUNE_STEP
+
+    manager = TrainingManager()
+    env = MockGameEnvironment()
+
+    manager._adjust_reward_multiplier(0.8, env, timeout_rate=0.6, median_terminal_turns=100.0)
+
+    assert manager.level_speed_reward_multiplier[manager.pieces_per_player] == pytest.approx(1 + SPEED_TUNE_STEP)
+    assert env.speed_reward_multiplier == pytest.approx(1 + SPEED_TUNE_STEP)
 
 
 def test_load_models_restores_training_state(tmp_path):


### PR DESCRIPTION
### Motivation
- Encourage faster game resolution by adding a separate speed-focused reward/penalty pathway and make closing the game an explicit objective. 
- Make near-finish states trackable and reward quick conversion from near-win to win so the curriculum doesn't rely solely on card-specific shaping. 
- Give teammates credit for enabling final moves to improve credit assignment for cooperative plays and provide stage-aware telemetry for analysis.

### Description
- Add configurable speed tuning parameters in `config.py` (`TIMEOUT_TUNE_TARGET`, `SLOW_TERMINAL_TURN_FRAC`, `MAX_SPEED_REWARD_MULTIPLIER`, `MIN_SPEED_REWARD_MULTIPLIER`, `SPEED_TUNE_STEP`, `TEAM_TERMINAL_CREDIT_RATIO`, `NEAR_FINISH_CONVERSION_WINDOW`, `NEAR_FINISH_CONVERSION_BONUS`) and adjust related constants (`FAST_FINISH_BONUS_SCALE`, `URGENCY_PENALTY_BASE`, `LONG_GAME_PENALTY_START`, `REWARD_CLIP_RANGE`).
- Extend `GameEnvironment` (`ai/environment.py`) with `speed_reward_multiplier`, `near_finish_turns`, `near_finish_conversion` accounting, and `set_speed_reward_multiplier`; apply the speed multiplier to long-game penalties, urgency penalty, fast-finish bonus, and timeout penalties; track and award a tapered `near_finish_conversion` bonus when a near-finish state is turned into a win within the conversion window; expose new reward event counters and totals for `near_finish_conversion`.
- Update `TrainingManager` (`ai/trainer.py`) to maintain per-level `level_speed_reward_multiplier`, apply it to environments, tune the speed multiplier in `_adjust_reward_multiplier` using `timeout_rate` and `median_terminal_turns`, immediately apply multipliers via `_apply_reward_schedule`, and award `team_terminal_credit` to teammates who contributed earlier when a team wins; scale unresolved-game `TIMEOUT_PENALTY` by the speed multiplier and include the new telemetry fields in logging.
- Update documentation (`game-ai-training/README.md`) to mention the additional telemetry fields and the speed-focused curriculum behavior, and add/modify unit tests to validate `near_finish` and `near_finish_conversion` behavior as well as speed tuning and team terminal credit logic.

### Testing
- Ran unit tests in `game-ai-training/tests/test_environment.py` which exercise near-finish detection and conversion behavior, and all assertions passed. 
- Ran unit tests in `game-ai-training/tests/test_trainer.py` which validate reward-schedule application, reward multiplier tuning (including timeout/slow-game response), and team terminal credit, and all assertions passed. 
- Executed the test suite with `pytest` on the modified modules to verify integration of environment and trainer changes, and the test run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe5f342c2c832a9eb1fc193fc285db)