### PR TITLE
Penalize missed homestretch entries; expose homeEntryActions and tune reward weights

### DIFF
--- a/game-ai-training/README.md
+++ b/game-ai-training/README.md
@@ -59,9 +59,13 @@ than 100 update steps.
 Training logs record how many times each of the following events occurs:
 
 - Completing a piece (+50 points).
-- Choosing to skip a possible homestretch entry (−1 point).
+- Entering the homestretch (+250 points), with matching severe penalties for
+  explicitly skipping or choosing another move when a homestretch-entry action is
+  available (−250 points).
 
-Additional tactical shaping rewards guide card-specific play without relying on
+The Node wrapper also tags legal actions that would enter the homestretch so the
+Python trainer can punish missed entries even when the bot chooses a different
+move. Additional tactical shaping rewards guide card-specific play without relying on
 periodic plot image checks. The trainer still records per-event reward totals in
 `training_stats.json`, but it no longer saves training-progress plot images at
 statistics intervals or at the end of training.

--- a/game-ai-training/ai/environment.py
+++ b/game-ai-training/ai/environment.py
@@ -34,8 +34,9 @@ from config import (
 
 # Simplified reward system used for initial curriculum training
 PIECE_COMPLETION_REWARD = 50.0
-# Only penalty currently applied when a bot rejects a homestretch entry
-SKIP_HOME_PENALTY = -1.0
+# Severe penalties used when a bot rejects or misses a homestretch entry.
+SKIP_HOME_PENALTY = REWARD_WEIGHTS.get('skip_home', -250.0)
+MISSED_HOME_ENTRY_PENALTY = REWARD_WEIGHTS.get('missed_home_entry', -250.0)
 # Extra shaping for learning card-specific tactics. Seven-card rewards only
 # apply when the card creates concrete impact; otherwise the move receives a
 # small penalty so bots learn not to burn sevens on low-value movement.
@@ -159,6 +160,7 @@ class GameEnvironment:
             'near_finish': 0,
             'near_finish_conversion': 0,
             'skip_home': 0,
+            'missed_home_entry': 0,
             'home_entry_progress': 0,
             'capture': 0,
             'safe_move': 0,
@@ -184,6 +186,7 @@ class GameEnvironment:
             'near_finish': 0.0,
             'near_finish_conversion': 0.0,
             'skip_home': 0.0,
+            'missed_home_entry': 0.0,
             'home_entry_progress': 0.0,
             'capture': 0.0,
             'safe_move': 0.0,
@@ -237,6 +240,7 @@ class GameEnvironment:
         self.last_step_info: Dict[str, float] = {}
         # Cache legal actions so state encoding can include action metadata.
         self.last_valid_actions: Dict[int, List[int]] = {}
+        self.last_home_entry_actions: Dict[int, List[int]] = {}
         # Tracks one-turn 8-card setup opportunities by player. A setup is
         # consumed on that player's next action so it cannot be farmed by
         # repeatedly moving away and back.
@@ -747,9 +751,11 @@ class GameEnvironment:
             fallback = self._default_discards(player_id)
             result = [fallback[0]] if fallback else []
             self.last_valid_actions[player_id] = result
+            self.last_home_entry_actions[player_id] = []
             return result
 
         actions = response.get("validActions", [])
+        self.last_home_entry_actions[player_id] = list(response.get("homeEntryActions", []))
         # Ensure actions are within the defined action space and remain valid
         # when checked individually. The Node wrapper occasionally returns
         # discard actions for cards that no longer exist. Filtering with
@@ -765,10 +771,12 @@ class GameEnvironment:
             if discard_actions:
                 result = [discard_actions[0]]
                 self.last_valid_actions[player_id] = result
+                self.last_home_entry_actions[player_id] = []
                 return result
             fallback = self._default_discards(player_id)
             result = [fallback[0]] if fallback else []
             self.last_valid_actions[player_id] = result
+            self.last_home_entry_actions[player_id] = []
             return result
 
         # Deduplicate while preserving order so the bot only evaluates unique
@@ -783,6 +791,10 @@ class GameEnvironment:
         # Return the complete set of valid actions so the agent can evaluate
         # every option provided by the game wrapper.
         self.last_valid_actions[player_id] = unique_actions
+        valid_action_set = set(unique_actions)
+        self.last_home_entry_actions[player_id] = [
+            act for act in self.last_home_entry_actions.get(player_id, []) if act in valid_action_set
+        ]
         return unique_actions
 
     def is_action_valid(self, player_id: int, action: int) -> bool:
@@ -823,6 +835,9 @@ class GameEnvironment:
         teams = self.game_state.get('teams', []) if self.game_state else []
         prev_completed = [0] * max(len(teams), 2)
         prev_completed_players = self.get_completed_counts() if self.game_state else [0]*4
+
+        home_entry_actions = set(self.last_home_entry_actions.get(player_id, []))
+        entry_available_before = bool(home_entry_actions)
 
         if self.game_state and 'pieces' in self.game_state:
             for p in self.game_state['pieces']:
@@ -1093,6 +1108,11 @@ class GameEnvironment:
 
         if home_entry_reward > 0:
             weighted_reward += home_entry_reward
+
+        if entry_available_before and home_entry_reward <= 0:
+            self.reward_event_counts['missed_home_entry'] += 1
+            self.reward_event_totals['missed_home_entry'] += MISSED_HOME_ENTRY_PENALTY
+            weighted_reward += MISSED_HOME_ENTRY_PENALTY
 
         if seven_card_played and (capture_occurred or home_entry_piece_ids or piece_reward > 0):
             if seven_split_played:

--- a/game-ai-training/config.py
+++ b/game-ai-training/config.py
@@ -96,11 +96,12 @@ REWARD_WEIGHTS = {
     # Completing a piece remains a strong objective signal, but lower than
     # before to reduce farming of intermediate rewards without closing games.
     'home_completion': 35.0,
-    # Discourage skipping a valid home entry.
-    'skip_home': -1.0,
-    # Reward entering the home stretch; this is boosted when it follows
-    # an 8-card setup that newly put the piece within entry reach.
-    'home_entry': 8.0,
+    # Make homestretch entry overwhelmingly preferred whenever it is available.
+    'home_entry': 250.0,
+    # Heavily punish rejecting or missing a valid home entry so bots learn this
+    # is never an acceptable alternative to entering the homestretch.
+    'skip_home': -250.0,
+    'missed_home_entry': -250.0,
     # Small tactical bonuses to improve credit assignment.
     'home_entry_progress': 1.0,
     'capture': 2.0,
@@ -153,7 +154,7 @@ REPEATED_STATE_THRESHOLD = 3
 REPEATED_STATE_PENALTY = -0.6
 
 # Clip range for the per-step weighted reward sum.
-REWARD_CLIP_RANGE = (-180.0, 180.0)
+REWARD_CLIP_RANGE = (-1200.0, 1200.0)
 
 # Multiplier applied to positive rewards based on the current
 # number of pieces per player. The curriculum increases the

--- a/game-ai-training/game/game_wrapper.js
+++ b/game-ai-training/game/game_wrapper.js
@@ -103,10 +103,13 @@ class GameWrapper {
                         return { error: "Failed to setup game" };
                     }
                     
-                case 'getValidActions':
+                case 'getValidActions': {
+                    const validActions = this.getValidActions(command.playerId);
                     return {
-                        validActions: this.getValidActions(command.playerId)
+                        validActions,
+                        homeEntryActions: this.getHomeEntryActions(command.playerId, validActions)
                     };
+                }
                     
                 case 'makeMove':
                     return this.makeMove(command.playerId, command.actionId);
@@ -340,6 +343,85 @@ class GameWrapper {
         } catch (error) {
             return [];
         }
+    }
+
+    actionWouldEnterHome(playerId, actionId) {
+        try {
+            if (!this.game || !this.game.players || !this.game.players[playerId] || actionId >= 70) {
+                return false;
+            }
+
+            const clone = this.game.cloneForSimulation();
+
+            if (actionId >= 60) {
+                const moves = this.specialActions[actionId];
+                if (!moves) return false;
+                const before = moves.map(m => {
+                    const piece = clone.pieces.find(p => p.id === m.pieceId);
+                    return {
+                        id: m.pieceId,
+                        inHomeStretch: Boolean(piece && piece.inHomeStretch)
+                    };
+                });
+                let result = clone.makeSpecialMove(moves);
+                if (result && result.action === 'homeEntryChoice') {
+                    result = clone.resumeSpecialMove(true);
+                }
+                if (result && result.success === false) {
+                    return false;
+                }
+                return before.some(info => {
+                    const piece = clone.pieces.find(p => p.id === info.id);
+                    return piece && !info.inHomeStretch && piece.inHomeStretch;
+                });
+            }
+
+            const cardIndex = Math.floor(actionId / 10);
+            let pieceNumber = actionId % 10;
+            if (pieceNumber === 0) {
+                pieceNumber = 10;
+            }
+
+            const countCheck = this.game.piecesPerPlayer || 5;
+            let ownerId = playerId;
+            if (pieceNumber > countCheck) {
+                const partner = this.game.partnerIdFor && this.game.partnerIdFor(playerId);
+                if (partner === null || partner === undefined) {
+                    return false;
+                }
+                ownerId = partner;
+                pieceNumber -= countCheck;
+            }
+
+            const pieceId = `p${ownerId}_${pieceNumber}`;
+            const beforePiece = clone.pieces.find(p => p.id === pieceId);
+            if (!beforePiece || beforePiece.inHomeStretch || beforePiece.completed) {
+                return false;
+            }
+
+            let result = clone.makeMove(pieceId, cardIndex);
+            if (result && result.action === 'homeEntryChoice') {
+                result = clone.makeMove(pieceId, cardIndex, true);
+            }
+            if (result && result.success === false) {
+                return false;
+            }
+
+            const afterPiece = clone.pieces.find(p => p.id === pieceId);
+            return Boolean(afterPiece && afterPiece.inHomeStretch);
+        } catch (e) {
+            return false;
+        }
+    }
+
+    getHomeEntryActions(playerId, actions) {
+        const result = [];
+        for (const action of actions || []) {
+            if (this.actionWouldEnterHome(playerId, action)) {
+                result.push(action);
+            }
+        }
+        return result;
     }
 
     findFirstAvailableAction(playerId) {

--- a/game-ai-training/tests/test_environment.py
+++ b/game-ai-training/tests/test_environment.py
@@ -8,6 +8,7 @@ from ai.environment import (
     SEVEN_SPLIT_HOME_ENTRY_REWARD,
     SEVEN_SPLIT_REWARD,
     SKIP_HOME_PENALTY,
+    MISSED_HOME_ENTRY_PENALTY,
     STUCK_SMART_CARD_DISCARD_PENALTY,
     SMART_CARD_MISUSE_PENALTY,
     EIGHT_CARD_REACH_REWARD,
@@ -113,6 +114,50 @@ def test_skip_home_penalty():
     assert len(calls) == 2
     assert reward == pytest.approx(SKIP_HOME_PENALTY + step_cost)
     assert env.reward_event_counts['skip_home'] == 1
+
+
+def test_missed_home_entry_penalty_when_entry_action_available():
+    env = GameEnvironment()
+    step_cost = STEP_PENALTY_BASE * max(1.0, env.pieces_per_player / 2.0)
+    env.game_state = {
+        'currentPlayerIndex': 0,
+        'teams': [[{'position': 0}, {'position': 2}], [{'position': 1}, {'position': 3}]],
+        'pieces': [
+            {
+                'id': 'p0_1',
+                'playerId': 0,
+                'position': {'row': 0, 'col': 8},
+                'inHomeStretch': False,
+                'inPenaltyZone': False,
+                'completed': False,
+            }
+        ],
+    }
+    env.player_team_map = {0: 0, 2: 0, 1: 1, 3: 1}
+    env.last_home_entry_actions[0] = [1]
+
+    new_state = {
+        'pieces': [
+            {
+                'id': 'p0_1',
+                'playerId': 0,
+                'position': {'row': 0, 'col': 7},
+                'inHomeStretch': False,
+                'inPenaltyZone': False,
+                'completed': False,
+            }
+        ],
+        'teams': env.game_state['teams'],
+    }
+    response = {'success': True, 'gameState': new_state, 'gameEnded': False, 'winningTeam': None}
+
+    with patch.object(env, 'send_command', return_value=response):
+        with patch.object(env, 'is_action_valid', return_value=True):
+            with patch.object(env, 'get_state', return_value=np.zeros(env.state_size)):
+                _, reward, _ = env.step(0, 0)
+
+    assert reward == pytest.approx(MISSED_HOME_ENTRY_PENALTY + step_cost)
+    assert env.reward_event_counts['missed_home_entry'] == 1
 
 
 def test_seven_split_home_entry_reward():


### PR DESCRIPTION
### Motivation
- Make homestretch entry an overwhelmingly preferred action and ensure the trainer can punish both explicit rejections and cases where a bot opts for a different move when entry was available. 
- Surface action-level metadata from the Node game wrapper so the Python environment can detect home-entry opportunities without re-simulating game logic.

### Description
- Increase `home_entry` reward and add heavy negative weights `skip_home` and `missed_home_entry` in `config.py`, and expand `REWARD_CLIP_RANGE` to accommodate larger magnitude values.
- Replace the simple `SKIP_HOME_PENALTY` constant with `SKIP_HOME_PENALTY = REWARD_WEIGHTS.get('skip_home', -250.0)` and add `MISSED_HOME_ENTRY_PENALTY` in `ai/environment.py`, plus track counts/totals for `'missed_home_entry'` in the environment telemetry.
- Record home-entry candidates in `GameEnvironment.get_valid_actions` via `last_home_entry_actions` and apply `MISSED_HOME_ENTRY_PENALTY` in `step` when a home-entry action was available but no entry reward was given.
- Add `actionWouldEnterHome` and `getHomeEntryActions` to `game_wrapper.js` and include `homeEntryActions` in the `getValidActions` response so the Python side can mark actionable home-entry moves.
- Update `README.md` to document the stronger home-entry rewards/penalties and reward monitoring changes.

### Testing
- Added `test_missed_home_entry_penalty_when_entry_action_available` to `game-ai-training/tests/test_environment.py` and ran `pytest` on the environment tests. 
- The environment unit tests including the new missed-entry test completed successfully (all tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00853a92e0832abc1b2cb18e65a740)