### PR TITLE
Prioritize and filter actions using fixed-play and avoid metadata in wrappers and environment

### DIFF
--- a/game-ai-training/ai/environment.py
+++ b/game-ai-training/ai/environment.py
@@ -249,6 +249,8 @@ class GameEnvironment:
         # Cache legal actions so state encoding can include action metadata.
         self.last_valid_actions: Dict[int, List[int]] = {}
         self.last_home_entry_actions: Dict[int, List[int]] = {}
+        self.last_fixed_play_actions: Dict[int, List[int]] = {}
+        self.last_avoid_actions: Dict[int, List[int]] = {}
         # Tracks one-turn 8-card setup opportunities by player. A setup is
         # consumed on that player's next action so it cannot be farmed by
         # repeatedly moving away and back.
@@ -760,10 +762,14 @@ class GameEnvironment:
             result = [fallback[0]] if fallback else []
             self.last_valid_actions[player_id] = result
             self.last_home_entry_actions[player_id] = []
+            self.last_fixed_play_actions[player_id] = []
+            self.last_avoid_actions[player_id] = []
             return result
 
         actions = response.get("validActions", [])
         self.last_home_entry_actions[player_id] = list(response.get("homeEntryActions", []))
+        self.last_fixed_play_actions[player_id] = list(response.get("fixedPlayActions", []))
+        self.last_avoid_actions[player_id] = list(response.get("avoidActions", []))
         # Ensure actions are within the defined action space and remain valid
         # when checked individually. The Node wrapper occasionally returns
         # discard actions for cards that no longer exist. Filtering with
@@ -780,11 +786,15 @@ class GameEnvironment:
                 result = [discard_actions[0]]
                 self.last_valid_actions[player_id] = result
                 self.last_home_entry_actions[player_id] = []
+                self.last_fixed_play_actions[player_id] = []
+                self.last_avoid_actions[player_id] = []
                 return result
             fallback = self._default_discards(player_id)
             result = [fallback[0]] if fallback else []
             self.last_valid_actions[player_id] = result
             self.last_home_entry_actions[player_id] = []
+            self.last_fixed_play_actions[player_id] = []
+            self.last_avoid_actions[player_id] = []
             return result
 
         # Deduplicate while preserving order so the bot only evaluates unique
@@ -805,8 +815,27 @@ class GameEnvironment:
             # Homestretch entry is a rule-level priority for the training policy:
             # when any legal action can enter home, mask out every alternative so
             # the bot cannot learn to prefer captures, setup moves, or discards.
+            self.last_fixed_play_actions[player_id] = []
+            self.last_avoid_actions[player_id] = []
             self.last_valid_actions[player_id] = home_entry_actions
             return home_entry_actions
+
+        fixed_play_actions = [
+            act for act in self.last_fixed_play_actions.get(player_id, []) if act in valid_action_set
+        ]
+        self.last_fixed_play_actions[player_id] = fixed_play_actions
+        if fixed_play_actions:
+            # Fixed tactical plays are treated like home-stretch entries: if a
+            # legal move can make an urgent capture/setup, hide lower-value
+            # alternatives from the learner so training reinforces the tactic.
+            self.last_valid_actions[player_id] = fixed_play_actions
+            return fixed_play_actions
+
+        avoid_actions = {act for act in self.last_avoid_actions.get(player_id, []) if act in valid_action_set}
+        self.last_avoid_actions[player_id] = [act for act in unique_actions if act in avoid_actions]
+        filtered_actions = [act for act in unique_actions if act not in avoid_actions]
+        if filtered_actions:
+            unique_actions = filtered_actions
 
         # Return the complete set of non-entry valid actions only when no
         # homestretch-entry action is available.
@@ -1370,6 +1399,8 @@ class GameEnvironment:
             {'general': 0, 'since_two': 0} for _ in range(4)
         ]
         self.last_step_info = {}
+        self.last_fixed_play_actions = {}
+        self.last_avoid_actions = {}
         self.state_visit_counts = {}
         self.total_state_visits = 0
         self.unique_state_visits = 0

--- a/game-ai-training/game/game_wrapper.js
+++ b/game-ai-training/game/game_wrapper.js
@@ -105,9 +105,12 @@ class GameWrapper {
                     
                 case 'getValidActions': {
                     const validActions = this.getValidActions(command.playerId);
+                    const fixedPlayActions = this.getFixedPlayActions(command.playerId, validActions);
                     return {
                         validActions,
-                        homeEntryActions: this.getHomeEntryActions(command.playerId, validActions)
+                        homeEntryActions: this.getHomeEntryActions(command.playerId, validActions),
+                        fixedPlayActions: fixedPlayActions.priorityActions,
+                        avoidActions: fixedPlayActions.avoidActions
                     };
                 }
                     
@@ -343,6 +346,232 @@ class GameWrapper {
         } catch (error) {
             return [];
         }
+    }
+
+
+    getTrackCoordinates() {
+        const track = [];
+        for (let col = 0; col < 19; col++) track.push({ row: 0, col });
+        for (let row = 1; row < 19; row++) track.push({ row, col: 18 });
+        for (let col = 17; col >= 0; col--) track.push({ row: 18, col });
+        for (let row = 17; row > 0; row--) track.push({ row, col: 0 });
+        return track;
+    }
+
+    positionsEqual(a, b) {
+        return Boolean(a && b && a.row === b.row && a.col === b.col);
+    }
+
+    entranceForPlayer(playerId) {
+        return [
+            { row: 0, col: 4 },
+            { row: 4, col: 18 },
+            { row: 18, col: 14 },
+            { row: 14, col: 0 }
+        ][playerId];
+    }
+
+    startForPlayer(playerId) {
+        return [
+            { row: 0, col: 8 },
+            { row: 8, col: 18 },
+            { row: 18, col: 10 },
+            { row: 10, col: 0 }
+        ][playerId];
+    }
+
+    trackIndex(pos) {
+        const track = this.getTrackCoordinates();
+        return track.findIndex(p => this.positionsEqual(p, pos));
+    }
+
+    stepsToEntrance(pos, playerId) {
+        const track = this.getTrackCoordinates();
+        const startIdx = this.trackIndex(pos);
+        const entranceIdx = this.trackIndex(this.entranceForPlayer(playerId));
+        if (startIdx < 0 || entranceIdx < 0) return -1;
+        return (entranceIdx - startIdx + track.length) % track.length;
+    }
+
+    withinHomeEntryReach(piece) {
+        if (!piece || piece.inPenaltyZone || piece.inHomeStretch || piece.completed) {
+            return false;
+        }
+        const stepsToEntry = this.stepsToEntrance(piece.position, piece.playerId);
+        if (stepsToEntry < 0) return false;
+        for (const cardSteps of [1, 2, 3, 4, 5, 6, 7, 9, 10]) {
+            const remaining = cardSteps - stepsToEntry;
+            if (remaining >= 1 && remaining <= 5) return true;
+        }
+        return false;
+    }
+
+    flattenCaptures(captures) {
+        const flat = [];
+        for (const capture of captures || []) {
+            flat.push(capture);
+            if (capture.result && capture.result.captures) {
+                flat.push(...this.flattenCaptures(capture.result.captures));
+            }
+        }
+        return flat;
+    }
+
+    actionPieceInfo(playerId, actionId) {
+        if (actionId >= 60) return null;
+        const pieceCount = this.game.piecesPerPlayer || 5;
+        let pieceNumber = actionId % 10;
+        let cardIndex;
+        if (pieceNumber === 0) {
+            pieceNumber = 10;
+            cardIndex = (actionId - pieceNumber) / 10;
+        } else {
+            cardIndex = Math.floor(actionId / 10);
+        }
+        let ownerId = playerId;
+        if (pieceNumber > pieceCount) {
+            const partner = this.game.partnerIdFor && this.game.partnerIdFor(playerId);
+            if (partner === null || partner === undefined) return null;
+            ownerId = partner;
+            pieceNumber -= pieceCount;
+        }
+        return { ownerId, pieceNumber, pieceId: `p${ownerId}_${pieceNumber}`, cardIndex };
+    }
+
+    simulateActionOutcomes(playerId, actionId) {
+        const outcomes = [];
+        if (!this.game || actionId >= 70) return outcomes;
+
+        if (actionId >= 60) {
+            const moves = this.specialActions[actionId];
+            if (!moves) return outcomes;
+            const clone = this.game.cloneForSimulation();
+            try {
+                let result = clone.makeSpecialMove(moves);
+                if (result && result.action === 'homeEntryChoice') {
+                    result = clone.resumeSpecialMove(true);
+                }
+                if (!result || result.success === false) return outcomes;
+                const movedPieceIds = moves.map(m => m.pieceId);
+                const finalPieces = {};
+                for (const pid of movedPieceIds) {
+                    const piece = clone.pieces.find(p => p.id === pid);
+                    if (piece) finalPieces[pid] = JSON.parse(JSON.stringify(piece));
+                }
+                outcomes.push({
+                    captures: this.flattenCaptures(result.captures),
+                    movedPieceIds,
+                    finalPieces
+                });
+            } catch (e) {}
+            return outcomes;
+        }
+
+        const info = this.actionPieceInfo(playerId, actionId);
+        if (!info) return outcomes;
+        const clone = this.game.cloneForSimulation();
+        try {
+            let result = clone.makeMove(info.pieceId, info.cardIndex);
+            if (result && result.action === 'homeEntryChoice') {
+                result = clone.makeMove(info.pieceId, info.cardIndex, true);
+            }
+            if (result && result.action === 'choosePosition') {
+                for (const target of result.validPositions || []) {
+                    const choiceClone = this.game.cloneForSimulation();
+                    try {
+                        const choicePiece = choiceClone.pieces.find(p => p.id === info.pieceId);
+                        const choiceResult = choiceClone.moveToSelectedPosition(choicePiece, target.id);
+                        const finalPiece = choiceClone.pieces.find(p => p.id === info.pieceId);
+                        outcomes.push({
+                            captures: this.flattenCaptures(choiceResult && choiceResult.captures),
+                            movedPieceIds: [info.pieceId],
+                            finalPieces: finalPiece ? { [info.pieceId]: JSON.parse(JSON.stringify(finalPiece)) } : {},
+                            jokerTargetId: target.id
+                        });
+                    } catch (e) {}
+                }
+            } else if (result && result.success !== false) {
+                const finalPiece = clone.pieces.find(p => p.id === info.pieceId);
+                outcomes.push({
+                    captures: this.flattenCaptures(result.captures),
+                    movedPieceIds: [info.pieceId],
+                    finalPieces: finalPiece ? { [info.pieceId]: JSON.parse(JSON.stringify(finalPiece)) } : {}
+                });
+            }
+        } catch (e) {}
+        return outcomes;
+    }
+
+    getFixedPlayActions(playerId, actions) {
+        const priority = [];
+        const avoid = [];
+        if (!this.game) return { priorityActions: priority, avoidActions: avoid };
+
+        const partnerId = this.game.partnerIdFor ? this.game.partnerIdFor(playerId) : null;
+        const partnerHasPenaltyPiece = partnerId !== null && partnerId !== undefined && this.game.pieces.some(
+            p => p.playerId === partnerId && p.inPenaltyZone && !p.completed
+        );
+        const partnerStart = this.startForPlayer(partnerId);
+
+        for (const action of actions || []) {
+            if (action >= 70) continue;
+            const outcomes = this.simulateActionOutcomes(playerId, action);
+            let capturesHomeReachOpponent = false;
+            let capturesOpponentOnStart = false;
+            let capturesPartnerOnStart = false;
+            let parksOwnPieceOnPartnerStart = false;
+            let vacatesPartnerStart = false;
+
+            for (const outcome of outcomes) {
+                for (const capture of outcome.captures || []) {
+                    const capturedBefore = this.game.pieces.find(p => p.id === capture.pieceId);
+                    if (!capturedBefore) continue;
+                    const isPartner = this.game.isPartner && this.game.isPartner(playerId, capturedBefore.playerId);
+                    const isSelf = capturedBefore.playerId === playerId;
+                    const isOpponent = !isSelf && !isPartner;
+                    if (isOpponent && this.withinHomeEntryReach(capturedBefore)) {
+                        capturesHomeReachOpponent = true;
+                    }
+                    const capturedStart = this.startForPlayer(capturedBefore.playerId);
+                    if (isOpponent && this.positionsEqual(capturedBefore.position, capturedStart)) {
+                        capturesOpponentOnStart = true;
+                    }
+                    if (isPartner && this.positionsEqual(capturedBefore.position, capturedStart)) {
+                        capturesPartnerOnStart = true;
+                    }
+                }
+            }
+
+            if (partnerHasPenaltyPiece && partnerStart) {
+                for (const outcome of outcomes) {
+                    for (const pieceId of outcome.movedPieceIds || []) {
+                        const beforeMove = this.game.pieces.find(p => p.id === pieceId);
+                        const afterMove = outcome.finalPieces && outcome.finalPieces[pieceId];
+                        if (!beforeMove || beforeMove.playerId !== playerId) continue;
+                        const startedOnPartnerStart = this.positionsEqual(beforeMove.position, partnerStart);
+                        const endedOnPartnerStart = this.positionsEqual(afterMove && afterMove.position, partnerStart);
+                        if (!startedOnPartnerStart && endedOnPartnerStart) {
+                            parksOwnPieceOnPartnerStart = true;
+                        }
+                        if (startedOnPartnerStart && !endedOnPartnerStart) {
+                            vacatesPartnerStart = true;
+                        }
+                    }
+                }
+            }
+
+            if (capturesHomeReachOpponent || capturesPartnerOnStart || parksOwnPieceOnPartnerStart) {
+                priority.push(action);
+            }
+            if (capturesOpponentOnStart || vacatesPartnerStart) {
+                avoid.push(action);
+            }
+        }
+
+        return {
+            priorityActions: Array.from(new Set(priority)),
+            avoidActions: Array.from(new Set(avoid))
+        };
     }
 
     actionWouldEnterHome(playerId, actionId) {
@@ -670,7 +899,9 @@ class GameWrapper {
                                     }
                                 }
                                 for (const pid of infoList) {
-                                    const p = this.game.pieces.find(pp => pp.id === pid && !pp.completed && !pp.inPenaltyZone);
+                                    const p = this.game.pieces.find(pp => (
+                                        pp.id === pid && !pp.completed && !pp.inPenaltyZone
+                                    ));
                                     if (p) pieceIds.push(pid);
                                 }
                                 for (let i = 0; i < pieceIds.length && !result; i++) {
@@ -722,7 +953,8 @@ class GameWrapper {
                             player.cards.splice(cardIndex, 1);
                             this.game.stats.roundsWithoutPlay[player.position]++;
                             this.game.nextTurn();
-                            const dMsg = `${player.name} descartou um ${fallbackCard.value === 'JOKER' ? 'C' : fallbackCard.value}`;
+                            const fallbackLabel = fallbackCard.value === 'JOKER' ? 'C' : fallbackCard.value;
+                            const dMsg = `${player.name} descartou um ${fallbackLabel}`;
                             this.game.history.push(dMsg);
                             result = { success: true, action: 'discard' };
                         }
@@ -762,7 +994,28 @@ class GameWrapper {
                 }
 
                 if (result && result.action === 'choosePosition') {
-                    const target = result.validPositions && result.validPositions[0];
+                    const targets = result.validPositions || [];
+                    let target = targets[0];
+                    let bestScore = -Infinity;
+                    for (const candidate of targets) {
+                        const targetPiece = this.game.pieces.find(p => p.id === candidate.id);
+                        if (!targetPiece) continue;
+                        const isPartner = this.game.isPartner && this.game.isPartner(playerId, targetPiece.playerId);
+                        const isOpponent = targetPiece.playerId !== playerId && !isPartner;
+                        let score = 0;
+                        if (isOpponent && this.withinHomeEntryReach(targetPiece)) score += 100;
+                        const targetStart = this.startForPlayer(targetPiece.playerId);
+                        if (isOpponent && this.positionsEqual(targetPiece.position, targetStart)) {
+                            score -= 50;
+                        }
+                        if (isPartner && this.positionsEqual(targetPiece.position, targetStart)) {
+                            score += 80;
+                        }
+                        if (score > bestScore) {
+                            bestScore = score;
+                            target = candidate;
+                        }
+                    }
                     if (!target) {
                         throw new Error('No valid Joker positions');
                     }

--- a/game-ai-training/tests/game_wrapper.test.js
+++ b/game-ai-training/tests/game_wrapper.test.js
@@ -166,3 +166,204 @@ describe('GameWrapper 7-card split actions', () => {
     expect(specialActions.every(action => wrapper.specialActions[action].length > 1)).toBe(true);
   });
 });
+
+describe('GameWrapper fixed play action metadata', () => {
+  function buildWrapper(capturedPiece, captureAction = 'opponentCapture') {
+    const GameWrapper = loadGameWrapper();
+    const wrapper = new GameWrapper();
+    const pieces = [
+      {
+        id: 'p0_1',
+        playerId: 0,
+        completed: false,
+        inPenaltyZone: false,
+        inHomeStretch: false,
+        position: { row: 0, col: 14 }
+      },
+      capturedPiece
+    ];
+    wrapper.game = {
+      pieces,
+      piecesPerPlayer: 5,
+      partnerIdFor(playerId) {
+        return playerId === 0 ? 2 : 0;
+      },
+      isPartner(a, b) {
+        return (a === 0 && b === 2) || (a === 2 && b === 0);
+      },
+      cloneForSimulation() {
+        const clonePieces = JSON.parse(JSON.stringify(pieces));
+        return {
+          pieces: clonePieces,
+          makeMove() {
+            return { success: true, captures: [{ pieceId: capturedPiece.id, action: captureAction }] };
+          }
+        };
+      }
+    };
+    return wrapper;
+  }
+
+  test('prioritizes capturing an opponent in home-entry reach', () => {
+    const wrapper = buildWrapper({
+      id: 'p1_1',
+      playerId: 1,
+      completed: false,
+      inPenaltyZone: false,
+      inHomeStretch: false,
+      position: { row: 0, col: 15 }
+    });
+
+    const metadata = wrapper.getFixedPlayActions(0, [1]);
+
+    expect(metadata.priorityActions).toEqual([1]);
+    expect(metadata.avoidActions).toEqual([]);
+  });
+
+  test('marks opponent captures on start squares as avoidable', () => {
+    const wrapper = buildWrapper({
+      id: 'p1_1',
+      playerId: 1,
+      completed: false,
+      inPenaltyZone: false,
+      inHomeStretch: false,
+      position: { row: 8, col: 18 }
+    });
+
+    const metadata = wrapper.getFixedPlayActions(0, [1]);
+
+    expect(metadata.priorityActions).toEqual([]);
+    expect(metadata.avoidActions).toEqual([1]);
+  });
+
+  test('prioritizes capturing a partner on their start square', () => {
+    const wrapper = buildWrapper({
+      id: 'p2_1',
+      playerId: 2,
+      completed: false,
+      inPenaltyZone: false,
+      inHomeStretch: false,
+      position: { row: 18, col: 10 }
+    }, 'partnerCapture');
+
+    const metadata = wrapper.getFixedPlayActions(0, [1]);
+
+    expect(metadata.priorityActions).toEqual([1]);
+    expect(metadata.avoidActions).toEqual([]);
+  });
+
+  test('does not prioritize partner captures on home entrance squares', () => {
+    const wrapper = buildWrapper({
+      id: 'p2_1',
+      playerId: 2,
+      completed: false,
+      inPenaltyZone: false,
+      inHomeStretch: false,
+      position: { row: 18, col: 14 }
+    }, 'partnerCapture');
+
+    const metadata = wrapper.getFixedPlayActions(0, [1]);
+
+    expect(metadata.priorityActions).toEqual([]);
+    expect(metadata.avoidActions).toEqual([]);
+  });
+
+  test('prioritizes parking an own piece on partner start when partner is jailed', () => {
+    const GameWrapper = loadGameWrapper();
+    const wrapper = new GameWrapper();
+    const pieces = [
+      {
+        id: 'p2_1',
+        playerId: 2,
+        completed: false,
+        inPenaltyZone: false,
+        inHomeStretch: false,
+        position: { row: 18, col: 11 }
+      },
+      {
+        id: 'p0_1',
+        playerId: 0,
+        completed: false,
+        inPenaltyZone: true,
+        inHomeStretch: false,
+        position: { row: 2, col: 8 }
+      }
+    ];
+    wrapper.game = {
+      pieces,
+      piecesPerPlayer: 5,
+      partnerIdFor(playerId) {
+        return playerId === 2 ? 0 : 2;
+      },
+      isPartner(a, b) {
+        return (a === 0 && b === 2) || (a === 2 && b === 0);
+      },
+      cloneForSimulation() {
+        const clonePieces = JSON.parse(JSON.stringify(pieces));
+        return {
+          pieces: clonePieces,
+          makeMove(pieceId) {
+            const piece = clonePieces.find(p => p.id === pieceId);
+            piece.position = { row: 0, col: 8 };
+            return { success: true };
+          }
+        };
+      }
+    };
+
+    const metadata = wrapper.getFixedPlayActions(2, [1]);
+
+    expect(metadata.priorityActions).toEqual([1]);
+    expect(metadata.avoidActions).toEqual([]);
+  });
+
+  test('avoids vacating partner start when partner is jailed', () => {
+    const GameWrapper = loadGameWrapper();
+    const wrapper = new GameWrapper();
+    const pieces = [
+      {
+        id: 'p2_1',
+        playerId: 2,
+        completed: false,
+        inPenaltyZone: false,
+        inHomeStretch: false,
+        position: { row: 0, col: 8 }
+      },
+      {
+        id: 'p0_1',
+        playerId: 0,
+        completed: false,
+        inPenaltyZone: true,
+        inHomeStretch: false,
+        position: { row: 2, col: 8 }
+      }
+    ];
+    wrapper.game = {
+      pieces,
+      piecesPerPlayer: 5,
+      partnerIdFor(playerId) {
+        return playerId === 2 ? 0 : 2;
+      },
+      isPartner(a, b) {
+        return (a === 0 && b === 2) || (a === 2 && b === 0);
+      },
+      cloneForSimulation() {
+        const clonePieces = JSON.parse(JSON.stringify(pieces));
+        return {
+          pieces: clonePieces,
+          makeMove(pieceId) {
+            const piece = clonePieces.find(p => p.id === pieceId);
+            piece.position = { row: 0, col: 9 };
+            return { success: true };
+          }
+        };
+      }
+    };
+
+    const metadata = wrapper.getFixedPlayActions(2, [1]);
+
+    expect(metadata.priorityActions).toEqual([]);
+    expect(metadata.avoidActions).toEqual([1]);
+  });
+
+});

--- a/game-ai-training/tests/test_environment.py
+++ b/game-ai-training/tests/test_environment.py
@@ -698,3 +698,55 @@ def test_near_finish_conversion_bonus_rewards_fast_close():
     assert reward == pytest.approx(expected)
     assert env.reward_event_counts['near_finish_conversion'] == 1
     assert env.reward_event_totals['near_finish_conversion'] == pytest.approx(expected_conversion)
+
+
+def test_get_valid_actions_prioritizes_fixed_play_actions_after_home_entries():
+    env = GameEnvironment()
+    response = {
+        'validActions': [1, 2, 3],
+        'homeEntryActions': [],
+        'fixedPlayActions': [3],
+        'avoidActions': [],
+    }
+
+    with patch.object(env, 'send_command', return_value=response):
+        with patch.object(env, 'is_action_valid', return_value=True):
+            actions = env.get_valid_actions(0)
+
+    assert actions == [3]
+    assert env.last_valid_actions[0] == [3]
+    assert env.last_fixed_play_actions[0] == [3]
+
+
+def test_get_valid_actions_filters_avoidable_fixed_play_actions_when_alternatives_exist():
+    env = GameEnvironment()
+    response = {
+        'validActions': [1, 2, 3],
+        'homeEntryActions': [],
+        'fixedPlayActions': [],
+        'avoidActions': [2, 3],
+    }
+
+    with patch.object(env, 'send_command', return_value=response):
+        with patch.object(env, 'is_action_valid', return_value=True):
+            actions = env.get_valid_actions(0)
+
+    assert actions == [1]
+    assert env.last_avoid_actions[0] == [2, 3]
+
+
+def test_get_valid_actions_keeps_avoidable_actions_if_forced():
+    env = GameEnvironment()
+    response = {
+        'validActions': [2],
+        'homeEntryActions': [],
+        'fixedPlayActions': [],
+        'avoidActions': [2],
+    }
+
+    with patch.object(env, 'send_command', return_value=response):
+        with patch.object(env, 'is_action_valid', return_value=True):
+            actions = env.get_valid_actions(0)
+
+    assert actions == [2]
+    assert env.last_avoid_actions[0] == [2]

--- a/server/__tests__/bot_wrapper.test.js
+++ b/server/__tests__/bot_wrapper.test.js
@@ -1,0 +1,125 @@
+const BotWrapper = require('../bot_wrapper');
+
+function buildCaptureWrapper(capturedPiece, captureAction = 'opponentCapture') {
+  const wrapper = new BotWrapper(null);
+  const pieces = [
+    {
+      id: 'p0_1',
+      playerId: 0,
+      completed: false,
+      inPenaltyZone: false,
+      inHomeStretch: false,
+      position: { row: 0, col: 14 }
+    },
+    capturedPiece
+  ];
+  wrapper.game = {
+    pieces,
+    piecesPerPlayer: 5,
+    partnerIdFor(playerId) {
+      return playerId === 0 ? 2 : 0;
+    },
+    isPartner(a, b) {
+      return (a === 0 && b === 2) || (a === 2 && b === 0);
+    },
+    cloneForSimulation() {
+      const clonePieces = JSON.parse(JSON.stringify(pieces));
+      return {
+        pieces: clonePieces,
+        makeMove(pieceId) {
+          if (pieceId !== 'p0_1') {
+            return { success: true };
+          }
+          return { success: true, captures: [{ pieceId: capturedPiece.id, action: captureAction }] };
+        }
+      };
+    }
+  };
+  return wrapper;
+}
+
+describe('BotWrapper live fixed play constraints', () => {
+  test('prioritizes fixed plays before sending actions to human-game bots', () => {
+    const wrapper = buildCaptureWrapper({
+      id: 'p1_1',
+      playerId: 1,
+      completed: false,
+      inPenaltyZone: false,
+      inHomeStretch: false,
+      position: { row: 0, col: 15 }
+    });
+
+    expect(wrapper.applyActionConstraints(0, [1, 2])).toEqual([1]);
+  });
+
+  test('filters avoidable opponent-start captures when another action exists', () => {
+    const wrapper = buildCaptureWrapper({
+      id: 'p1_1',
+      playerId: 1,
+      completed: false,
+      inPenaltyZone: false,
+      inHomeStretch: false,
+      position: { row: 8, col: 18 }
+    });
+
+    expect(wrapper.applyActionConstraints(0, [1, 2])).toEqual([2]);
+  });
+
+  test('keeps avoidable actions when they are forced', () => {
+    const wrapper = buildCaptureWrapper({
+      id: 'p1_1',
+      playerId: 1,
+      completed: false,
+      inPenaltyZone: false,
+      inHomeStretch: false,
+      position: { row: 8, col: 18 }
+    });
+
+    expect(wrapper.applyActionConstraints(0, [1])).toEqual([1]);
+  });
+
+  test('prioritizes parking an own piece on partner start when partner is jailed', () => {
+    const wrapper = new BotWrapper(null);
+    const pieces = [
+      {
+        id: 'p2_1',
+        playerId: 2,
+        completed: false,
+        inPenaltyZone: false,
+        inHomeStretch: false,
+        position: { row: 18, col: 11 }
+      },
+      {
+        id: 'p0_1',
+        playerId: 0,
+        completed: false,
+        inPenaltyZone: true,
+        inHomeStretch: false,
+        position: { row: 2, col: 8 }
+      }
+    ];
+    wrapper.game = {
+      pieces,
+      piecesPerPlayer: 5,
+      partnerIdFor(playerId) {
+        return playerId === 2 ? 0 : 2;
+      },
+      isPartner(a, b) {
+        return (a === 0 && b === 2) || (a === 2 && b === 0);
+      },
+      cloneForSimulation() {
+        const clonePieces = JSON.parse(JSON.stringify(pieces));
+        return {
+          pieces: clonePieces,
+          makeMove(pieceId) {
+            const piece = clonePieces.find(p => p.id === pieceId);
+            piece.position = { row: 0, col: 8 };
+            return { success: true };
+          }
+        };
+      }
+    };
+
+    expect(wrapper.applyActionConstraints(2, [1, 2])).toEqual([1]);
+  });
+});

--- a/server/bot_wrapper.js
+++ b/server/bot_wrapper.js
@@ -131,10 +131,314 @@ class BotWrapper {
         }
       }
 
-      return validActions;
+      return this.applyActionConstraints(playerId, validActions);
     } catch (e) {
       return [];
     }
+  }
+
+
+  getTrackCoordinates() {
+    const track = [];
+    for (let col = 0; col < 19; col++) track.push({ row: 0, col });
+    for (let row = 1; row < 19; row++) track.push({ row, col: 18 });
+    for (let col = 17; col >= 0; col--) track.push({ row: 18, col });
+    for (let row = 17; row > 0; row--) track.push({ row, col: 0 });
+    return track;
+  }
+
+  positionsEqual(a, b) {
+    return Boolean(a && b && a.row === b.row && a.col === b.col);
+  }
+
+  entranceForPlayer(playerId) {
+    return [
+      { row: 0, col: 4 },
+      { row: 4, col: 18 },
+      { row: 18, col: 14 },
+      { row: 14, col: 0 }
+    ][playerId];
+  }
+
+  startForPlayer(playerId) {
+    return [
+      { row: 0, col: 8 },
+      { row: 8, col: 18 },
+      { row: 18, col: 10 },
+      { row: 10, col: 0 }
+    ][playerId];
+  }
+
+  trackIndex(pos) {
+    const track = this.getTrackCoordinates();
+    return track.findIndex(p => this.positionsEqual(p, pos));
+  }
+
+  stepsToEntrance(pos, playerId) {
+    const track = this.getTrackCoordinates();
+    const startIdx = this.trackIndex(pos);
+    const entranceIdx = this.trackIndex(this.entranceForPlayer(playerId));
+    if (startIdx < 0 || entranceIdx < 0) return -1;
+    return (entranceIdx - startIdx + track.length) % track.length;
+  }
+
+  withinHomeEntryReach(piece) {
+    if (!piece || piece.inPenaltyZone || piece.inHomeStretch || piece.completed) {
+      return false;
+    }
+    const stepsToEntry = this.stepsToEntrance(piece.position, piece.playerId);
+    if (stepsToEntry < 0) return false;
+    for (const cardSteps of [1, 2, 3, 4, 5, 6, 7, 9, 10]) {
+      const remaining = cardSteps - stepsToEntry;
+      if (remaining >= 1 && remaining <= 5) return true;
+    }
+    return false;
+  }
+
+  flattenCaptures(captures) {
+    const flat = [];
+    for (const capture of captures || []) {
+      flat.push(capture);
+      if (capture.result && capture.result.captures) {
+        flat.push(...this.flattenCaptures(capture.result.captures));
+      }
+    }
+    return flat;
+  }
+
+  actionPieceInfo(playerId, actionId) {
+    if (actionId >= 60) return null;
+    const pieceCount = this.game.piecesPerPlayer || 5;
+    let pieceNumber = actionId % 10;
+    let cardIndex;
+    if (pieceNumber === 0) {
+      pieceNumber = 10;
+      cardIndex = (actionId - pieceNumber) / 10;
+    } else {
+      cardIndex = Math.floor(actionId / 10);
+    }
+    let ownerId = playerId;
+    if (pieceNumber > pieceCount) {
+      const partner = this.game.partnerIdFor && this.game.partnerIdFor(playerId);
+      if (partner === null || partner === undefined) return null;
+      ownerId = partner;
+      pieceNumber -= pieceCount;
+    }
+    return { ownerId, pieceNumber, pieceId: `p${ownerId}_${pieceNumber}`, cardIndex };
+  }
+
+  simulateActionOutcomes(playerId, actionId) {
+    const outcomes = [];
+    if (!this.game || actionId >= 70) return outcomes;
+
+    if (actionId >= 60) {
+      const moves = this.specialActions[actionId];
+      if (!moves) return outcomes;
+      const clone = this.game.cloneForSimulation();
+      try {
+        let result = clone.makeSpecialMove(moves);
+        if (result && result.action === 'homeEntryChoice') {
+          result = clone.resumeSpecialMove(true);
+        }
+        if (!result || result.success === false) return outcomes;
+        const movedPieceIds = moves.map(m => m.pieceId);
+        const finalPieces = {};
+        for (const pid of movedPieceIds) {
+          const piece = clone.pieces.find(p => p.id === pid);
+          if (piece) finalPieces[pid] = JSON.parse(JSON.stringify(piece));
+        }
+        outcomes.push({
+          captures: this.flattenCaptures(result.captures),
+          movedPieceIds,
+          finalPieces
+        });
+      } catch (e) {}
+      return outcomes;
+    }
+
+    const info = this.actionPieceInfo(playerId, actionId);
+    if (!info) return outcomes;
+    const clone = this.game.cloneForSimulation();
+    try {
+      let result = clone.makeMove(info.pieceId, info.cardIndex);
+      if (result && result.action === 'homeEntryChoice') {
+        result = clone.makeMove(info.pieceId, info.cardIndex, true);
+      }
+      if (result && result.action === 'choosePosition') {
+        for (const target of result.validPositions || []) {
+          const choiceClone = this.game.cloneForSimulation();
+          try {
+            const choicePiece = choiceClone.pieces.find(p => p.id === info.pieceId);
+            const choiceResult = choiceClone.moveToSelectedPosition(choicePiece, target.id);
+            const finalPiece = choiceClone.pieces.find(p => p.id === info.pieceId);
+            outcomes.push({
+              captures: this.flattenCaptures(choiceResult && choiceResult.captures),
+              movedPieceIds: [info.pieceId],
+              finalPieces: finalPiece ? { [info.pieceId]: JSON.parse(JSON.stringify(finalPiece)) } : {},
+              jokerTargetId: target.id
+            });
+          } catch (e) {}
+        }
+      } else if (result && result.success !== false) {
+        const finalPiece = clone.pieces.find(p => p.id === info.pieceId);
+        outcomes.push({
+          captures: this.flattenCaptures(result.captures),
+          movedPieceIds: [info.pieceId],
+          finalPieces: finalPiece ? { [info.pieceId]: JSON.parse(JSON.stringify(finalPiece)) } : {}
+        });
+      }
+    } catch (e) {}
+    return outcomes;
+  }
+
+  getFixedPlayActions(playerId, actions) {
+    const priority = [];
+    const avoid = [];
+    if (!this.game) return { priorityActions: priority, avoidActions: avoid };
+
+    const partnerId = this.game.partnerIdFor ? this.game.partnerIdFor(playerId) : null;
+    const partnerHasPenaltyPiece = partnerId !== null && partnerId !== undefined && this.game.pieces.some(
+      p => p.playerId === partnerId && p.inPenaltyZone && !p.completed
+    );
+    const partnerStart = this.startForPlayer(partnerId);
+
+    for (const action of actions || []) {
+      if (action >= 70) continue;
+      const outcomes = this.simulateActionOutcomes(playerId, action);
+      let capturesHomeReachOpponent = false;
+      let capturesOpponentOnStart = false;
+      let capturesPartnerOnStart = false;
+      let parksOwnPieceOnPartnerStart = false;
+      let vacatesPartnerStart = false;
+
+      for (const outcome of outcomes) {
+        for (const capture of outcome.captures || []) {
+          const capturedBefore = this.game.pieces.find(p => p.id === capture.pieceId);
+          if (!capturedBefore) continue;
+          const isPartner = this.game.isPartner && this.game.isPartner(playerId, capturedBefore.playerId);
+          const isSelf = capturedBefore.playerId === playerId;
+          const isOpponent = !isSelf && !isPartner;
+          if (isOpponent && this.withinHomeEntryReach(capturedBefore)) {
+            capturesHomeReachOpponent = true;
+          }
+          const capturedStart = this.startForPlayer(capturedBefore.playerId);
+          if (isOpponent && this.positionsEqual(capturedBefore.position, capturedStart)) {
+            capturesOpponentOnStart = true;
+          }
+          if (isPartner && this.positionsEqual(capturedBefore.position, capturedStart)) {
+            capturesPartnerOnStart = true;
+          }
+        }
+      }
+
+      if (partnerHasPenaltyPiece && partnerStart) {
+        for (const outcome of outcomes) {
+          for (const pieceId of outcome.movedPieceIds || []) {
+            const beforeMove = this.game.pieces.find(p => p.id === pieceId);
+            const afterMove = outcome.finalPieces && outcome.finalPieces[pieceId];
+            if (!beforeMove || beforeMove.playerId !== playerId) continue;
+            const startedOnPartnerStart = this.positionsEqual(beforeMove.position, partnerStart);
+            const endedOnPartnerStart = this.positionsEqual(afterMove && afterMove.position, partnerStart);
+            if (!startedOnPartnerStart && endedOnPartnerStart) {
+              parksOwnPieceOnPartnerStart = true;
+            }
+            if (startedOnPartnerStart && !endedOnPartnerStart) {
+              vacatesPartnerStart = true;
+            }
+          }
+        }
+      }
+
+      if (capturesHomeReachOpponent || capturesPartnerOnStart || parksOwnPieceOnPartnerStart) {
+        priority.push(action);
+      }
+      if (capturesOpponentOnStart || vacatesPartnerStart) {
+        avoid.push(action);
+      }
+    }
+
+    return {
+      priorityActions: Array.from(new Set(priority)),
+      avoidActions: Array.from(new Set(avoid))
+    };
+  }
+
+  actionWouldEnterHome(playerId, actionId) {
+    try {
+      if (!this.game || !this.game.players || !this.game.players[playerId] || actionId >= 70) {
+        return false;
+      }
+
+      const clone = this.game.cloneForSimulation();
+
+      if (actionId >= 60) {
+        const moves = this.specialActions[actionId];
+        if (!moves) return false;
+        const before = moves.map(m => {
+          const piece = clone.pieces.find(p => p.id === m.pieceId);
+          return {
+            id: m.pieceId,
+            inHomeStretch: Boolean(piece && piece.inHomeStretch)
+          };
+        });
+        let result = clone.makeSpecialMove(moves);
+        if (result && result.action === 'homeEntryChoice') {
+          result = clone.resumeSpecialMove(true);
+        }
+        if (result && result.success === false) {
+          return false;
+        }
+        return before.some(info => {
+          const piece = clone.pieces.find(p => p.id === info.id);
+          return piece && !info.inHomeStretch && piece.inHomeStretch;
+        });
+      }
+
+      const info = this.actionPieceInfo(playerId, actionId);
+      if (!info) return false;
+      const beforePiece = clone.pieces.find(p => p.id === info.pieceId);
+      if (!beforePiece || beforePiece.inHomeStretch || beforePiece.completed) {
+        return false;
+      }
+
+      let result = clone.makeMove(info.pieceId, info.cardIndex);
+      if (result && result.action === 'homeEntryChoice') {
+        result = clone.makeMove(info.pieceId, info.cardIndex, true);
+      }
+      if (result && result.success === false) {
+        return false;
+      }
+
+      const afterPiece = clone.pieces.find(p => p.id === info.pieceId);
+      return Boolean(afterPiece && afterPiece.inHomeStretch);
+    } catch (e) {
+      return false;
+    }
+  }
+
+  getHomeEntryActions(playerId, actions) {
+    return (actions || []).filter(action => this.actionWouldEnterHome(playerId, action));
+  }
+
+  applyActionConstraints(playerId, actions) {
+    const validActions = Array.from(new Set(actions || []));
+    const validActionSet = new Set(validActions);
+    const homeEntryActions = this.getHomeEntryActions(playerId, validActions);
+    if (homeEntryActions.length > 0) {
+      return homeEntryActions;
+    }
+
+    const fixedPlayMetadata = this.getFixedPlayActions(playerId, validActions);
+    const fixedPlayActions = fixedPlayMetadata.priorityActions.filter(action => validActionSet.has(action));
+    if (fixedPlayActions.length > 0) {
+      return fixedPlayActions;
+    }
+
+    const avoidActions = new Set(
+      fixedPlayMetadata.avoidActions.filter(action => validActionSet.has(action))
+    );
+    const filteredActions = validActions.filter(action => !avoidActions.has(action));
+    return filteredActions.length > 0 ? filteredActions : validActions;
   }
 
   makeMove(playerId, actionId) {
@@ -202,7 +506,28 @@ class BotWrapper {
         }
 
         if (result && result.action === 'choosePosition') {
-          const target = result.validPositions && result.validPositions[0];
+          const targets = result.validPositions || [];
+          let target = targets[0];
+          let bestScore = -Infinity;
+          for (const candidate of targets) {
+            const targetPiece = this.game.pieces.find(p => p.id === candidate.id);
+            if (!targetPiece) continue;
+            const isPartner = this.game.isPartner && this.game.isPartner(playerId, targetPiece.playerId);
+            const isOpponent = targetPiece.playerId !== playerId && !isPartner;
+            const targetStart = this.startForPlayer(targetPiece.playerId);
+            let score = 0;
+            if (isOpponent && this.withinHomeEntryReach(targetPiece)) score += 100;
+            if (isOpponent && this.positionsEqual(targetPiece.position, targetStart)) {
+              score -= 50;
+            }
+            if (isPartner && this.positionsEqual(targetPiece.position, targetStart)) {
+              score += 80;
+            }
+            if (score > bestScore) {
+              bestScore = score;
+              target = candidate;
+            }
+          }
           if (!target) {
             throw new Error('No valid Joker positions');
           }


### PR DESCRIPTION
### Motivation
- Improve training and live-bot decision quality by exposing tactical action metadata (priority/avoid) so agents and human-game bots prefer urgent captures/setups and avoid risky moves when alternatives exist.
- Allow wrappers to evaluate move outcomes (including special moves and joker targets) to identify high-value plays such as capturing opponents near home-entry or protecting a jailed partner.

### Description
- Add outcome simulation helpers and board utilities (`getTrackCoordinates`, `positionsEqual`, `entranceForPlayer`, `startForPlayer`, `trackIndex`, `stepsToEntrance`, `withinHomeEntryReach`, `flattenCaptures`, `actionPieceInfo`, `simulateActionOutcomes`) to `game_wrapper.js` and `bot_wrapper.js` to support tactical analysis.
- Implement `getFixedPlayActions` to return `priorityActions` and `avoidActions` by simulating each candidate action and inspecting captures and final positions, and wire these into `getValidActions` responses in `game_wrapper.js` as `fixedPlayActions` and `avoidActions`.
- Add `applyActionConstraints` / `getHomeEntryActions` logic in `bot_wrapper.js` to prefer home-entry actions, then fixed-play priority actions, and to filter out avoidable actions when alternatives exist.
- Extend Joker handling in `game_wrapper.js` and `bot_wrapper.js` to choose the best `choosePosition` target by scoring candidates (favor opponent captures that threaten home-entry, prefer partner-protecting captures, and de-prioritize captures on opponent start squares).
- Propagate fixed-play and avoid metadata into the Python trainer: add `last_fixed_play_actions` and `last_avoid_actions` fields, populate them from Node responses in `get_valid_actions`, and incorporate them when computing `last_valid_actions` so the trainer masks or filters actions according to tactical metadata; also reset these fields in `reset_reward_events`.
- Minor cleanup: make discard message formatting consistent when forcing fallbacks.
- Add unit tests: JavaScript tests for `GameWrapper` (`tests/game_wrapper.test.js`) and `BotWrapper` (`server/__tests__/bot_wrapper.test.js`), and Python tests in `tests/test_environment.py` validating the new prioritization/filtering behavior.

### Testing
- Ran Python unit tests including `game-ai-training/tests/test_environment.py` which exercise `GameEnvironment.get_valid_actions` behavior with `fixedPlayActions` and `avoidActions`, and they passed.
- Ran JavaScript unit tests for `game/game_wrapper.js` (`tests/game_wrapper.test.js`) verifying special-action behavior and `fixedPlayActions` metadata, and they passed under the Jest test suite.
- Ran server-side JS tests for `server/bot_wrapper.js` (`server/__tests__/bot_wrapper.test.js`) verifying live `applyActionConstraints` behavior, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01173b9730832a938b6eeff0c34557)