### PR TITLE
Prioritize deepest bot home-stretch entries

### DIFF
--- a/server/__tests__/bot_wrapper.test.js
+++ b/server/__tests__/bot_wrapper.test.js
@@ -1,4 +1,5 @@
 const BotWrapper = require('../bot_wrapper');
+const { Game } = require('../game');
 
 function buildCaptureWrapper(capturedPiece, captureAction = 'opponentCapture') {
   const wrapper = new BotWrapper(null);
@@ -76,6 +77,30 @@ describe('BotWrapper live fixed play constraints', () => {
     });
 
     expect(wrapper.applyActionConstraints(0, [1])).toEqual([1]);
+  });
+
+  test('keeps only the deepest home-stretch entry action', () => {
+    const game = new Game('deepest-entry');
+    game.addPlayer('1', 'Alice', true);
+    game.addPlayer('2', 'Bob');
+    game.addPlayer('3', 'Carol');
+    game.addPlayer('4', 'Dave');
+    game.setupTeams();
+    game.isActive = true;
+
+    const player = game.players[0];
+    player.cards = [
+      { suit: '♠', value: '2' },
+      { suit: '♣', value: '5' }
+    ];
+
+    const mover = game.pieces.find(p => p.id === 'p0_1');
+    mover.inPenaltyZone = false;
+    mover.position = { row: 0, col: 4 };
+
+    const wrapper = new BotWrapper(game);
+
+    expect(wrapper.getValidActions(0)).toEqual([11]);
   });
 
   test('prioritizes parking an own piece on partner start when partner is jailed', () => {

--- a/server/bot_wrapper.js
+++ b/server/bot_wrapper.js
@@ -169,6 +169,49 @@ class BotWrapper {
     ][playerId];
   }
 
+  homeStretchForPlayer(playerId, game = this.game) {
+    if (game && typeof game.homeStretchForPlayer === 'function') {
+      return game.homeStretchForPlayer(playerId);
+    }
+    return [
+      [
+        { row: 1, col: 4 },
+        { row: 2, col: 4 },
+        { row: 3, col: 4 },
+        { row: 4, col: 4 },
+        { row: 5, col: 4 }
+      ],
+      [
+        { row: 4, col: 17 },
+        { row: 4, col: 16 },
+        { row: 4, col: 15 },
+        { row: 4, col: 14 },
+        { row: 4, col: 13 }
+      ],
+      [
+        { row: 17, col: 14 },
+        { row: 16, col: 14 },
+        { row: 15, col: 14 },
+        { row: 14, col: 14 },
+        { row: 13, col: 14 }
+      ],
+      [
+        { row: 14, col: 1 },
+        { row: 14, col: 2 },
+        { row: 14, col: 3 },
+        { row: 14, col: 4 },
+        { row: 14, col: 5 }
+      ]
+    ][playerId];
+  }
+
+  homeStretchIndex(piece, game = this.game) {
+    if (!piece || !piece.position) return -1;
+    const stretch = this.homeStretchForPlayer(piece.playerId, game);
+    if (!stretch) return -1;
+    return stretch.findIndex(pos => this.positionsEqual(pos, piece.position));
+  }
+
   trackIndex(pos) {
     const track = this.getTrackCoordinates();
     return track.findIndex(p => this.positionsEqual(p, pos));
@@ -363,17 +406,17 @@ class BotWrapper {
     };
   }
 
-  actionWouldEnterHome(playerId, actionId) {
+  homeEntryDepthForAction(playerId, actionId) {
     try {
       if (!this.game || !this.game.players || !this.game.players[playerId] || actionId >= 70) {
-        return false;
+        return -1;
       }
 
       const clone = this.game.cloneForSimulation();
 
       if (actionId >= 60) {
         const moves = this.specialActions[actionId];
-        if (!moves) return false;
+        if (!moves) return -1;
         const before = moves.map(m => {
           const piece = clone.pieces.find(p => p.id === m.pieceId);
           return {
@@ -386,19 +429,20 @@ class BotWrapper {
           result = clone.resumeSpecialMove(true);
         }
         if (result && result.success === false) {
-          return false;
+          return -1;
         }
-        return before.some(info => {
+        return before.reduce((bestDepth, info) => {
           const piece = clone.pieces.find(p => p.id === info.id);
-          return piece && !info.inHomeStretch && piece.inHomeStretch;
-        });
+          if (!piece || info.inHomeStretch || !piece.inHomeStretch) return bestDepth;
+          return Math.max(bestDepth, this.homeStretchIndex(piece, clone));
+        }, -1);
       }
 
       const info = this.actionPieceInfo(playerId, actionId);
-      if (!info) return false;
+      if (!info) return -1;
       const beforePiece = clone.pieces.find(p => p.id === info.pieceId);
       if (!beforePiece || beforePiece.inHomeStretch || beforePiece.completed) {
-        return false;
+        return -1;
       }
 
       let result = clone.makeMove(info.pieceId, info.cardIndex);
@@ -406,18 +450,29 @@ class BotWrapper {
         result = clone.makeMove(info.pieceId, info.cardIndex, true);
       }
       if (result && result.success === false) {
-        return false;
+        return -1;
       }
 
       const afterPiece = clone.pieces.find(p => p.id === info.pieceId);
-      return Boolean(afterPiece && afterPiece.inHomeStretch);
+      if (!afterPiece || !afterPiece.inHomeStretch) return -1;
+      return this.homeStretchIndex(afterPiece, clone);
     } catch (e) {
-      return false;
+      return -1;
     }
   }
 
+  actionWouldEnterHome(playerId, actionId) {
+    return this.homeEntryDepthForAction(playerId, actionId) >= 0;
+  }
+
   getHomeEntryActions(playerId, actions) {
-    return (actions || []).filter(action => this.actionWouldEnterHome(playerId, action));
+    const entries = (actions || [])
+      .map(action => ({ action, depth: this.homeEntryDepthForAction(playerId, action) }))
+      .filter(entry => entry.depth >= 0);
+    if (entries.length === 0) return [];
+
+    const deepest = Math.max(...entries.map(entry => entry.depth));
+    return entries.filter(entry => entry.depth === deepest).map(entry => entry.action);
   }
 
   applyActionConstraints(playerId, actions) {


### PR DESCRIPTION
### Motivation
- Ensure bots always prefer the legal home-entry that places a piece farthest into the home stretch so the model never sees weaker entry options when a deeper entry exists.

### Description
- Add `homeStretchForPlayer` and `homeStretchIndex` helpers to resolve and score positions using the game engine when available and a fallback coordinate map otherwise.
- Implement `homeEntryDepthForAction` which simulates an action on a cloned game and returns the resulting home-stretch index (or `-1` when it does not enter), and expose `actionWouldEnterHome` as its boolean wrapper.
- Change `getHomeEntryActions` to keep only the action(s) with the maximum home-stretch depth so `applyActionConstraints` will return the deepest entry choices to the bot.
- Add a regression test in `server/__tests__/bot_wrapper.test.js` that sets up a piece at the home-stretch entry with `2` and `5` cards and verifies only the `5` action is presented by `getValidActions`.

### Testing
- Ran `npm test -- --runTestsByPath server/__tests__/bot_wrapper.test.js` and the suite passed (bot wrapper tests passed).
- Ran `npm test -- --runTestsByPath server/__tests__/game.test.js` and the game tests passed.
- Ran the full test suite with `npm test` and all test suites passed (no test failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01e44f1984832a88db81c55c9e30d9)