### PR TITLE
Avoid protected card discards when bots are stuck

### DIFF
--- a/game-ai-training/game/game_wrapper.js
+++ b/game-ai-training/game/game_wrapper.js
@@ -329,13 +329,11 @@ class GameWrapper {
             const validActions = [...specialActionsList, ...moveActions];
 
             if (validActions.length === 0) {
-                // If no moves were generated, allow discarding any card. This
-                // ensures the Python trainer always receives at least one
-                // action even when a playable card lies outside the scanned
-                // range.
-                const maxDiscardCards = Math.min(cardIndices.length, 10);
-                for (let i = 0; i < maxDiscardCards; i++) {
-                    const cardIdx = cardIndices[i];
+                // If no moves were generated, allow discarding only low-value
+                // cards first. Preserve 7, 8 and Joker unless every discard
+                // option is protected.
+                const discardCardIndices = this.getPreferredDiscardCardIndices(player.cards, cardIndices);
+                for (const cardIdx of discardCardIndices) {
                     validActions.push(70 + cardIdx);
                 }
             }
@@ -346,6 +344,17 @@ class GameWrapper {
         } catch (error) {
             return [];
         }
+    }
+
+    isProtectedDiscardCard(card) {
+        return Boolean(card && ['7', '8', 'JOKER'].includes(card.value));
+    }
+
+    getPreferredDiscardCardIndices(cards, candidateIndices) {
+        const safeIndices = (candidateIndices || [])
+            .filter(idx => cards && cards[idx] && !this.isProtectedDiscardCard(cards[idx]));
+        const selectedIndices = safeIndices.length > 0 ? safeIndices : (candidateIndices || []);
+        return selectedIndices.slice(0, 10);
     }
 
 
@@ -821,6 +830,16 @@ class GameWrapper {
             if (actionId >= 70) {
                 const cardIndex = actionId - 70;
                 playedCard = this.game.players[playerId].cards[cardIndex];
+
+                const preferredDiscardCardIndices = this.getPreferredDiscardCardIndices(
+                    this.game.players[playerId].cards,
+                    Object.keys(this.game.players[playerId].cards || {}).map(Number)
+                );
+                if (this.isProtectedDiscardCard(playedCard) &&
+                    preferredDiscardCardIndices.length > 0 &&
+                    !preferredDiscardCardIndices.includes(cardIndex)) {
+                    return this.makeMove(playerId, 70 + preferredDiscardCardIndices[0]);
+                }
 
                 if (this.game.hasAnyValidMove && this.game.hasAnyValidMove(playerId)) {
                     const alt = this.findFirstAvailableAction(playerId);

--- a/game-ai-training/tests/game_wrapper.test.js
+++ b/game-ai-training/tests/game_wrapper.test.js
@@ -167,6 +167,89 @@ describe('GameWrapper 7-card split actions', () => {
   });
 });
 
+describe('GameWrapper discard protection', () => {
+  function buildDiscardOnlyWrapper(cards) {
+    const GameWrapper = loadGameWrapper();
+    const wrapper = new GameWrapper();
+    wrapper.game = {
+      players: [{ cards }],
+      pieces: [],
+      piecesPerPlayer: 1,
+      cloneForSimulation() {
+        return {
+          pieces: [],
+          makeMove() {
+            throw new Error('no moves');
+          },
+          makeSpecialMove() {
+            throw new Error('no special moves');
+          }
+        };
+      }
+    };
+    return wrapper;
+  }
+
+  test('does not expose 7, 8 or Joker discards while safer cards are available', () => {
+    const wrapper = buildDiscardOnlyWrapper([
+      { value: 'JOKER' },
+      { value: '8' },
+      { value: '7' },
+      { value: '5' },
+      { value: 'K' }
+    ]);
+
+    expect(wrapper.getValidActions(0)).toEqual([73, 74]);
+  });
+
+  test('allows protected discards only when every discard option is protected', () => {
+    const wrapper = buildDiscardOnlyWrapper([
+      { value: '8' },
+      { value: 'JOKER' },
+      { value: '7' }
+    ]);
+
+    expect(wrapper.getValidActions(0)).toEqual([70, 71, 72]);
+  });
+
+  test('redirects stale protected discard actions to a safer discard', () => {
+    const GameWrapper = loadGameWrapper();
+    const wrapper = new GameWrapper();
+    const discardedIndices = [];
+    wrapper.game = {
+      isActive: true,
+      currentPlayerIndex: 0,
+      players: [{ name: 'Bot_0', position: 0, cards: [{ value: 'JOKER' }, { value: '5' }] }],
+      pieces: [],
+      discardPile: [],
+      history: [],
+      stats: { roundsWithoutPlay: [0, 0, 0, 0], jokersPlayed: [0, 0, 0, 0] },
+      hasAnyValidMove() {
+        return false;
+      },
+      discardCard(cardIndex) {
+        discardedIndices.push(cardIndex);
+        this.players[0].cards.splice(cardIndex, 1);
+        return { success: true, action: 'discard' };
+      },
+      getCurrentPlayer() {
+        return null;
+      },
+      checkWinCondition() {
+        return false;
+      },
+      getWinningTeam() {
+        return null;
+      }
+    };
+
+    const response = wrapper.makeMove(0, 70);
+
+    expect(response.success).toBe(true);
+    expect(discardedIndices).toEqual([1]);
+  });
+});
+
 describe('GameWrapper fixed play action metadata', () => {
   function buildWrapper(capturedPiece, captureAction = 'opponentCapture') {
     const GameWrapper = loadGameWrapper();

--- a/server/bot_wrapper.js
+++ b/server/bot_wrapper.js
@@ -124,9 +124,8 @@ class BotWrapper {
       const validActions = [...specialActionsList, ...moveActions];
 
       if (validActions.length === 0) {
-        const maxDiscardCards = Math.min(cardIndices.length, 10);
-        for (let i = 0; i < maxDiscardCards; i++) {
-          const cardIdx = cardIndices[i];
+        const discardCardIndices = this.getPreferredDiscardCardIndices(player.cards, cardIndices);
+        for (const cardIdx of discardCardIndices) {
           validActions.push(70 + cardIdx);
         }
       }
@@ -135,6 +134,17 @@ class BotWrapper {
     } catch (e) {
       return [];
     }
+  }
+
+  isProtectedDiscardCard(card) {
+    return Boolean(card && ['7', '8', 'JOKER'].includes(card.value));
+  }
+
+  getPreferredDiscardCardIndices(cards, candidateIndices) {
+    const safeIndices = (candidateIndices || [])
+      .filter(idx => cards && cards[idx] && !this.isProtectedDiscardCard(cards[idx]));
+    const selectedIndices = safeIndices.length > 0 ? safeIndices : (candidateIndices || []);
+    return selectedIndices.slice(0, 10);
   }
 
 
@@ -512,6 +522,16 @@ class BotWrapper {
       if (actionId >= 70) {
         const cardIndex = actionId - 70;
         playedCard = this.game.players[playerId].cards[cardIndex];
+
+        const preferredDiscardCardIndices = this.getPreferredDiscardCardIndices(
+          this.game.players[playerId].cards,
+          Object.keys(this.game.players[playerId].cards || {}).map(Number)
+        );
+        if (this.isProtectedDiscardCard(playedCard) &&
+            preferredDiscardCardIndices.length > 0 &&
+            !preferredDiscardCardIndices.includes(cardIndex)) {
+          return this.makeMove(playerId, 70 + preferredDiscardCardIndices[0]);
+        }
 
         if (this.game.hasAnyValidMove && this.game.hasAnyValidMove(playerId)) {
           const alt = this.getValidActions(playerId)[0];


### PR DESCRIPTION
### Motivation
- Bots sometimes chose to discard protected cards (`JOKER`, `8`, `7`) when stuck, which harms play quality; discarding these should be avoided unless no safe discard exists.

### Description
- Prefer non-protected discard cards when no legal moves are generated by adding `isProtectedDiscardCard` and `getPreferredDiscardCardIndices` helpers and using them in the discard-generation path in `server/bot_wrapper.js` and `game-ai-training/game/game_wrapper.js`.
- Redirect stale/obsolete discard actions that attempt to discard a protected card in `makeMove` to a safer discard (if available) before calling `discardCard` in both the live bot wrapper and the training wrapper.
- Add Jest tests exercising the new behavior in `game-ai-training/tests/game_wrapper.test.js` to validate: (1) protected discards are not exposed when safer cards exist, (2) protected discards are allowed if all options are protected, and (3) stale protected-discard actions are redirected to a safer discard.

### Testing
- Ran the targeted wrapper tests with `npm test -- --runTestsByPath game-ai-training/tests/game_wrapper.test.js` and they passed (all new and existing assertions succeeded). 
- Ran the full Jest suite with `npm test -- --runInBand` and all test suites passed (total: 6 suites, 67 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a023774c234832aab667540661cb575)