### PR TITLE
Animate pieces along board path

### DIFF
--- a/public/js/game.js
+++ b/public/js/game.js
@@ -184,8 +184,87 @@ document.addEventListener('DOMContentLoaded', () => {
           pieceId: move.pieceId,
           from: move.oldPosition,
           to: move.newPosition,
+          direction: move.direction,
           order: index
         }));
+    }
+
+
+    function getTrackCoordinates() {
+      const track = [];
+      for (let col = 0; col <= 18; col++) track.push({ row: 0, col });
+      for (let row = 1; row <= 18; row++) track.push({ row, col: 18 });
+      for (let col = 17; col >= 0; col--) track.push({ row: 18, col });
+      for (let row = 17; row >= 1; row--) track.push({ row, col: 0 });
+      return track;
+    }
+
+    function positionIndex(path, position) {
+      return path.findIndex(pos => positionsEqual(pos, position));
+    }
+
+    function pathBetweenIndexes(path, startIndex, endIndex, direction = 'forward') {
+      if (startIndex === -1 || endIndex === -1) return [];
+      const step = direction === 'backward' ? -1 : 1;
+      const positions = [path[startIndex]];
+      let index = startIndex;
+      while (index !== endIndex) {
+        index = (index + step + path.length) % path.length;
+        positions.push(path[index]);
+        if (positions.length > path.length + 1) break;
+      }
+      return positions;
+    }
+
+    function buildBoardMovementPath(move, piece, previousPiece) {
+      const from = move?.from || previousPiece?.position;
+      const to = move?.to || piece?.position;
+      if (!from || !to || !piece || move?.direction === 'direct' || positionsEqual(from, to)) return [];
+
+      const track = getTrackCoordinates();
+      const startTrackIndex = positionIndex(track, from);
+      const endTrackIndex = positionIndex(track, to);
+      if (startTrackIndex !== -1 && endTrackIndex !== -1) {
+        return pathBetweenIndexes(track, startTrackIndex, endTrackIndex, move?.direction || 'forward');
+      }
+
+      const homeStretch = homeStretches[piece.playerId] || [];
+      const startHomeIndex = positionIndex(homeStretch, from);
+      const endHomeIndex = positionIndex(homeStretch, to);
+      if (startHomeIndex !== -1 && endHomeIndex !== -1 && endHomeIndex >= startHomeIndex) {
+        return homeStretch.slice(startHomeIndex, endHomeIndex + 1);
+      }
+
+      if (startTrackIndex !== -1 && endHomeIndex !== -1) {
+        const entrances = [
+          { row: 0, col: 4 },
+          { row: 4, col: 18 },
+          { row: 18, col: 14 },
+          { row: 14, col: 0 }
+        ];
+        const entranceIndex = positionIndex(track, entrances[piece.playerId]);
+        const boardPath = pathBetweenIndexes(track, startTrackIndex, entranceIndex, 'forward');
+        return [...boardPath, ...homeStretch.slice(0, endHomeIndex + 1)];
+      }
+
+      return [];
+    }
+
+    function buildMovementKeyframes(path, finalRect, rotation) {
+      const keyframes = path
+        .map(position => getCell(position.row, position.col))
+        .filter(Boolean)
+        .map(cell => {
+          const rect = cell.getBoundingClientRect();
+          const centeredLeft = rect.left + (rect.width - finalRect.width) / 2;
+          const centeredTop = rect.top + (rect.height - finalRect.height) / 2;
+          return {
+            transform: `translate(${centeredLeft - finalRect.left}px, ${centeredTop - finalRect.top}px) rotate(${-rotation}deg)`
+          };
+        });
+
+      keyframes.push({ transform: `rotate(${-rotation}deg)` });
+      return keyframes;
     }
 
     function clearMoveHighlights() {
@@ -1034,12 +1113,21 @@ function updatePlayerLabels() {
     pieceElement.style.transform = `rotate(${-rotation}deg)`;
 
     if (moved && (Math.abs(deltaX) > 0.5 || Math.abs(deltaY) > 0.5)) {
-      pieceElement.style.transform = `translate(${deltaX}px, ${deltaY}px) rotate(${-rotation}deg)`;
+      const boardMovementPath = moveDescriptor ? buildBoardMovementPath(moveDescriptor, piece, previousPiece) : [];
+      const keyframes = boardMovementPath.length > 1
+        ? buildMovementKeyframes(boardMovementPath, last, rotation)
+        : [
+            { transform: `translate(${deltaX}px, ${deltaY}px) rotate(${-rotation}deg)` },
+            { transform: `rotate(${-rotation}deg)` }
+          ];
+
+      pieceElement.style.transform = keyframes[0].transform;
       animations.push({
         element: pieceElement,
         from: moveDescriptor ? moveDescriptor.from : previousPiece.position,
         to: moveDescriptor ? moveDescriptor.to : piece.position,
         order: moveDescriptor ? moveDescriptor.order : animations.length,
+        keyframes,
         finalTransform: `rotate(${-rotation}deg)`
       });
     }
@@ -1062,9 +1150,14 @@ async function animatePieceMoves(animations) {
     highlightMoveCells(animation);
     animation.element.classList.add('moving');
     await waitForNextFrame();
-    animation.element.style.transition = `transform ${MOVE_ANIMATION_DURATION_MS}ms ease-in-out`;
+    animation.element.style.transition = 'none';
+    const movement = animation.element.animate(animation.keyframes, {
+      duration: MOVE_ANIMATION_DURATION_MS,
+      easing: 'ease-in-out',
+      fill: 'forwards'
+    });
+    await movement.finished.catch(() => {});
     animation.element.style.transform = animation.finalTransform;
-    await wait(MOVE_ANIMATION_DURATION_MS);
     animation.element.classList.remove('moving');
   }
 

--- a/server/bot_manager.js
+++ b/server/bot_manager.js
@@ -2,6 +2,14 @@ const { spawn } = require('child_process');
 const path = require('path');
 const BotWrapper = require('./bot_wrapper');
 const { logTurnState, logMoveDetails } = require('./log_utils');
+
+function getMoveAnimationDirection(card, result) {
+  if ((card && card.value === 'JOKER') || (result && ['leavePenalty', 'choosePosition'].includes(result.action))) {
+    return 'direct';
+  }
+  return card && card.value === '8' ? 'backward' : 'forward';
+}
+
 class BotManager {
   constructor(game, io, onGameOver = null) {
     this.game = game;
@@ -103,7 +111,8 @@ class BotManager {
         stateForClients.moveAnimations = result.moves.map(move => ({
           pieceId: move.pieceId,
           oldPosition: move.oldPosition,
-          newPosition: move.newPosition
+          newPosition: move.newPosition,
+          direction: 'forward'
         }));
       } else if (pieceId && oldPos) {
         const movedPiece = this.game.pieces.find(p => p.id === pieceId);
@@ -111,7 +120,8 @@ class BotManager {
           stateForClients.moveAnimations = [{
             pieceId,
             oldPosition: oldPos,
-            newPosition: { ...movedPiece.position }
+            newPosition: { ...movedPiece.position },
+            direction: getMoveAnimationDirection(playedCard, result)
           }];
         }
       }

--- a/server/server.js
+++ b/server/server.js
@@ -71,6 +71,14 @@ app.get('/replay', (req, res) => {
 
 
 
+
+function getMoveAnimationDirection(card, moveResult) {
+  if ((card && card.value === 'JOKER') || (moveResult && ['leavePenalty', 'choosePosition'].includes(moveResult.action))) {
+    return 'direct';
+  }
+  return card && card.value === '8' ? 'backward' : 'forward';
+}
+
 function announceHomeStretch(game, roomId) {
   for (let i = 0; i < game.players.length; i++) {
     if (!game.homeStretchAnnounced[i] && game.hasAllPiecesInHomeStretch(i)) {
@@ -721,7 +729,8 @@ socket.on('makeMove', ({ roomId, pieceId, cardIndex, enterHome }) => {
       updatedState.moveAnimations = [{
         pieceId,
         oldPosition: oldPos,
-        newPosition: { ...movedPiece.position }
+        newPosition: { ...movedPiece.position },
+        direction: getMoveAnimationDirection(playedCard, moveResult)
       }];
     }
     io.to(roomId).emit('gameStateUpdate', updatedState);
@@ -797,7 +806,8 @@ socket.on('confirmHomeEntry', ({ roomId, pieceId, cardIndex, enterHome }) => {
       updatedState.moveAnimations = [{
         pieceId,
         oldPosition: oldPos,
-        newPosition: { ...movedPiece.position }
+        newPosition: { ...movedPiece.position },
+        direction: getMoveAnimationDirection(playedCard, moveResult)
       }];
     }
     io.to(roomId).emit('gameStateUpdate', updatedState);
@@ -898,7 +908,8 @@ socket.on('confirmHomeEntry', ({ roomId, pieceId, cardIndex, enterHome }) => {
         updatedState.moveAnimations = moveResult.moves.map(move => ({
           pieceId: move.pieceId,
           oldPosition: move.oldPosition,
-          newPosition: move.newPosition
+          newPosition: move.newPosition,
+          direction: 'forward'
         }));
       }
       io.to(roomId).emit('gameStateUpdate', updatedState);
@@ -1017,7 +1028,8 @@ socket.on('confirmHomeEntry', ({ roomId, pieceId, cardIndex, enterHome }) => {
         updatedState.moveAnimations = moveResult.moves.map(move => ({
           pieceId: move.pieceId,
           oldPosition: move.oldPosition,
-          newPosition: move.newPosition
+          newPosition: move.newPosition,
+          direction: 'forward'
         }));
       }
       io.to(roomId).emit('gameStateUpdate', updatedState);


### PR DESCRIPTION
### Motivation
- Make piece animations follow the actual board path and the in-game movement direction so users can visually track moves more easily, while keeping captures/teleports as direct transitions.

### Description
- Frontend: parse server-provided `moveAnimations` direction and build waypoint paths with `getTrackCoordinates`, `buildBoardMovementPath` and `buildMovementKeyframes` to create per-cell keyframes for normal moves; use `Element.animate` to run those keyframes and fall back to a simple translate when no path is available.
- Frontend: update piece placement/animation logic in `positionPieces` / `animatePieceMoves` to apply keyframe-based animations while preserving board rotation and final transforms.
- Backend: annotate move payloads with `direction` in `server/server.js` and `server/bot_manager.js` so clients can distinguish `forward`, `backward` and `direct` (for Joker/penalty-exit/teleport) animations; special/multi-move sequences are marked `forward` by default.
- Behavior: captures and teleport-like moves remain direct (teleport across board); standard track movements are animated along the perimeter/home-stretch in the same direction pieces actually move in the game.

### Testing
- Ran syntax checks with `node --check public/js/game.js && node --check server/server.js && node --check server/bot_manager.js` and they passed.
- Ran the automated test suite with `npm test -- --runInBand` (Jest): all test suites passed (6 test suites, 67 tests total).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0252d52640832a85e983fdebae06ab)