### PR TITLE
Prioritize homestretch piece moves for bots

### DIFF
--- a/game-ai-training/ai/environment.py
+++ b/game-ai-training/ai/environment.py
@@ -249,6 +249,7 @@ class GameEnvironment:
         # Cache legal actions so state encoding can include action metadata.
         self.last_valid_actions: Dict[int, List[int]] = {}
         self.last_home_entry_actions: Dict[int, List[int]] = {}
+        self.last_home_stretch_move_actions: Dict[int, List[int]] = {}
         self.last_fixed_play_actions: Dict[int, List[int]] = {}
         self.last_avoid_actions: Dict[int, List[int]] = {}
         # Tracks one-turn 8-card setup opportunities by player. A setup is
@@ -762,12 +763,14 @@ class GameEnvironment:
             result = [fallback[0]] if fallback else []
             self.last_valid_actions[player_id] = result
             self.last_home_entry_actions[player_id] = []
+            self.last_home_stretch_move_actions[player_id] = []
             self.last_fixed_play_actions[player_id] = []
             self.last_avoid_actions[player_id] = []
             return result
 
         actions = response.get("validActions", [])
         self.last_home_entry_actions[player_id] = list(response.get("homeEntryActions", []))
+        self.last_home_stretch_move_actions[player_id] = list(response.get("homeStretchMoveActions", []))
         self.last_fixed_play_actions[player_id] = list(response.get("fixedPlayActions", []))
         self.last_avoid_actions[player_id] = list(response.get("avoidActions", []))
         # Ensure actions are within the defined action space and remain valid
@@ -786,6 +789,7 @@ class GameEnvironment:
                 result = [discard_actions[0]]
                 self.last_valid_actions[player_id] = result
                 self.last_home_entry_actions[player_id] = []
+                self.last_home_stretch_move_actions[player_id] = []
                 self.last_fixed_play_actions[player_id] = []
                 self.last_avoid_actions[player_id] = []
                 return result
@@ -793,6 +797,7 @@ class GameEnvironment:
             result = [fallback[0]] if fallback else []
             self.last_valid_actions[player_id] = result
             self.last_home_entry_actions[player_id] = []
+            self.last_home_stretch_move_actions[player_id] = []
             self.last_fixed_play_actions[player_id] = []
             self.last_avoid_actions[player_id] = []
             return result
@@ -815,10 +820,24 @@ class GameEnvironment:
             # Homestretch entry is a rule-level priority for the training policy:
             # when any legal action can enter home, mask out every alternative so
             # the bot cannot learn to prefer captures, setup moves, or discards.
+            self.last_home_stretch_move_actions[player_id] = []
             self.last_fixed_play_actions[player_id] = []
             self.last_avoid_actions[player_id] = []
             self.last_valid_actions[player_id] = home_entry_actions
             return home_entry_actions
+
+        home_stretch_move_actions = [
+            act for act in self.last_home_stretch_move_actions.get(player_id, []) if act in valid_action_set
+        ]
+        self.last_home_stretch_move_actions[player_id] = home_stretch_move_actions
+        if home_stretch_move_actions:
+            # Once a piece is already in the homestretch, moving it deeper with
+            # A/2/3/4 or a split 7 is mandatory so bots keep organizing pieces
+            # instead of wasting winning positions on unrelated moves.
+            self.last_fixed_play_actions[player_id] = []
+            self.last_avoid_actions[player_id] = []
+            self.last_valid_actions[player_id] = home_stretch_move_actions
+            return home_stretch_move_actions
 
         fixed_play_actions = [
             act for act in self.last_fixed_play_actions.get(player_id, []) if act in valid_action_set
@@ -843,6 +862,9 @@ class GameEnvironment:
         valid_action_set = set(unique_actions)
         self.last_home_entry_actions[player_id] = [
             act for act in self.last_home_entry_actions.get(player_id, []) if act in valid_action_set
+        ]
+        self.last_home_stretch_move_actions[player_id] = [
+            act for act in self.last_home_stretch_move_actions.get(player_id, []) if act in valid_action_set
         ]
         return unique_actions
 

--- a/game-ai-training/game/game_wrapper.js
+++ b/game-ai-training/game/game_wrapper.js
@@ -109,6 +109,7 @@ class GameWrapper {
                     return {
                         validActions,
                         homeEntryActions: this.getHomeEntryActions(command.playerId, validActions),
+                        homeStretchMoveActions: this.getHomeStretchMoveActions(command.playerId, validActions),
                         fixedPlayActions: fixedPlayActions.priorityActions,
                         avoidActions: fixedPlayActions.avoidActions
                     };
@@ -389,6 +390,49 @@ class GameWrapper {
         ][playerId];
     }
 
+    homeStretchForPlayer(playerId, game = this.game) {
+        if (game && typeof game.homeStretchForPlayer === 'function') {
+            return game.homeStretchForPlayer(playerId);
+        }
+        return [
+            [
+                { row: 1, col: 4 },
+                { row: 2, col: 4 },
+                { row: 3, col: 4 },
+                { row: 4, col: 4 },
+                { row: 5, col: 4 }
+            ],
+            [
+                { row: 4, col: 17 },
+                { row: 4, col: 16 },
+                { row: 4, col: 15 },
+                { row: 4, col: 14 },
+                { row: 4, col: 13 }
+            ],
+            [
+                { row: 17, col: 14 },
+                { row: 16, col: 14 },
+                { row: 15, col: 14 },
+                { row: 14, col: 14 },
+                { row: 13, col: 14 }
+            ],
+            [
+                { row: 14, col: 1 },
+                { row: 14, col: 2 },
+                { row: 14, col: 3 },
+                { row: 14, col: 4 },
+                { row: 14, col: 5 }
+            ]
+        ][playerId];
+    }
+
+    homeStretchIndex(piece, game = this.game) {
+        if (!piece || !piece.position) return -1;
+        const stretch = this.homeStretchForPlayer(piece.playerId, game);
+        if (!stretch) return -1;
+        return stretch.findIndex(pos => this.positionsEqual(pos, piece.position));
+    }
+
     trackIndex(pos) {
         const track = this.getTrackCoordinates();
         return track.findIndex(p => this.positionsEqual(p, pos));
@@ -650,6 +694,75 @@ class GameWrapper {
         } catch (e) {
             return false;
         }
+    }
+
+    homeStretchProgressForAction(playerId, actionId) {
+        try {
+            if (!this.game || !this.game.players || !this.game.players[playerId] || actionId >= 70) {
+                return -1;
+            }
+
+            const clone = this.game.cloneForSimulation();
+            const beforeByPiece = new Map();
+            const trackBefore = (pieceId) => {
+                const piece = clone.pieces.find(p => p.id === pieceId);
+                if (!piece || !piece.inHomeStretch || piece.completed) return;
+                beforeByPiece.set(pieceId, this.homeStretchIndex(piece, clone));
+            };
+
+            if (actionId >= 60) {
+                const moves = this.specialActions[actionId];
+                if (!moves) return -1;
+                for (const move of moves) {
+                    trackBefore(move.pieceId);
+                }
+                if (beforeByPiece.size === 0) return -1;
+
+                let result = clone.makeSpecialMove(moves);
+                if (result && result.action === 'homeEntryChoice') {
+                    result = clone.resumeSpecialMove(true);
+                }
+                if (result && result.success === false) {
+                    return -1;
+                }
+            } else {
+                const info = this.actionPieceInfo(playerId, actionId);
+                if (!info) return -1;
+                const card = this.game.players[playerId].cards[info.cardIndex];
+                if (!card || !['A', '2', '3', '4'].includes(card.value)) {
+                    return -1;
+                }
+                trackBefore(info.pieceId);
+                if (beforeByPiece.size === 0) return -1;
+
+                const result = clone.makeMove(info.pieceId, info.cardIndex);
+                if (result && result.success === false) {
+                    return -1;
+                }
+            }
+
+            let bestProgress = -1;
+            for (const [pieceId, beforeIndex] of beforeByPiece.entries()) {
+                const piece = clone.pieces.find(p => p.id === pieceId);
+                const afterIndex = this.homeStretchIndex(piece, clone);
+                if (afterIndex > beforeIndex) {
+                    bestProgress = Math.max(bestProgress, afterIndex);
+                }
+            }
+            return bestProgress;
+        } catch (e) {
+            return -1;
+        }
+    }
+
+    getHomeStretchMoveActions(playerId, actions) {
+        const moves = (actions || [])
+            .map(action => ({ action, progress: this.homeStretchProgressForAction(playerId, action) }))
+            .filter(entry => entry.progress >= 0);
+        if (moves.length === 0) return [];
+
+        const deepest = Math.max(...moves.map(entry => entry.progress));
+        return moves.filter(entry => entry.progress === deepest).map(entry => entry.action);
     }
 
     getHomeEntryActions(playerId, actions) {

--- a/game-ai-training/tests/test_environment.py
+++ b/game-ai-training/tests/test_environment.py
@@ -135,6 +135,26 @@ def test_get_valid_actions_prioritizes_home_entry_actions():
     assert env.last_home_entry_actions[0] == [2]
 
 
+
+def test_get_valid_actions_prioritizes_home_stretch_move_actions_after_entries():
+    env = GameEnvironment()
+    response = {
+        'validActions': [1, 2, 2, 3],
+        'homeEntryActions': [],
+        'homeStretchMoveActions': [2, 4],
+        'fixedPlayActions': [3],
+        'avoidActions': [],
+    }
+
+    with patch.object(env, 'send_command', return_value=response):
+        with patch.object(env, 'is_action_valid', return_value=True):
+            actions = env.get_valid_actions(0)
+
+    assert actions == [2]
+    assert env.last_valid_actions[0] == [2]
+    assert env.last_home_stretch_move_actions[0] == [2]
+    assert env.last_fixed_play_actions[0] == []
+
 def test_missed_home_entry_penalty_when_entry_action_available():
     env = GameEnvironment()
     step_cost = STEP_PENALTY_BASE * max(1.0, env.pieces_per_player / 2.0)

--- a/server/__tests__/bot_wrapper.test.js
+++ b/server/__tests__/bot_wrapper.test.js
@@ -103,6 +103,37 @@ describe('BotWrapper live fixed play constraints', () => {
     expect(wrapper.getValidActions(0)).toEqual([11]);
   });
 
+
+  test('keeps only deepest available home-stretch move action', () => {
+    const game = new Game('home-stretch-progress');
+    game.addPlayer('1', 'Alice', true);
+    game.addPlayer('2', 'Bob');
+    game.addPlayer('3', 'Carol');
+    game.addPlayer('4', 'Dave');
+    game.setupTeams();
+    game.isActive = true;
+
+    const player = game.players[0];
+    player.cards = [
+      { suit: '♠', value: 'A' },
+      { suit: '♣', value: '2' },
+      { suit: '♦', value: '5' }
+    ];
+
+    const homeMover = game.pieces.find(p => p.id === 'p0_1');
+    homeMover.inPenaltyZone = false;
+    homeMover.inHomeStretch = true;
+    homeMover.position = { ...game.homeStretchForPlayer(0)[0] };
+
+    const boardMover = game.pieces.find(p => p.id === 'p0_2');
+    boardMover.inPenaltyZone = false;
+    boardMover.position = { row: 0, col: 9 };
+
+    const wrapper = new BotWrapper(game);
+
+    expect(wrapper.getValidActions(0)).toEqual([11]);
+  });
+
   test('prioritizes parking an own piece on partner start when partner is jailed', () => {
     const wrapper = new BotWrapper(null);
     const pieces = [

--- a/server/bot_wrapper.js
+++ b/server/bot_wrapper.js
@@ -475,6 +475,75 @@ class BotWrapper {
     return this.homeEntryDepthForAction(playerId, actionId) >= 0;
   }
 
+  homeStretchProgressForAction(playerId, actionId) {
+    try {
+      if (!this.game || !this.game.players || !this.game.players[playerId] || actionId >= 70) {
+        return -1;
+      }
+
+      const clone = this.game.cloneForSimulation();
+      const beforeByPiece = new Map();
+      const trackBefore = (pieceId) => {
+        const piece = clone.pieces.find(p => p.id === pieceId);
+        if (!piece || !piece.inHomeStretch || piece.completed) return;
+        beforeByPiece.set(pieceId, this.homeStretchIndex(piece, clone));
+      };
+
+      if (actionId >= 60) {
+        const moves = this.specialActions[actionId];
+        if (!moves) return -1;
+        for (const move of moves) {
+          trackBefore(move.pieceId);
+        }
+        if (beforeByPiece.size === 0) return -1;
+
+        let result = clone.makeSpecialMove(moves);
+        if (result && result.action === 'homeEntryChoice') {
+          result = clone.resumeSpecialMove(true);
+        }
+        if (result && result.success === false) {
+          return -1;
+        }
+      } else {
+        const info = this.actionPieceInfo(playerId, actionId);
+        if (!info) return -1;
+        const card = this.game.players[playerId].cards[info.cardIndex];
+        if (!card || !['A', '2', '3', '4'].includes(card.value)) {
+          return -1;
+        }
+        trackBefore(info.pieceId);
+        if (beforeByPiece.size === 0) return -1;
+
+        const result = clone.makeMove(info.pieceId, info.cardIndex);
+        if (result && result.success === false) {
+          return -1;
+        }
+      }
+
+      let bestProgress = -1;
+      for (const [pieceId, beforeIndex] of beforeByPiece.entries()) {
+        const piece = clone.pieces.find(p => p.id === pieceId);
+        const afterIndex = this.homeStretchIndex(piece, clone);
+        if (afterIndex > beforeIndex) {
+          bestProgress = Math.max(bestProgress, afterIndex);
+        }
+      }
+      return bestProgress;
+    } catch (e) {
+      return -1;
+    }
+  }
+
+  getHomeStretchMoveActions(playerId, actions) {
+    const moves = (actions || [])
+      .map(action => ({ action, progress: this.homeStretchProgressForAction(playerId, action) }))
+      .filter(entry => entry.progress >= 0);
+    if (moves.length === 0) return [];
+
+    const deepest = Math.max(...moves.map(entry => entry.progress));
+    return moves.filter(entry => entry.progress === deepest).map(entry => entry.action);
+  }
+
   getHomeEntryActions(playerId, actions) {
     const entries = (actions || [])
       .map(action => ({ action, depth: this.homeEntryDepthForAction(playerId, action) }))
@@ -491,6 +560,11 @@ class BotWrapper {
     const homeEntryActions = this.getHomeEntryActions(playerId, validActions);
     if (homeEntryActions.length > 0) {
       return homeEntryActions;
+    }
+
+    const homeStretchMoveActions = this.getHomeStretchMoveActions(playerId, validActions);
+    if (homeStretchMoveActions.length > 0) {
+      return homeStretchMoveActions;
     }
 
     const fixedPlayMetadata = this.getFixedPlayActions(playerId, validActions);


### PR DESCRIPTION
### Motivation
- Bots were missing winning/organizing moves for pieces already in the homestretch and losing games by not advancing those pieces.
- Homestretch-entry actions are already prioritized; similar masking is needed for moves that progress pieces already inside the homestretch (A/2/3/4 and split-7 moves).
- Expose this metadata to the training environment so learners cannot ignore mandatory homestretch organization during training.

### Description
- Added homestretch progress detection and selection logic with `homeStretchProgressForAction` and `getHomeStretchMoveActions` to the server bot wrapper, and integrated it into action filtering so homestretch moves are returned when present. (server/bot_wrapper.js)
- Exposed `homeStretchMoveActions` from the training game wrapper and added `homeStretchForPlayer`/`homeStretchIndex` helpers used for progress calculations. (game-ai-training/game/game_wrapper.js)
- Extended the Python training environment to cache `last_home_stretch_move_actions` and to mask to homestretch-move actions after home-entry masking and before fixed tactical plays. (game-ai-training/ai/environment.py)
- Added regression tests covering live bot homestretch move prioritization and the training-side masking behavior. (server/__tests__/bot_wrapper.test.js, game-ai-training/tests/test_environment.py)

### Testing
- Ran the JavaScript unit tests: `npm test -- --runInBand server/__tests__/bot_wrapper.test.js game-ai-training/tests/game_wrapper.test.js` and the suites passed (JS tests: PASS).
- Ran the Python tests: `pytest game-ai-training/tests/test_environment.py -q` and all tests passed (`18 passed`).
- New/updated tests cover the homestretch move prioritization both in live bot logic and the training environment and passed in CI-like local runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a025f0507e8832aaafc3b5ee802e340)