### PR TITLE
Improve board move animation tracking

### DIFF
--- a/public/js/game.js
+++ b/public/js/game.js
@@ -185,7 +185,7 @@ document.addEventListener('DOMContentLoaded', () => {
           from: move.oldPosition,
           to: move.newPosition,
           direction: move.direction,
-          order: index
+          order: Number.isFinite(move.order) ? move.order : index
         }));
     }
 

--- a/server/bot_manager.js
+++ b/server/bot_manager.js
@@ -3,6 +3,44 @@ const path = require('path');
 const BotWrapper = require('./bot_wrapper');
 const { logTurnState, logMoveDetails } = require('./log_utils');
 
+
+function positionsEqual(a, b) {
+  return Boolean(a && b && a.row === b.row && a.col === b.col);
+}
+
+function capturePiecePositions(game) {
+  const positions = new Map();
+  game.pieces.forEach(piece => {
+    positions.set(piece.id, { ...piece.position });
+  });
+  return positions;
+}
+
+function buildMoveAnimations(game, previousPositions, primaryMoves = []) {
+  const animations = primaryMoves.map((move, index) => ({
+    ...move,
+    order: index
+  }));
+  const primaryPieceIds = new Set(primaryMoves.map(move => move.pieceId));
+
+  game.pieces.forEach(piece => {
+    const oldPosition = previousPositions.get(piece.id);
+    if (!oldPosition || primaryPieceIds.has(piece.id) || positionsEqual(oldPosition, piece.position)) {
+      return;
+    }
+
+    animations.push({
+      pieceId: piece.id,
+      oldPosition,
+      newPosition: { ...piece.position },
+      direction: 'direct',
+      order: animations.length
+    });
+  });
+
+  return animations;
+}
+
 function getMoveAnimationDirection(card, result) {
   if ((card && card.value === 'JOKER') || (result && ['leavePenalty', 'choosePosition'].includes(result.action))) {
     return 'direct';
@@ -104,25 +142,27 @@ class BotManager {
         playedCard = this.game.players[current.position].cards[cardIndex];
       }
 
+      const previousPositions = capturePiecePositions(this.game);
       const result = this.wrapper.makeMove(current.position, actionId);
       const roomId = this.game.roomId;
       const stateForClients = result.gameState;
       if (actionId >= 60 && actionId < 70 && result.moves) {
-        stateForClients.moveAnimations = result.moves.map(move => ({
+        const primaryMoves = result.moves.map(move => ({
           pieceId: move.pieceId,
           oldPosition: move.oldPosition,
           newPosition: move.newPosition,
           direction: 'forward'
         }));
+        stateForClients.moveAnimations = buildMoveAnimations(this.game, previousPositions, primaryMoves);
       } else if (pieceId && oldPos) {
         const movedPiece = this.game.pieces.find(p => p.id === pieceId);
         if (movedPiece) {
-          stateForClients.moveAnimations = [{
+          stateForClients.moveAnimations = buildMoveAnimations(this.game, previousPositions, [{
             pieceId,
             oldPosition: oldPos,
             newPosition: { ...movedPiece.position },
             direction: getMoveAnimationDirection(playedCard, result)
-          }];
+          }]);
         }
       }
       this.io.to(roomId).emit('gameStateUpdate', stateForClients);

--- a/server/server.js
+++ b/server/server.js
@@ -72,6 +72,44 @@ app.get('/replay', (req, res) => {
 
 
 
+
+function positionsEqual(a, b) {
+  return Boolean(a && b && a.row === b.row && a.col === b.col);
+}
+
+function capturePiecePositions(game) {
+  const positions = new Map();
+  game.pieces.forEach(piece => {
+    positions.set(piece.id, { ...piece.position });
+  });
+  return positions;
+}
+
+function buildMoveAnimations(game, previousPositions, primaryMoves = []) {
+  const animations = primaryMoves.map((move, index) => ({
+    ...move,
+    order: index
+  }));
+  const primaryPieceIds = new Set(primaryMoves.map(move => move.pieceId));
+
+  game.pieces.forEach(piece => {
+    const oldPosition = previousPositions.get(piece.id);
+    if (!oldPosition || primaryPieceIds.has(piece.id) || positionsEqual(oldPosition, piece.position)) {
+      return;
+    }
+
+    animations.push({
+      pieceId: piece.id,
+      oldPosition,
+      newPosition: { ...piece.position },
+      direction: 'direct',
+      order: animations.length
+    });
+  });
+
+  return animations;
+}
+
 function getMoveAnimationDirection(card, moveResult) {
   if ((card && card.value === 'JOKER') || (moveResult && ['leavePenalty', 'choosePosition'].includes(moveResult.action))) {
     return 'direct';
@@ -693,6 +731,7 @@ socket.on('makeMove', ({ roomId, pieceId, cardIndex, enterHome }) => {
   try {
     const piece = game.pieces.find(p => p.id === pieceId);
     const oldPos = { ...piece.position };
+    const previousPositions = capturePiecePositions(game);
     const playedCard = currentPlayer.cards[cardIndex];
     const moveResult = game.makeMove(pieceId, cardIndex, enterHome);
 
@@ -726,12 +765,12 @@ socket.on('makeMove', ({ roomId, pieceId, cardIndex, enterHome }) => {
     const updatedState = game.getGameState();
     const movedPiece = game.pieces.find(p => p.id === pieceId);
     if (movedPiece) {
-      updatedState.moveAnimations = [{
+      updatedState.moveAnimations = buildMoveAnimations(game, previousPositions, [{
         pieceId,
         oldPosition: oldPos,
         newPosition: { ...movedPiece.position },
         direction: getMoveAnimationDirection(playedCard, moveResult)
-      }];
+      }]);
     }
     io.to(roomId).emit('gameStateUpdate', updatedState);
     announceHomeStretch(game, roomId);
@@ -793,6 +832,7 @@ socket.on('confirmHomeEntry', ({ roomId, pieceId, cardIndex, enterHome }) => {
    try {
     const piece = game.pieces.find(p => p.id === pieceId);
     const oldPos = { ...piece.position };
+    const previousPositions = capturePiecePositions(game);
     const playedCard = currentPlayer.cards[cardIndex];
     const moveResult = game.makeMove(pieceId, cardIndex, enterHome);
     const msg = logMoveDetails(currentPlayer, pieceId, oldPos, moveResult, game, playedCard);
@@ -803,12 +843,12 @@ socket.on('confirmHomeEntry', ({ roomId, pieceId, cardIndex, enterHome }) => {
     const updatedState = game.getGameState();
     const movedPiece = game.pieces.find(p => p.id === pieceId);
     if (movedPiece) {
-      updatedState.moveAnimations = [{
+      updatedState.moveAnimations = buildMoveAnimations(game, previousPositions, [{
         pieceId,
         oldPosition: oldPos,
         newPosition: { ...movedPiece.position },
         direction: getMoveAnimationDirection(playedCard, moveResult)
-      }];
+      }]);
     }
     io.to(roomId).emit('gameStateUpdate', updatedState);
     announceHomeStretch(game, roomId);
@@ -865,6 +905,7 @@ socket.on('confirmHomeEntry', ({ roomId, pieceId, cardIndex, enterHome }) => {
     
     try {
       const currentPlayer = game.getCurrentPlayer();
+      const previousPositions = capturePiecePositions(game);
       const moveResult = game.makeSpecialMove(moves);
 
       // Atualizar a mão do jogador imediatamente após jogar a carta 7
@@ -905,12 +946,13 @@ socket.on('confirmHomeEntry', ({ roomId, pieceId, cardIndex, enterHome }) => {
       // Atualizar estado do jogo para todos
       const updatedState = game.getGameState();
       if (moveResult.moves) {
-        updatedState.moveAnimations = moveResult.moves.map(move => ({
+        const primaryMoves = moveResult.moves.map(move => ({
           pieceId: move.pieceId,
           oldPosition: move.oldPosition,
           newPosition: move.newPosition,
           direction: 'forward'
         }));
+        updatedState.moveAnimations = buildMoveAnimations(game, previousPositions, primaryMoves);
       }
       io.to(roomId).emit('gameStateUpdate', updatedState);
       announceHomeStretch(game, roomId);
@@ -985,6 +1027,7 @@ socket.on('confirmHomeEntry', ({ roomId, pieceId, cardIndex, enterHome }) => {
     }
 
     try {
+      const previousPositions = capturePiecePositions(game);
       const moveResult = game.resumeSpecialMove(enterHome);
 
       // Garantir que a mão seja atualizada após concluir o movimento especial
@@ -1025,12 +1068,13 @@ socket.on('confirmHomeEntry', ({ roomId, pieceId, cardIndex, enterHome }) => {
 
       const updatedState = game.getGameState();
       if (moveResult.moves) {
-        updatedState.moveAnimations = moveResult.moves.map(move => ({
+        const primaryMoves = moveResult.moves.map(move => ({
           pieceId: move.pieceId,
           oldPosition: move.oldPosition,
           newPosition: move.newPosition,
           direction: 'forward'
         }));
+        updatedState.moveAnimations = buildMoveAnimations(game, previousPositions, primaryMoves);
       }
       io.to(roomId).emit('gameStateUpdate', updatedState);
       announceHomeStretch(game, roomId);


### PR DESCRIPTION
### Motivation

- Animations were sometimes visually inconsistent: pieces could appear to move in the wrong direction or captured pieces followed the regular board path instead of traversing directly to penalty/home; this made it hard to visually track what happened on a turn.

### Description

- Capturei as posições de todas as peças antes de aplicar um movimento e passei a construir a lista de animações a partir desse snapshot para preservar trajetórias reais dos movimentos principais e detectar peças deslocadas por captura.
- Adicionei utilitários `positionsEqual`, `capturePiecePositions` e `buildMoveAnimations` em `server/server.js` e `server/bot_manager.js` para combinar movimentos primários (ordenados) com movimentos secundários marcados como `direction: 'direct'` (para peças capturadas/deslocadas).
- Atualizei os pontos onde movimentos são executados (`makeMove`, `makeSpecialMove`, `confirmHomeEntry`, `resumeSpecialMove`) e o bot manager para capturar as posições pré-movimento e emitir `moveAnimations` compostas usando a nova função.
- No cliente (`public/js/game.js`) preservei a ordem enviada pelo servidor ao construir descritores de animação e corrigi `order` para respeitar `move.order` quando numérico, garantindo que a peça principal anime antes das peças movidas diretamente.

### Testing

- Verificação de sintaxe com `node --check server/server.js && node --check server/bot_manager.js && node --check public/js/game.js` executada com sucesso.
- Suite de testes automatizados `npm test -- --runInBand` executada com sucesso: 6 test suites passed, 68 tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02639ddb14832ab30a58253a276613)