### PR TITLE
Fix piece animation transforms and generate ordered moveAnimations for all moved pieces

### DIFF
--- a/public/js/game.js
+++ b/public/js/game.js
@@ -185,7 +185,7 @@ document.addEventListener('DOMContentLoaded', () => {
           from: move.oldPosition,
           to: move.newPosition,
           direction: move.direction,
-          order: index
+          order: Number.isFinite(move.order) ? move.order : index
         }));
     }
 
@@ -250,16 +250,36 @@ document.addEventListener('DOMContentLoaded', () => {
       return [];
     }
 
+    function viewportDeltaToBoardDelta(deltaX, deltaY, rotation) {
+      const radians = -rotation * Math.PI / 180;
+      const cos = Math.cos(radians);
+      const sin = Math.sin(radians);
+      return {
+        x: deltaX * cos - deltaY * sin,
+        y: deltaX * sin + deltaY * cos
+      };
+    }
+
+    function rectCenterDelta(fromRect, toRect) {
+      return {
+        x: (fromRect.left + fromRect.width / 2) - (toRect.left + toRect.width / 2),
+        y: (fromRect.top + fromRect.height / 2) - (toRect.top + toRect.height / 2)
+      };
+    }
+
+    function translateTransformFromViewportDelta(deltaX, deltaY, rotation) {
+      const localDelta = viewportDeltaToBoardDelta(deltaX, deltaY, rotation);
+      return `translate(${localDelta.x}px, ${localDelta.y}px) rotate(${-rotation}deg)`;
+    }
+
     function buildMovementKeyframes(path, finalRect, rotation) {
       const keyframes = path
         .map(position => getCell(position.row, position.col))
         .filter(Boolean)
         .map(cell => {
-          const rect = cell.getBoundingClientRect();
-          const centeredLeft = rect.left + (rect.width - finalRect.width) / 2;
-          const centeredTop = rect.top + (rect.height - finalRect.height) / 2;
+          const delta = rectCenterDelta(cell.getBoundingClientRect(), finalRect);
           return {
-            transform: `translate(${centeredLeft - finalRect.left}px, ${centeredTop - finalRect.top}px) rotate(${-rotation}deg)`
+            transform: translateTransformFromViewportDelta(delta.x, delta.y, rotation)
           };
         });
 
@@ -1106,8 +1126,9 @@ function updatePlayerLabels() {
     cell.appendChild(pieceElement);
     const last = pieceElement.getBoundingClientRect();
     const moved = moveDescriptor || (previousPiece && !positionsEqual(previousPiece.position, piece.position));
-    const deltaX = first ? first.left - last.left : 0;
-    const deltaY = first ? first.top - last.top : 0;
+    const delta = first ? rectCenterDelta(first, last) : { x: 0, y: 0 };
+    const deltaX = delta.x;
+    const deltaY = delta.y;
 
     pieceElement.style.transition = 'none';
     pieceElement.style.transform = `rotate(${-rotation}deg)`;
@@ -1117,7 +1138,7 @@ function updatePlayerLabels() {
       const keyframes = boardMovementPath.length > 1
         ? buildMovementKeyframes(boardMovementPath, last, rotation)
         : [
-            { transform: `translate(${deltaX}px, ${deltaY}px) rotate(${-rotation}deg)` },
+            { transform: translateTransformFromViewportDelta(deltaX, deltaY, rotation) },
             { transform: `rotate(${-rotation}deg)` }
           ];
 

--- a/server/bot_manager.js
+++ b/server/bot_manager.js
@@ -3,6 +3,44 @@ const path = require('path');
 const BotWrapper = require('./bot_wrapper');
 const { logTurnState, logMoveDetails } = require('./log_utils');
 
+
+function positionsEqual(a, b) {
+  return Boolean(a && b && a.row === b.row && a.col === b.col);
+}
+
+function capturePiecePositions(game) {
+  const positions = new Map();
+  game.pieces.forEach(piece => {
+    positions.set(piece.id, { ...piece.position });
+  });
+  return positions;
+}
+
+function buildMoveAnimations(game, previousPositions, primaryMoves = []) {
+  const animations = primaryMoves.map((move, index) => ({
+    ...move,
+    order: index
+  }));
+  const primaryPieceIds = new Set(primaryMoves.map(move => move.pieceId));
+
+  game.pieces.forEach(piece => {
+    const oldPosition = previousPositions.get(piece.id);
+    if (!oldPosition || primaryPieceIds.has(piece.id) || positionsEqual(oldPosition, piece.position)) {
+      return;
+    }
+
+    animations.push({
+      pieceId: piece.id,
+      oldPosition,
+      newPosition: { ...piece.position },
+      direction: 'direct',
+      order: animations.length
+    });
+  });
+
+  return animations;
+}
+
 function getMoveAnimationDirection(card, result) {
   if ((card && card.value === 'JOKER') || (result && ['leavePenalty', 'choosePosition'].includes(result.action))) {
     return 'direct';
@@ -104,25 +142,27 @@ class BotManager {
         playedCard = this.game.players[current.position].cards[cardIndex];
       }
 
+      const previousPositions = capturePiecePositions(this.game);
       const result = this.wrapper.makeMove(current.position, actionId);
       const roomId = this.game.roomId;
       const stateForClients = result.gameState;
       if (actionId >= 60 && actionId < 70 && result.moves) {
-        stateForClients.moveAnimations = result.moves.map(move => ({
+        const primaryMoves = result.moves.map(move => ({
           pieceId: move.pieceId,
           oldPosition: move.oldPosition,
           newPosition: move.newPosition,
           direction: 'forward'
         }));
+        stateForClients.moveAnimations = buildMoveAnimations(this.game, previousPositions, primaryMoves);
       } else if (pieceId && oldPos) {
         const movedPiece = this.game.pieces.find(p => p.id === pieceId);
         if (movedPiece) {
-          stateForClients.moveAnimations = [{
+          stateForClients.moveAnimations = buildMoveAnimations(this.game, previousPositions, [{
             pieceId,
             oldPosition: oldPos,
             newPosition: { ...movedPiece.position },
             direction: getMoveAnimationDirection(playedCard, result)
-          }];
+          }]);
         }
       }
       this.io.to(roomId).emit('gameStateUpdate', stateForClients);

--- a/server/server.js
+++ b/server/server.js
@@ -72,6 +72,44 @@ app.get('/replay', (req, res) => {
 
 
 
+
+function positionsEqual(a, b) {
+  return Boolean(a && b && a.row === b.row && a.col === b.col);
+}
+
+function capturePiecePositions(game) {
+  const positions = new Map();
+  game.pieces.forEach(piece => {
+    positions.set(piece.id, { ...piece.position });
+  });
+  return positions;
+}
+
+function buildMoveAnimations(game, previousPositions, primaryMoves = []) {
+  const animations = primaryMoves.map((move, index) => ({
+    ...move,
+    order: index
+  }));
+  const primaryPieceIds = new Set(primaryMoves.map(move => move.pieceId));
+
+  game.pieces.forEach(piece => {
+    const oldPosition = previousPositions.get(piece.id);
+    if (!oldPosition || primaryPieceIds.has(piece.id) || positionsEqual(oldPosition, piece.position)) {
+      return;
+    }
+
+    animations.push({
+      pieceId: piece.id,
+      oldPosition,
+      newPosition: { ...piece.position },
+      direction: 'direct',
+      order: animations.length
+    });
+  });
+
+  return animations;
+}
+
 function getMoveAnimationDirection(card, moveResult) {
   if ((card && card.value === 'JOKER') || (moveResult && ['leavePenalty', 'choosePosition'].includes(moveResult.action))) {
     return 'direct';
@@ -693,6 +731,7 @@ socket.on('makeMove', ({ roomId, pieceId, cardIndex, enterHome }) => {
   try {
     const piece = game.pieces.find(p => p.id === pieceId);
     const oldPos = { ...piece.position };
+    const previousPositions = capturePiecePositions(game);
     const playedCard = currentPlayer.cards[cardIndex];
     const moveResult = game.makeMove(pieceId, cardIndex, enterHome);
 
@@ -726,12 +765,12 @@ socket.on('makeMove', ({ roomId, pieceId, cardIndex, enterHome }) => {
     const updatedState = game.getGameState();
     const movedPiece = game.pieces.find(p => p.id === pieceId);
     if (movedPiece) {
-      updatedState.moveAnimations = [{
+      updatedState.moveAnimations = buildMoveAnimations(game, previousPositions, [{
         pieceId,
         oldPosition: oldPos,
         newPosition: { ...movedPiece.position },
         direction: getMoveAnimationDirection(playedCard, moveResult)
-      }];
+      }]);
     }
     io.to(roomId).emit('gameStateUpdate', updatedState);
     announceHomeStretch(game, roomId);
@@ -793,6 +832,7 @@ socket.on('confirmHomeEntry', ({ roomId, pieceId, cardIndex, enterHome }) => {
    try {
     const piece = game.pieces.find(p => p.id === pieceId);
     const oldPos = { ...piece.position };
+    const previousPositions = capturePiecePositions(game);
     const playedCard = currentPlayer.cards[cardIndex];
     const moveResult = game.makeMove(pieceId, cardIndex, enterHome);
     const msg = logMoveDetails(currentPlayer, pieceId, oldPos, moveResult, game, playedCard);
@@ -803,12 +843,12 @@ socket.on('confirmHomeEntry', ({ roomId, pieceId, cardIndex, enterHome }) => {
     const updatedState = game.getGameState();
     const movedPiece = game.pieces.find(p => p.id === pieceId);
     if (movedPiece) {
-      updatedState.moveAnimations = [{
+      updatedState.moveAnimations = buildMoveAnimations(game, previousPositions, [{
         pieceId,
         oldPosition: oldPos,
         newPosition: { ...movedPiece.position },
         direction: getMoveAnimationDirection(playedCard, moveResult)
-      }];
+      }]);
     }
     io.to(roomId).emit('gameStateUpdate', updatedState);
     announceHomeStretch(game, roomId);
@@ -865,6 +905,7 @@ socket.on('confirmHomeEntry', ({ roomId, pieceId, cardIndex, enterHome }) => {
     
     try {
       const currentPlayer = game.getCurrentPlayer();
+      const previousPositions = capturePiecePositions(game);
       const moveResult = game.makeSpecialMove(moves);
 
       // Atualizar a mão do jogador imediatamente após jogar a carta 7
@@ -905,12 +946,13 @@ socket.on('confirmHomeEntry', ({ roomId, pieceId, cardIndex, enterHome }) => {
       // Atualizar estado do jogo para todos
       const updatedState = game.getGameState();
       if (moveResult.moves) {
-        updatedState.moveAnimations = moveResult.moves.map(move => ({
+        const primaryMoves = moveResult.moves.map(move => ({
           pieceId: move.pieceId,
           oldPosition: move.oldPosition,
           newPosition: move.newPosition,
           direction: 'forward'
         }));
+        updatedState.moveAnimations = buildMoveAnimations(game, previousPositions, primaryMoves);
       }
       io.to(roomId).emit('gameStateUpdate', updatedState);
       announceHomeStretch(game, roomId);
@@ -985,6 +1027,7 @@ socket.on('confirmHomeEntry', ({ roomId, pieceId, cardIndex, enterHome }) => {
     }
 
     try {
+      const previousPositions = capturePiecePositions(game);
       const moveResult = game.resumeSpecialMove(enterHome);
 
       // Garantir que a mão seja atualizada após concluir o movimento especial
@@ -1025,12 +1068,13 @@ socket.on('confirmHomeEntry', ({ roomId, pieceId, cardIndex, enterHome }) => {
 
       const updatedState = game.getGameState();
       if (moveResult.moves) {
-        updatedState.moveAnimations = moveResult.moves.map(move => ({
+        const primaryMoves = moveResult.moves.map(move => ({
           pieceId: move.pieceId,
           oldPosition: move.oldPosition,
           newPosition: move.newPosition,
           direction: 'forward'
         }));
+        updatedState.moveAnimations = buildMoveAnimations(game, previousPositions, primaryMoves);
       }
       io.to(roomId).emit('gameStateUpdate', updatedState);
       announceHomeStretch(game, roomId);


### PR DESCRIPTION
### Motivation

- Ensure piece movement animations account for board rotation and use centered deltas so visuals remain correct when the board is rotated.
- Produce deterministic, ordered `moveAnimations` that include both primary moves and any other pieces that changed position so clients can animate all visible changes.

### Description

- In `public/js/game.js` added `rectCenterDelta`, `viewportDeltaToBoardDelta`, and `translateTransformFromViewportDelta` and replaced raw viewport-left/top deltas with center-based, rotation-aware transforms for keyframe generation and one-step moves, and made `getMoveAnimationDescriptors` respect numeric `order` when present via `Number.isFinite(move.order)`.
- In `server/bot_manager.js` and `server/server.js` added helper functions `positionsEqual`, `capturePiecePositions`, and `buildMoveAnimations` to capture pre-move piece positions and construct a full `moveAnimations` array that includes primary moves (preserving an explicit `order`) and any additional moved pieces as `direct` moves.
- Replaced several places that previously set `stateForClients.moveAnimations` or `updatedState.moveAnimations` with calls to `buildMoveAnimations` (bot moves, normal moves, special moves, `confirmHomeEntry`, and resume special move flows) so clients receive consistent animation metadata.

### Testing

- Ran the project's automated test/build commands: `npm test` and `npm run build`, both of which completed successfully.
- Verified the updated server paths that emit `gameStateUpdate` include `moveAnimations` with explicit `order` values by running local game turns with bot and human moves (smoke tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02639ddb14832ab30a58253a276613)