### PR TITLE
Prefer deepest home-stretch entries for training bots

### DIFF
--- a/game-ai-training/game/game_wrapper.js
+++ b/game-ai-training/game/game_wrapper.js
@@ -627,17 +627,17 @@ class GameWrapper {
         };
     }
 
-    actionWouldEnterHome(playerId, actionId) {
+    homeEntryDepthForAction(playerId, actionId) {
         try {
             if (!this.game || !this.game.players || !this.game.players[playerId] || actionId >= 70) {
-                return false;
+                return -1;
             }
 
             const clone = this.game.cloneForSimulation();
 
             if (actionId >= 60) {
                 const moves = this.specialActions[actionId];
-                if (!moves) return false;
+                if (!moves) return -1;
                 const before = moves.map(m => {
                     const piece = clone.pieces.find(p => p.id === m.pieceId);
                     return {
@@ -650,50 +650,40 @@ class GameWrapper {
                     result = clone.resumeSpecialMove(true);
                 }
                 if (result && result.success === false) {
-                    return false;
+                    return -1;
                 }
-                return before.some(info => {
+                return before.reduce((bestDepth, info) => {
                     const piece = clone.pieces.find(p => p.id === info.id);
-                    return piece && !info.inHomeStretch && piece.inHomeStretch;
-                });
+                    if (!piece || info.inHomeStretch || !piece.inHomeStretch) return bestDepth;
+                    return Math.max(bestDepth, this.homeStretchIndex(piece, clone));
+                }, -1);
             }
 
-            const cardIndex = Math.floor(actionId / 10);
-            let pieceNumber = actionId % 10;
-            if (pieceNumber === 0) {
-                pieceNumber = 10;
-            }
-
-            const countCheck = this.game.piecesPerPlayer || 5;
-            let ownerId = playerId;
-            if (pieceNumber > countCheck) {
-                const partner = this.game.partnerIdFor && this.game.partnerIdFor(playerId);
-                if (partner === null || partner === undefined) {
-                    return false;
-                }
-                ownerId = partner;
-                pieceNumber -= countCheck;
-            }
-
-            const pieceId = `p${ownerId}_${pieceNumber}`;
-            const beforePiece = clone.pieces.find(p => p.id === pieceId);
+            const info = this.actionPieceInfo(playerId, actionId);
+            if (!info) return -1;
+            const beforePiece = clone.pieces.find(p => p.id === info.pieceId);
             if (!beforePiece || beforePiece.inHomeStretch || beforePiece.completed) {
-                return false;
+                return -1;
             }
 
-            let result = clone.makeMove(pieceId, cardIndex);
+            let result = clone.makeMove(info.pieceId, info.cardIndex);
             if (result && result.action === 'homeEntryChoice') {
-                result = clone.makeMove(pieceId, cardIndex, true);
+                result = clone.makeMove(info.pieceId, info.cardIndex, true);
             }
             if (result && result.success === false) {
-                return false;
+                return -1;
             }
 
-            const afterPiece = clone.pieces.find(p => p.id === pieceId);
-            return Boolean(afterPiece && afterPiece.inHomeStretch);
+            const afterPiece = clone.pieces.find(p => p.id === info.pieceId);
+            if (!afterPiece || !afterPiece.inHomeStretch) return -1;
+            return this.homeStretchIndex(afterPiece, clone);
         } catch (e) {
-            return false;
+            return -1;
         }
+    }
+
+    actionWouldEnterHome(playerId, actionId) {
+        return this.homeEntryDepthForAction(playerId, actionId) >= 0;
     }
 
     homeStretchProgressForAction(playerId, actionId) {
@@ -766,13 +756,13 @@ class GameWrapper {
     }
 
     getHomeEntryActions(playerId, actions) {
-        const result = [];
-        for (const action of actions || []) {
-            if (this.actionWouldEnterHome(playerId, action)) {
-                result.push(action);
-            }
-        }
-        return result;
+        const entries = (actions || [])
+            .map(action => ({ action, depth: this.homeEntryDepthForAction(playerId, action) }))
+            .filter(entry => entry.depth >= 0);
+        if (entries.length === 0) return [];
+
+        const deepest = Math.max(...entries.map(entry => entry.depth));
+        return entries.filter(entry => entry.depth === deepest).map(entry => entry.action);
     }
 
     findFirstAvailableAction(playerId) {

--- a/game-ai-training/tests/game_wrapper.test.js
+++ b/game-ai-training/tests/game_wrapper.test.js
@@ -167,6 +167,31 @@ describe('GameWrapper 7-card split actions', () => {
   });
 });
 
+describe('GameWrapper home-stretch entry priorities', () => {
+  test('reports only the deepest available home-stretch entry action', () => {
+    const GameWrapper = loadGameWrapper();
+    const wrapper = new GameWrapper();
+    wrapper.setupGame();
+
+    const game = wrapper.game;
+    game.players[0].cards = [
+      { suit: '♠', value: '2' },
+      { suit: '♣', value: '5' }
+    ];
+
+    const mover = game.pieces.find(p => p.id === 'p0_1');
+    mover.inPenaltyZone = false;
+    mover.inHomeStretch = false;
+    mover.completed = false;
+    mover.position = { row: 0, col: 4 };
+
+    const validActions = wrapper.getValidActions(0);
+
+    expect(validActions).toEqual(expect.arrayContaining([1, 11]));
+    expect(wrapper.getHomeEntryActions(0, validActions)).toEqual([11]);
+  });
+});
+
 describe('GameWrapper discard protection', () => {
   function buildDiscardOnlyWrapper(cards) {
     const GameWrapper = loadGameWrapper();


### PR DESCRIPTION
### Motivation
- Ensure training/control wrappers always prefer entering the homestretch when possible and, among entry options, choose the move that lands farthest into the homestretch so bots progress toward completion. 
- Score both normal moves and special 7-split moves by simulated depth into the homestretch so the training policy can consistently pick the deepest entry. 
- Keep existing boolean helpers for compatibility while backing them with the new depth-based logic.

### Description
- Added `homeEntryDepthForAction` to the training `GameWrapper` to simulate actions (including split 7 moves) and return the deepest home-stretch index reached, and retained `actionWouldEnterHome` as a thin wrapper over the new scorer. (file: `game-ai-training/game/game_wrapper.js`)
- Updated `getHomeEntryActions` to return only actions that achieve the maximum depth (the deepest available entries) instead of a boolean filter. (file: `game-ai-training/game/game_wrapper.js`)
- Adjusted logic paths that previously used the boolean check to use the depth-based scorer where appropriate, and preserved behavior for special moves, joker choices and partner-piece encodings. (file: `game-ai-training/game/game_wrapper.js`)
- Added a Jest regression test verifying that when both shallow and deep entry actions exist the wrapper reports the deepest entry only. (file: `game-ai-training/tests/game_wrapper.test.js`)

### Testing
- Ran targeted Node tests with `npx jest game-ai-training/tests/game_wrapper.test.js server/__tests__/bot_wrapper.test.js --runInBand` and they passed. 
- Ran full JS test suite with `npm test -- --runInBand` and all server + wrapper suites passed (no failures). 
- Ran Python training tests with `python3 -m pytest game-ai-training/tests` and all training tests passed (no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02822ddb48832a98a207f04a338765)