### PR TITLE
Avoid bot moves that leave pieces out of home-stretch reach

### DIFF
--- a/server/__tests__/bot_wrapper.test.js
+++ b/server/__tests__/bot_wrapper.test.js
@@ -79,6 +79,94 @@ describe('BotWrapper live fixed play constraints', () => {
     expect(wrapper.applyActionConstraints(0, [1])).toEqual([1]);
   });
 
+  test('filters moves that take a piece out of home-stretch reach when another move exists', () => {
+    const wrapper = new BotWrapper(null);
+    const pieces = [
+      {
+        id: 'p0_1',
+        playerId: 0,
+        completed: false,
+        inPenaltyZone: false,
+        inHomeStretch: false,
+        position: { row: 0, col: 4 }
+      },
+      {
+        id: 'p0_2',
+        playerId: 0,
+        completed: false,
+        inPenaltyZone: false,
+        inHomeStretch: false,
+        position: { row: 0, col: 15 }
+      }
+    ];
+    wrapper.game = {
+      pieces,
+      players: [{ cards: [{ suit: '♠', value: '6' }] }],
+      piecesPerPlayer: 5,
+      partnerIdFor() {
+        return 2;
+      },
+      isPartner(a, b) {
+        return (a === 0 && b === 2) || (a === 2 && b === 0);
+      },
+      cloneForSimulation() {
+        const clonePieces = JSON.parse(JSON.stringify(pieces));
+        return {
+          pieces: clonePieces,
+          makeMove(pieceId) {
+            const piece = clonePieces.find(p => p.id === pieceId);
+            if (pieceId === 'p0_1') {
+              piece.position = { row: 0, col: 10 };
+            } else {
+              piece.position = { row: 0, col: 16 };
+            }
+            return { success: true };
+          }
+        };
+      }
+    };
+
+    expect(wrapper.applyActionConstraints(0, [1, 2])).toEqual([2]);
+  });
+
+  test('keeps home-stretch reach exit moves when they are forced', () => {
+    const wrapper = new BotWrapper(null);
+    const pieces = [
+      {
+        id: 'p0_1',
+        playerId: 0,
+        completed: false,
+        inPenaltyZone: false,
+        inHomeStretch: false,
+        position: { row: 0, col: 4 }
+      }
+    ];
+    wrapper.game = {
+      pieces,
+      players: [{ cards: [{ suit: '♠', value: '6' }] }],
+      piecesPerPlayer: 5,
+      partnerIdFor() {
+        return 2;
+      },
+      isPartner(a, b) {
+        return (a === 0 && b === 2) || (a === 2 && b === 0);
+      },
+      cloneForSimulation() {
+        const clonePieces = JSON.parse(JSON.stringify(pieces));
+        return {
+          pieces: clonePieces,
+          makeMove(pieceId) {
+            const piece = clonePieces.find(p => p.id === pieceId);
+            piece.position = { row: 0, col: 10 };
+            return { success: true };
+          }
+        };
+      }
+    };
+
+    expect(wrapper.applyActionConstraints(0, [1])).toEqual([1]);
+  });
+
   test('keeps only the deepest home-stretch entry action', () => {
     const game = new Game('deepest-entry');
     game.addPlayer('1', 'Alice', true);

--- a/server/bot_wrapper.js
+++ b/server/bot_wrapper.js
@@ -344,6 +344,43 @@ class BotWrapper {
     return outcomes;
   }
 
+  getHomeReachExitActions(playerId, actions) {
+    const avoid = [];
+    if (!this.game) return avoid;
+
+    for (const action of actions || []) {
+      if (action >= 70) continue;
+      const outcomes = this.simulateActionOutcomes(playerId, action);
+      if (outcomes.length === 0) continue;
+
+      const everyOutcomeLeavesReach = outcomes.every(outcome => {
+        let movedReachPiece = false;
+
+        for (const pieceId of outcome.movedPieceIds || []) {
+          const beforeMove = this.game.pieces.find(p => p.id === pieceId);
+          const afterMove = outcome.finalPieces && outcome.finalPieces[pieceId];
+          if (!beforeMove || !afterMove || !this.withinHomeEntryReach(beforeMove)) {
+            continue;
+          }
+
+          movedReachPiece = true;
+          const enteredHome = Boolean(afterMove.inHomeStretch || afterMove.completed);
+          if (enteredHome || this.withinHomeEntryReach(afterMove)) {
+            return false;
+          }
+        }
+
+        return movedReachPiece;
+      });
+
+      if (everyOutcomeLeavesReach) {
+        avoid.push(action);
+      }
+    }
+
+    return Array.from(new Set(avoid));
+  }
+
   getFixedPlayActions(playerId, actions) {
     const priority = [];
     const avoid = [];
@@ -565,6 +602,14 @@ class BotWrapper {
     const homeStretchMoveActions = this.getHomeStretchMoveActions(playerId, validActions);
     if (homeStretchMoveActions.length > 0) {
       return homeStretchMoveActions;
+    }
+
+    const homeReachExitActions = new Set(
+      this.getHomeReachExitActions(playerId, validActions).filter(action => validActionSet.has(action))
+    );
+    const reachSafeActions = validActions.filter(action => !homeReachExitActions.has(action));
+    if (reachSafeActions.length > 0 && reachSafeActions.length < validActions.length) {
+      return this.applyActionConstraints(playerId, reachSafeActions);
     }
 
     const fixedPlayMetadata = this.getFixedPlayActions(playerId, validActions);


### PR DESCRIPTION
### Motivation

- Reduce bad bot plays that move a piece which is currently within home-stretch entry reach to a position outside that reach without entering home. 
- Prefer other legal moves when available, but still allow the reach-exit move if it is the only legal option.

### Description

- Added `getHomeReachExitActions(playerId, actions)` to detect actions where every simulated outcome moves a piece that was `withinHomeEntryReach` to a position that is no longer in reach and does not enter the home stretch (`server/bot_wrapper.js`).
- Integrated the new reach-exit filtering into `applyActionConstraints` so that reach-exit actions are removed when safer alternatives exist, while preserving existing home-entry, home-stretch, and fixed-play prioritization logic (`server/bot_wrapper.js`).
- Added Jest tests covering the new behavior: one test that filters an avoidable reach-exit move and one test that keeps the reach-exit move when it is the only option (`server/__tests__/bot_wrapper.test.js`).

### Testing

- Ran `npm test -- --runInBand server/__tests__/bot_wrapper.test.js` and the updated suite passed.
- Ran the full JS test suite with `npm test -- --runInBand` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a047e966764832a84a53d09110d6df8)