### PR TITLE
Adjust turn animation sequencing and card-play animation

### DIFF
--- a/public/css/game.css
+++ b/public/css/game.css
@@ -922,3 +922,13 @@
   color: #e8ecf3;
   border: 1px solid rgba(140, 246, 255, 0.16);
 }
+
+.turn-card-animation {
+    position: fixed;
+    z-index: 2500;
+    pointer-events: none;
+    transform: translate(-50%, -50%);
+    margin: 0;
+    cursor: default;
+    box-shadow: 0 22px 48px rgba(140, 246, 255, 0.35), 0 0 28px rgba(255, 125, 255, 0.28);
+}

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -121,6 +121,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const pieceElements = {};
     const MOVE_ANIMATION_DURATION_MS = 1000;
+    const CARD_HOLD_ANIMATION_DURATION_MS = 500;
+    const CARD_TRAVEL_ANIMATION_DURATION_MS = 60 * 1000;
     let boardAnimationPromise = Promise.resolve();
     let gameStateUpdateQueue = Promise.resolve();
     let isAnimatingBoard = false;
@@ -144,6 +146,68 @@ document.addEventListener('DOMContentLoaded', () => {
     function getDisplayValue(card) {
       return card.value === 'JOKER' ? 'C' : card.value;
     }
+
+    function createFloatingCardElement(card) {
+      const element = document.createElement('div');
+      element.className = 'card turn-card-animation';
+      element.innerHTML = createCardHTML(card);
+      return element;
+    }
+
+    function getPenaltyZoneAnchor(playerId) {
+      const anchors = [
+        { row: 2, col: 8 },
+        { row: 8, col: 16 },
+        { row: 16, col: 10 },
+        { row: 10, col: 2 }
+      ];
+      return anchors[playerId] || null;
+    }
+
+    function elementCenter(rect) {
+      return {
+        x: rect.left + rect.width / 2,
+        y: rect.top + rect.height / 2
+      };
+    }
+
+    async function animatePlayedCard(cardAnimation) {
+      if (!cardAnimation || !cardAnimation.card) return;
+
+      const penaltyAnchor = getPenaltyZoneAnchor(cardAnimation.playerPosition);
+      const penaltyCell = penaltyAnchor ? getCell(penaltyAnchor.row, penaltyAnchor.col) : null;
+      const deckElement = document.querySelector('.deck .card-back') || document.querySelector('.deck-area');
+      if (!penaltyCell || !deckElement) return;
+
+      const startRect = penaltyCell.getBoundingClientRect();
+      const endRect = deckElement.getBoundingClientRect();
+      const startCenter = elementCenter(startRect);
+      const endCenter = elementCenter(endRect);
+      const floatingCard = createFloatingCardElement(cardAnimation.card);
+
+      floatingCard.style.left = `${startCenter.x}px`;
+      floatingCard.style.top = `${startCenter.y}px`;
+      document.body.appendChild(floatingCard);
+
+      await wait(CARD_HOLD_ANIMATION_DURATION_MS);
+      await waitForNextFrame();
+
+      const travel = floatingCard.animate([
+        { transform: 'translate(-50%, -50%) scale(1)', opacity: 1 },
+        {
+          transform: `translate(calc(-50% + ${endCenter.x - startCenter.x}px), calc(-50% + ${endCenter.y - startCenter.y}px)) scale(0.72)`,
+          opacity: 0.92
+        }
+      ], {
+        duration: CARD_TRAVEL_ANIMATION_DURATION_MS,
+        easing: 'ease-in-out',
+        fill: 'forwards'
+      });
+
+      await travel.finished.catch(() => {});
+      floatingCard.remove();
+    }
+
 
     function showStatusMessage(message, type = 'info') {
       turnMessage.textContent = message;
@@ -852,7 +916,7 @@ function updateBoard(previousState = null) {
   rotateBoard(false);
 
   console.log('Tabuleiro atualizado');
-  return animatePieceMoves(animations);
+  return animateTurnSequence(animations, gameState.cardAnimation);
 }
 
 
@@ -1166,14 +1230,27 @@ function updatePlayerLabels() {
   return animations.sort((a, b) => a.order - b.order);
 }
 
-async function animatePieceMoves(animations) {
-  if (!animations || animations.length === 0) {
+async function animateTurnSequence(animations, cardAnimation) {
+  if ((!animations || animations.length === 0) && !cardAnimation) {
     isAnimatingBoard = false;
     return;
   }
 
   isAnimatingBoard = true;
   isMyTurn = false;
+  showStatusMessage('Acompanhando a carta da jogada...', 'info');
+
+  await animatePlayedCard(cardAnimation);
+  await animatePieceMoves(animations);
+
+  isAnimatingBoard = false;
+}
+
+async function animatePieceMoves(animations) {
+  if (!animations || animations.length === 0) {
+    return;
+  }
+
   showStatusMessage('Acompanhando a jogada no tabuleiro...', 'info');
 
   for (const animation of animations) {
@@ -1192,7 +1269,6 @@ async function animatePieceMoves(animations) {
   }
 
   clearMoveHighlights();
-  isAnimatingBoard = false;
 }
 
 

--- a/server/server.js
+++ b/server/server.js
@@ -27,13 +27,20 @@ app.use(express.static(path.join(__dirname, '../public')));
 const rooms = new Map();
 
 const MOVE_ANIMATION_DURATION_MS = 1000;
+const CARD_HOLD_ANIMATION_DURATION_MS = 500;
+const CARD_TRAVEL_ANIMATION_DURATION_MS = 60 * 1000;
 const TURN_ANIMATION_BUFFER_MS = 150;
 
-function getTurnAnimationDelay(moveAnimations) {
-  if (!Array.isArray(moveAnimations) || moveAnimations.length === 0) {
+function getTurnAnimationDelay(moveAnimations, cardAnimation = null) {
+  const pieceAnimationCount = Array.isArray(moveAnimations) ? moveAnimations.length : 0;
+  if (pieceAnimationCount === 0 && !cardAnimation) {
     return 0;
   }
-  return (moveAnimations.length * MOVE_ANIMATION_DURATION_MS) + TURN_ANIMATION_BUFFER_MS;
+
+  const cardDelay = cardAnimation
+    ? CARD_HOLD_ANIMATION_DURATION_MS + CARD_TRAVEL_ANIMATION_DURATION_MS
+    : 0;
+  return cardDelay + (pieceAnimationCount * MOVE_ANIMATION_DURATION_MS) + TURN_ANIMATION_BUFFER_MS;
 }
 
 function isTurnLocked(game) {
@@ -49,8 +56,8 @@ function rejectIfTurnLocked(game, socket) {
   return true;
 }
 
-function scheduleNextTurn(game, moveAnimations = []) {
-  const delay = getTurnAnimationDelay(moveAnimations);
+function scheduleNextTurn(game, moveAnimations = [], cardAnimation = null) {
+  const delay = getTurnAnimationDelay(moveAnimations, cardAnimation);
 
   if (game.turnTimer) {
     clearTimeout(game.turnTimer);
@@ -147,37 +154,35 @@ function capturePiecePositions(game) {
   return positions;
 }
 
-function animationLeavesDestination(animation, otherAnimation) {
-  return positionsEqual(animation.oldPosition, otherAnimation.newPosition);
-}
-
 function orderMoveAnimations(animations) {
-  const remaining = animations.map((animation, originalIndex) => ({
-    ...animation,
-    originalIndex
-  }));
-  const ordered = [];
+  const primaryAnimations = animations.filter(animation => animation.isPrimaryMove);
 
-  while (remaining.length > 0) {
-    const blockingIndex = remaining.findIndex(animation =>
-      remaining.some(otherAnimation =>
-        otherAnimation !== animation && animationLeavesDestination(animation, otherAnimation)
-      )
-    );
-    const nextIndex = blockingIndex === -1 ? 0 : blockingIndex;
-    const [nextAnimation] = remaining.splice(nextIndex, 1);
-    ordered.push(nextAnimation);
-  }
+  return animations
+    .map((animation, originalIndex) => {
+      const capturingMove = primaryAnimations.find(primary =>
+        primary.pieceId !== animation.pieceId &&
+        positionsEqual(primary.newPosition, animation.oldPosition)
+      );
 
-  return ordered.map(({ originalIndex, ...animation }, order) => ({
-    ...animation,
-    order
-  }));
+      return {
+        ...animation,
+        originalIndex,
+        order: capturingMove
+          ? capturingMove.order + 0.5
+          : (Number.isFinite(animation.order) ? animation.order : originalIndex)
+      };
+    })
+    .sort((a, b) => a.order - b.order || a.originalIndex - b.originalIndex)
+    .map(({ originalIndex, isPrimaryMove, ...animation }, order) => ({
+      ...animation,
+      order
+    }));
 }
 
 function buildMoveAnimations(game, previousPositions, primaryMoves = []) {
   const animations = primaryMoves.map((move, index) => ({
     ...move,
+    isPrimaryMove: true,
     order: index
   }));
   const primaryPieceIds = new Set(primaryMoves.map(move => move.pieceId));
@@ -198,6 +203,17 @@ function buildMoveAnimations(game, previousPositions, primaryMoves = []) {
   });
 
   return orderMoveAnimations(animations);
+}
+
+function buildCardAnimation(card, playerPosition) {
+  if (!card || playerPosition === undefined || playerPosition === null) {
+    return null;
+  }
+
+  return {
+    card: { suit: card.suit, value: card.value },
+    playerPosition
+  };
 }
 
 function getMoveAnimationDirection(card, moveResult) {
@@ -528,6 +544,7 @@ socket.on('discardCard', ({ roomId, cardIndex }) => {
     // Atualizar estado do jogo para todos já com o próximo jogador definido
     const updatedState = game.getGameState();
     updatedState.moveAnimations = buildMoveAnimations(game, previousPositions);
+    updatedState.cardAnimation = buildCardAnimation(card, currentPlayer.position);
     io.to(roomId).emit('gameStateUpdate', updatedState);
     announceHomeStretch(game, roomId);
     logTurnState(game);
@@ -558,7 +575,7 @@ socket.on('discardCard', ({ roomId, cardIndex }) => {
       return;
     }
     
-    scheduleNextTurn(game, updatedState.moveAnimations);
+    scheduleNextTurn(game, updatedState.moveAnimations, updatedState.cardAnimation);
   } catch (error) {
     console.error(`Erro ao descartar carta:`, error);
     socket.emit('error', error.message);
@@ -716,6 +733,7 @@ socket.on('makeJokerMove', ({ roomId, pieceId, targetPieceId, cardIndex }) => {
         direction: 'direct'
       }]);
     }
+    updatedState.cardAnimation = buildCardAnimation(card, currentPlayer.position);
     io.to(roomId).emit('gameStateUpdate', updatedState);
     announceHomeStretch(game, roomId);
 
@@ -737,7 +755,7 @@ socket.on('makeJokerMove', ({ roomId, pieceId, targetPieceId, cardIndex }) => {
       return;
     }
 
-    scheduleNextTurn(game, updatedState.moveAnimations);
+    scheduleNextTurn(game, updatedState.moveAnimations, updatedState.cardAnimation);
 
     // Atualizar o estado salvo no histórico para refletir o jogo após todas as
     // alterações do movimento Joker
@@ -880,6 +898,7 @@ socket.on('makeMove', ({ roomId, pieceId, cardIndex, enterHome }) => {
         direction: getMoveAnimationDirection(playedCard, moveResult)
       }]);
     }
+    updatedState.cardAnimation = buildCardAnimation(playedCard, currentPlayer.position);
     io.to(roomId).emit('gameStateUpdate', updatedState);
     announceHomeStretch(game, roomId);
     logTurnState(game);
@@ -904,7 +923,7 @@ socket.on('makeMove', ({ roomId, pieceId, cardIndex, enterHome }) => {
       return;
     }
 
-    scheduleNextTurn(game, updatedState.moveAnimations);
+    scheduleNextTurn(game, updatedState.moveAnimations, updatedState.cardAnimation);
 
   } catch (error) {
     console.error(`Erro ao processar movimento:`, error);
@@ -951,6 +970,7 @@ socket.on('confirmHomeEntry', ({ roomId, pieceId, cardIndex, enterHome }) => {
         direction: getMoveAnimationDirection(playedCard, moveResult)
       }]);
     }
+    updatedState.cardAnimation = buildCardAnimation(playedCard, currentPlayer.position);
     io.to(roomId).emit('gameStateUpdate', updatedState);
     announceHomeStretch(game, roomId);
 
@@ -972,7 +992,7 @@ socket.on('confirmHomeEntry', ({ roomId, pieceId, cardIndex, enterHome }) => {
       return;
     }
 
-    scheduleNextTurn(game, updatedState.moveAnimations);
+    scheduleNextTurn(game, updatedState.moveAnimations, updatedState.cardAnimation);
    } catch (error) {
      console.error('Erro ao confirmar entrada na vitória:', error);
      socket.emit('error', error.message);
@@ -1002,6 +1022,7 @@ socket.on('confirmHomeEntry', ({ roomId, pieceId, cardIndex, enterHome }) => {
     
     try {
       const currentPlayer = game.getCurrentPlayer();
+      const playedCard = currentPlayer.cards.find(card => card.value === '7') || { value: '7', suit: '♠' };
       const previousPositions = capturePiecePositions(game);
       const moveResult = game.makeSpecialMove(moves);
 
@@ -1051,6 +1072,7 @@ socket.on('confirmHomeEntry', ({ roomId, pieceId, cardIndex, enterHome }) => {
         }));
         updatedState.moveAnimations = buildMoveAnimations(game, previousPositions, primaryMoves);
       }
+      updatedState.cardAnimation = buildCardAnimation(playedCard, currentPlayer.position);
       io.to(roomId).emit('gameStateUpdate', updatedState);
       announceHomeStretch(game, roomId);
       logTurnState(game);
@@ -1070,7 +1092,7 @@ socket.on('confirmHomeEntry', ({ roomId, pieceId, cardIndex, enterHome }) => {
         return;
       }
       
-      scheduleNextTurn(game, updatedState.moveAnimations);
+      scheduleNextTurn(game, updatedState.moveAnimations, updatedState.cardAnimation);
 
     } catch (error) {
       socket.emit('error', error.message);
@@ -1121,6 +1143,9 @@ socket.on('confirmHomeEntry', ({ roomId, pieceId, cardIndex, enterHome }) => {
     }
 
     try {
+      const playedCard = game.pendingSpecialMove
+        ? currentPlayer.cards[game.pendingSpecialMove.cardIndex]
+        : null;
       const previousPositions = capturePiecePositions(game);
       const moveResult = game.resumeSpecialMove(enterHome);
 
@@ -1170,6 +1195,7 @@ socket.on('confirmHomeEntry', ({ roomId, pieceId, cardIndex, enterHome }) => {
         }));
         updatedState.moveAnimations = buildMoveAnimations(game, previousPositions, primaryMoves);
       }
+      updatedState.cardAnimation = buildCardAnimation(playedCard || { value: '7', suit: '♠' }, currentPlayer.position);
       io.to(roomId).emit('gameStateUpdate', updatedState);
       announceHomeStretch(game, roomId);
       logTurnState(game);
@@ -1188,7 +1214,7 @@ socket.on('confirmHomeEntry', ({ roomId, pieceId, cardIndex, enterHome }) => {
         return;
       }
 
-      scheduleNextTurn(game, updatedState.moveAnimations);
+      scheduleNextTurn(game, updatedState.moveAnimations, updatedState.cardAnimation);
     } catch (error) {
       console.error('Erro ao confirmar entrada na vitória especial:', error);
       socket.emit('error', error.message);


### PR DESCRIPTION
### Motivation
- Evitar que peças capturadas comecem a se mover antes que a peça capturadora chegue e exibir visualmente a carta jogada antes das animações das peças; o objetivo é sincronizar melhor a ordem das animações e tornar a jogada mais clara para o jogador.
- Garantir que o servidor bloqueie o próximo turno enquanto a animação da carta (aparecer sobre a penalty zone por 0,5s e viajar até o baralho em 60s) estiver em progresso para todos os clientes.

### Description
- Adiciona metadados `cardAnimation` ao estado de jogo emitido pelo servidor via `gameStateUpdate` e propaga esse objeto para o cliente para controlar a animação da carta antes do movimento das peças; a função `buildCardAnimation` cria o payload. (`server/server.js`)
- Ajusta o cálculo de delay de turno em `getTurnAnimationDelay` e `scheduleNextTurn` para considerar `CARD_HOLD_ANIMATION_DURATION_MS` (500ms) + `CARD_TRAVEL_ANIMATION_DURATION_MS` (60s) quando existe `cardAnimation`. (`server/server.js`)
- Reordena a montagem de animações `orderMoveAnimations` para priorizar moves primários e garantir que peças capturadas só sejam animadas após a peça capturadora chegar à posição de captura, evitando o efeito de fugida prematura. (`server/server.js`)
- Implementa a animação cliente-side que cria um elemento flutuante da carta sobre a penalty zone do jogador, espera `0.5s` e depois anima sua viagem ao centro do baralho em `60s`, executando isso antes de `animatePieceMoves`; inserção de `animatePlayedCard`, `animateTurnSequence` e estilos `.turn-card-animation`. (`public/js/game.js`, `public/css/game.css`)
- Integra `cardAnimation` na sequência de atualização do tabuleiro em `updateBoard` de modo que a sequência seja: carta aparece/viaja → animações das peças. (`public/js/game.js`)

### Testing
- Verificação de sintaxe com `node --check public/js/game.js` e `node --check server/server.js`, ambos concluídos com sucesso. 
- Execução completa da suíte de testes automatizados com `npm test -- --runInBand`, todos os testes passaram: `6` test suites e `71` testes executados com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06898281e8832abe2e0762aee198b8)