### PR TITLE
Fix move animation destination flicker

### DIFF
--- a/public/js/game.js
+++ b/public/js/game.js
@@ -1198,9 +1198,19 @@ function updatePlayerLabels() {
     const previousPiece = getPieceById(previousState, piece.id);
     const moveDescriptor = moveDescriptorByPiece.get(piece.id);
     const first = previousPieceRects[piece.id];
+    const moved = moveDescriptor || (previousPiece && !positionsEqual(previousPiece.position, piece.position));
+
+    // A peça precisa ser anexada à célula de destino para calcular o FLIP,
+    // mas não pode ficar visível ali antes de receber o transform inicial.
+    // Caso contrário, o navegador pode pintar um frame no destino durante a
+    // animação da carta e só depois reposicionar a peça na origem.
+    if (moved) {
+      pieceElement.style.transition = 'none';
+      pieceElement.style.visibility = 'hidden';
+    }
+
     cell.appendChild(pieceElement);
     const last = pieceElement.getBoundingClientRect();
-    const moved = moveDescriptor || (previousPiece && !positionsEqual(previousPiece.position, piece.position));
     const delta = first ? rectCenterDelta(first, last) : { x: 0, y: 0 };
     const deltaX = delta.x;
     const deltaY = delta.y;
@@ -1218,6 +1228,7 @@ function updatePlayerLabels() {
           ];
 
       pieceElement.style.transform = keyframes[0].transform;
+      pieceElement.style.visibility = '';
       animations.push({
         element: pieceElement,
         from: moveDescriptor ? moveDescriptor.from : previousPiece.position,
@@ -1226,6 +1237,8 @@ function updatePlayerLabels() {
         keyframes,
         finalTransform: `rotate(${-rotation}deg)`
       });
+    } else {
+      pieceElement.style.visibility = '';
     }
   });
 


### PR DESCRIPTION
### Motivation
- Prevent pieces briefly appearing at their destination before the move animation starts when the frontend attaches elements to destination cells to compute FLIP measurements.

### Description
- Update `positionPieces` in `public/js/game.js` to hide moved piece elements (`style.visibility = 'hidden'`) before appending them to the destination cell for FLIP measurement and only reveal them after the initial transform is applied, avoiding a destination flash.
- Keep existing FLIP calculation and keyframe generation logic but ensure the element is invisible while the browser may paint the destination frame.
- The change is localized to the client-side rendering logic that computes and enqueues move animations (`positionPieces` / move animation preparation).

### Testing
- Ran the test suite with `npm test -- --runInBand`; all test suites passed (6 test suites, 72 tests) and no failures were produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0692eeb9a8832ab10d48a60e3c9d50)