### PR TITLE
BotWrapper: fallback to discard when special action is stale/invalid

### DIFF
--- a/server/__tests__/bot_wrapper.test.js
+++ b/server/__tests__/bot_wrapper.test.js
@@ -284,4 +284,50 @@ describe('BotWrapper live fixed play constraints', () => {
     expect(response.playedCard).toEqual({ suit: '♥', value: '2' });
   });
 
+  test('falls back to discarding a seven when bot selects stale special action with no valid moves', () => {
+    const game = new Game('bot-stale-special-discard');
+    game.addPlayer('1', 'Bot', true);
+    game.addPlayer('2', 'Bob');
+    game.addPlayer('3', 'Carol');
+    game.addPlayer('4', 'Dave');
+    game.setupTeams();
+    game.isActive = true;
+    game.currentPlayerIndex = 0;
+    game.players[0].cards = [{ suit: '♠', value: '7' }];
+
+    const wrapper = new BotWrapper(game);
+    expect(game.hasAnyValidMove(0)).toBe(false);
+
+    const response = wrapper.makeMove(0, 60);
+
+    expect(response.success).toBe(true);
+    expect(response.action).toBe('discard');
+    expect(response.playedCard).toEqual({ suit: '♠', value: '7' });
+    expect(game.players[0].cards).toHaveLength(0);
+    expect(game.currentPlayerIndex).toBe(3);
+  });
+
+  test('falls back to discarding when bot special seven action becomes invalid and no moves remain', () => {
+    const game = new Game('bot-invalid-special-discard');
+    game.addPlayer('1', 'Bot', true);
+    game.addPlayer('2', 'Bob');
+    game.addPlayer('3', 'Carol');
+    game.addPlayer('4', 'Dave');
+    game.setupTeams();
+    game.isActive = true;
+    game.currentPlayerIndex = 0;
+    game.players[0].cards = [{ suit: '♠', value: '7' }];
+
+    const wrapper = new BotWrapper(game);
+    wrapper.specialActions[60] = [{ pieceId: 'p0_1', steps: 7 }];
+
+    const response = wrapper.makeMove(0, 60);
+
+    expect(response.success).toBe(true);
+    expect(response.action).toBe('discard');
+    expect(response.playedCard).toEqual({ suit: '♠', value: '7' });
+    expect(game.players[0].cards).toHaveLength(0);
+    expect(game.currentPlayerIndex).toBe(3);
+  });
+
 });

--- a/server/bot_wrapper.js
+++ b/server/bot_wrapper.js
@@ -147,6 +147,30 @@ class BotWrapper {
     return selectedIndices.slice(0, 10);
   }
 
+  getFallbackDiscardAction(playerId) {
+    const cards = this.game && this.game.players && this.game.players[playerId]
+      ? this.game.players[playerId].cards
+      : [];
+    const cardIndices = Object.keys(cards || {}).map(Number).filter(idx => cards[idx]);
+    const discardCardIndices = this.getPreferredDiscardCardIndices(cards, cardIndices);
+    const fallbackIndex = discardCardIndices.length > 0 ? discardCardIndices[0] : cardIndices[0];
+    return fallbackIndex !== undefined ? 70 + fallbackIndex : null;
+  }
+
+  shouldFallbackToDiscard(playerId) {
+    return this.game &&
+      this.game.hasAnyValidMove &&
+      !this.game.hasAnyValidMove(playerId);
+  }
+
+  makeFallbackDiscardMove(playerId) {
+    const fallbackAction = this.getFallbackDiscardAction(playerId);
+    if (fallbackAction === null) {
+      throw new Error('No valid fallback discard');
+    }
+    return this.makeMove(playerId, fallbackAction);
+  }
+
 
   getTrackCoordinates() {
     const track = [];
@@ -668,9 +692,19 @@ class BotWrapper {
         playedCard = this.game.players[playerId].cards.find(card => card.value === '7');
         const moves = this.specialActions[actionId];
         if (!moves) {
+          if (this.shouldFallbackToDiscard(playerId)) {
+            return this.makeFallbackDiscardMove(playerId);
+          }
           throw new Error('Invalid special action');
         }
-        result = this.game.makeSpecialMove(moves);
+        try {
+          result = this.game.makeSpecialMove(moves);
+        } catch (e) {
+          if (this.shouldFallbackToDiscard(playerId)) {
+            return this.makeFallbackDiscardMove(playerId);
+          }
+          throw e;
+        }
         if (result && result.action === 'homeEntryChoice') {
           result = this.game.resumeSpecialMove(true);
         }


### PR DESCRIPTION
### Motivation

- Prevent the bot from throwing or getting stuck when a selected special action is stale or becomes invalid and the bot has no other valid moves.

### Description

- Added `getFallbackDiscardAction`, `shouldFallbackToDiscard`, and `makeFallbackDiscardMove` helpers to choose and perform a safe discard when needed.  
- Updated `makeMove` to detect missing or failing special actions (actionId >= 60) and fall back to performing a discard when `hasAnyValidMove` reports no valid moves.  
- Wrapped `game.makeSpecialMove` in a `try/catch` and trigger the discard fallback on error when appropriate.  
- Added unit tests in `server/__tests__/bot_wrapper.test.js` to cover stale/invalid special-action fallbacks to discarding.

### Testing

- Ran the unit test suite with `npm test` and the modified `server/__tests__/bot_wrapper.test.js` tests passed.  
- The new tests `falls back to discarding a seven when bot selects stale special action with no valid moves` and `falls back to discarding when bot special seven action becomes invalid and no moves remain` both succeed.  
- Existing `BotWrapper` tests were executed and remained green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a076aa67858832abb5f4db2cbf983d6)