### PR TITLE
Improve board piece animation robustness and add bot fallback discard for stale/invalid special actions

### DIFF
--- a/public/js/game.js
+++ b/public/js/game.js
@@ -223,6 +223,16 @@ document.addEventListener('DOMContentLoaded', () => {
       return new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
     }
 
+    function cancelElementAnimations(element) {
+      element.getAnimations().forEach(animation => {
+        try {
+          animation.cancel();
+        } catch (error) {
+          console.warn('Erro ao cancelar animação anterior da peça:', error);
+        }
+      });
+    }
+
     function positionsEqual(a, b) {
       return Boolean(a && b && a.row === b.row && a.col === b.col);
     }
@@ -1205,6 +1215,7 @@ function updatePlayerLabels() {
     // Caso contrário, o navegador pode pintar um frame no destino durante a
     // animação da carta e só depois reposicionar a peça na origem.
     if (moved) {
+      cancelElementAnimations(pieceElement);
       pieceElement.style.transition = 'none';
       pieceElement.style.visibility = 'hidden';
     }
@@ -1228,13 +1239,17 @@ function updatePlayerLabels() {
           ];
 
       pieceElement.style.transform = keyframes[0].transform;
-      pieceElement.style.visibility = '';
+      // Mantém a peça real invisível até o instante em que a animação do
+      // tabuleiro começa. Assim, se o navegador pintar entre o append na célula
+      // final e o início da WAAPI, ele nunca exibe um frame no destino.
+      pieceElement.style.visibility = 'hidden';
       animations.push({
         element: pieceElement,
         from: moveDescriptor ? moveDescriptor.from : previousPiece.position,
         to: moveDescriptor ? moveDescriptor.to : piece.position,
         order: moveDescriptor ? moveDescriptor.order : animations.length,
         keyframes,
+        initialTransform: keyframes[0].transform,
         finalTransform: `rotate(${-rotation}deg)`
       });
     } else {
@@ -1270,17 +1285,28 @@ async function animatePieceMoves(animations) {
 
   for (const animation of animations) {
     highlightMoveCells(animation);
+    cancelElementAnimations(animation.element);
     animation.element.classList.add('moving');
-    await waitForNextFrame();
     animation.element.style.transition = 'none';
+    animation.element.style.transform = animation.initialTransform || animation.keyframes[0].transform;
+    animation.element.style.visibility = '';
+    await waitForNextFrame();
     const movement = animation.element.animate(animation.keyframes, {
       duration: MOVE_ANIMATION_DURATION_MS,
       easing: 'ease-in-out',
       fill: 'forwards'
     });
-    await movement.finished.catch(() => {});
-    animation.element.style.transform = animation.finalTransform;
-    animation.element.classList.remove('moving');
+
+    try {
+      await movement.finished;
+    } catch (error) {
+      // A animação pode ser cancelada por uma atualização mais nova do estado.
+    } finally {
+      animation.element.style.transform = animation.finalTransform;
+      animation.element.style.visibility = '';
+      movement.cancel();
+      animation.element.classList.remove('moving');
+    }
   }
 
   clearMoveHighlights();

--- a/server/__tests__/bot_wrapper.test.js
+++ b/server/__tests__/bot_wrapper.test.js
@@ -284,4 +284,50 @@ describe('BotWrapper live fixed play constraints', () => {
     expect(response.playedCard).toEqual({ suit: '♥', value: '2' });
   });
 
+  test('falls back to discarding a seven when bot selects stale special action with no valid moves', () => {
+    const game = new Game('bot-stale-special-discard');
+    game.addPlayer('1', 'Bot', true);
+    game.addPlayer('2', 'Bob');
+    game.addPlayer('3', 'Carol');
+    game.addPlayer('4', 'Dave');
+    game.setupTeams();
+    game.isActive = true;
+    game.currentPlayerIndex = 0;
+    game.players[0].cards = [{ suit: '♠', value: '7' }];
+
+    const wrapper = new BotWrapper(game);
+    expect(game.hasAnyValidMove(0)).toBe(false);
+
+    const response = wrapper.makeMove(0, 60);
+
+    expect(response.success).toBe(true);
+    expect(response.action).toBe('discard');
+    expect(response.playedCard).toEqual({ suit: '♠', value: '7' });
+    expect(game.players[0].cards).toHaveLength(0);
+    expect(game.currentPlayerIndex).toBe(3);
+  });
+
+  test('falls back to discarding when bot special seven action becomes invalid and no moves remain', () => {
+    const game = new Game('bot-invalid-special-discard');
+    game.addPlayer('1', 'Bot', true);
+    game.addPlayer('2', 'Bob');
+    game.addPlayer('3', 'Carol');
+    game.addPlayer('4', 'Dave');
+    game.setupTeams();
+    game.isActive = true;
+    game.currentPlayerIndex = 0;
+    game.players[0].cards = [{ suit: '♠', value: '7' }];
+
+    const wrapper = new BotWrapper(game);
+    wrapper.specialActions[60] = [{ pieceId: 'p0_1', steps: 7 }];
+
+    const response = wrapper.makeMove(0, 60);
+
+    expect(response.success).toBe(true);
+    expect(response.action).toBe('discard');
+    expect(response.playedCard).toEqual({ suit: '♠', value: '7' });
+    expect(game.players[0].cards).toHaveLength(0);
+    expect(game.currentPlayerIndex).toBe(3);
+  });
+
 });

--- a/server/bot_wrapper.js
+++ b/server/bot_wrapper.js
@@ -147,6 +147,30 @@ class BotWrapper {
     return selectedIndices.slice(0, 10);
   }
 
+  getFallbackDiscardAction(playerId) {
+    const cards = this.game && this.game.players && this.game.players[playerId]
+      ? this.game.players[playerId].cards
+      : [];
+    const cardIndices = Object.keys(cards || {}).map(Number).filter(idx => cards[idx]);
+    const discardCardIndices = this.getPreferredDiscardCardIndices(cards, cardIndices);
+    const fallbackIndex = discardCardIndices.length > 0 ? discardCardIndices[0] : cardIndices[0];
+    return fallbackIndex !== undefined ? 70 + fallbackIndex : null;
+  }
+
+  shouldFallbackToDiscard(playerId) {
+    return this.game &&
+      this.game.hasAnyValidMove &&
+      !this.game.hasAnyValidMove(playerId);
+  }
+
+  makeFallbackDiscardMove(playerId) {
+    const fallbackAction = this.getFallbackDiscardAction(playerId);
+    if (fallbackAction === null) {
+      throw new Error('No valid fallback discard');
+    }
+    return this.makeMove(playerId, fallbackAction);
+  }
+
 
   getTrackCoordinates() {
     const track = [];
@@ -668,9 +692,19 @@ class BotWrapper {
         playedCard = this.game.players[playerId].cards.find(card => card.value === '7');
         const moves = this.specialActions[actionId];
         if (!moves) {
+          if (this.shouldFallbackToDiscard(playerId)) {
+            return this.makeFallbackDiscardMove(playerId);
+          }
           throw new Error('Invalid special action');
         }
-        result = this.game.makeSpecialMove(moves);
+        try {
+          result = this.game.makeSpecialMove(moves);
+        } catch (e) {
+          if (this.shouldFallbackToDiscard(playerId)) {
+            return this.makeFallbackDiscardMove(playerId);
+          }
+          throw e;
+        }
         if (result && result.action === 'homeEntryChoice') {
           result = this.game.resumeSpecialMove(true);
         }


### PR DESCRIPTION
### Motivation

- Prevent visual glitches and race conditions when pieces are re-rendered or updated by ensuring previous animations are cancelled and visibility/transform are set deterministically. 
- Make bot decision logic more robust when a previously computed special action becomes stale or invalid by falling back to a safe discard action. 
- Add coverage for the fallback behavior to avoid runtime failures in edge cases where no valid moves remain.

### Description

- Frontend: added `cancelElementAnimations` and call sites to cancel prior WAAPI animations before reusing or appending piece elements, and adjusted visibility/initial transform handling to avoid flashes between DOM append and animation start. 
- Frontend: store `initialTransform` for move descriptors, set `visibility` explicitly before starting WAAPI animations, and wrap awaiting `movement.finished` in `try/catch/finally` to gracefully handle cancelled animations and ensure final state is applied. 
- Backend: added `getFallbackDiscardAction`, `shouldFallbackToDiscard`, and `makeFallbackDiscardMove` helpers and updated `makeMove` to fall back to a discard when a special action is missing or `makeSpecialMove` throws and the player has no other valid moves. 
- Tests: added unit tests to `server/__tests__/bot_wrapper.test.js` for the new fallback behaviors when special actions are stale or become invalid.

### Testing

- Ran the server unit tests targeting the bot logic with `jest server/__tests__/bot_wrapper.test.js` and the new tests passed. 
- Ran the full test suite with `npm test` and observed no regressions in automated tests. 
- No automated frontend visual tests were added; the animation changes are guarded by WAAPI-safe checks and exception handling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a076aa67858832abb5f4db2cbf983d6)