### PR TITLE
Fix discard marker and filter intermediate Joker replay snapshots

### DIFF
--- a/public/js/game.js
+++ b/public/js/game.js
@@ -760,7 +760,7 @@ function flushDeferredTurnEvents() {
 function checkIfStuckInPenalty(cards, canMoveFlag) {
   if (!gameState || !gameState.pieces) return;
 
-  const cardElements = document.querySelectorAll('.card');
+  const cardElements = cardsContainer.querySelectorAll('.card');
 
   if (canMoveFlag === false) {
     showStatusMessage('Você não tem jogadas possíveis. Selecione uma carta para descartar.', 'error');
@@ -1382,9 +1382,10 @@ function updateTurnInfo() {
         if (stateOverride.discardPile && stateOverride.discardPile.length > 0) {
             const card = stateOverride.discardPile[0];
             topDiscard.innerHTML = createCardHTML(card);
-            topDiscard.classList.remove('hidden');
+            topDiscard.classList.remove('hidden', 'discard-only');
         } else {
             topDiscard.innerHTML = '';
+            topDiscard.classList.remove('discard-only');
             topDiscard.classList.add('hidden');
         }
     }
@@ -1609,7 +1610,7 @@ function handleCardClick(index) {
 
 // Adicione esta função auxiliar
 function isPlayerStuckInPenalty() {
-  const cardElements = document.querySelectorAll('.card');
+  const cardElements = cardsContainer.querySelectorAll('.card');
   return cardElements.length > 0 && cardElements[0].classList.contains('discard-only');
 }
 

--- a/server/__tests__/replay_utils.test.js
+++ b/server/__tests__/replay_utils.test.js
@@ -1,0 +1,40 @@
+const { isIntermediateJokerReplayEntry, replayHistoryForSave } = require('../replay_utils');
+
+describe('replayHistoryForSave', () => {
+  const players = [
+    { id: 'p1', name: 'Alice', position: 0, cards: [{ value: 'JOKER' }] },
+    { id: 'p2', name: 'Bob', position: 1, cards: [] }
+  ];
+
+  test('hides joker snapshots captured before the turn advances', () => {
+    const intermediate = {
+      move: 'Alice jogou um C',
+      state: {
+        players,
+        currentPlayerIndex: 0,
+        pieces: [{ id: 'p0_1', inHomeStretch: true }, { id: 'p1_1', inPenaltyZone: true }]
+      }
+    };
+    const normal = {
+      move: 'Bob jogou um 5',
+      state: { players, currentPlayerIndex: 0 }
+    };
+
+    expect(isIntermediateJokerReplayEntry(intermediate)).toBe(true);
+    expect(replayHistoryForSave([intermediate, normal])).toEqual([normal]);
+  });
+
+  test('keeps final joker snapshots after the turn has advanced', () => {
+    const finalJoker = {
+      move: 'Alice jogou um C',
+      state: {
+        players,
+        currentPlayerIndex: 1,
+        discardPile: [{ value: 'JOKER' }]
+      }
+    };
+
+    expect(isIntermediateJokerReplayEntry(finalJoker)).toBe(false);
+    expect(replayHistoryForSave([finalJoker])).toEqual([finalJoker]);
+  });
+});

--- a/server/replay_utils.js
+++ b/server/replay_utils.js
@@ -1,0 +1,48 @@
+function actorForMove(entry) {
+  const move = entry && entry.move;
+  const players = entry && entry.state && entry.state.players;
+
+  if (!move || !Array.isArray(players)) {
+    return null;
+  }
+
+  return players.find(player => player && player.name && move.startsWith(player.name)) || null;
+}
+
+function isJokerMove(entry) {
+  const move = entry && entry.move;
+  if (!move) return false;
+
+  return /(?:\bC\b|JOKER|Joker)/.test(move);
+}
+
+function isIntermediateJokerReplayEntry(entry) {
+  if (!isJokerMove(entry)) {
+    return false;
+  }
+
+  const state = entry && entry.state;
+  const actor = actorForMove(entry);
+
+  return Boolean(
+    state &&
+    actor &&
+    Number.isInteger(state.currentPlayerIndex) &&
+    actor.position === state.currentPlayerIndex
+  );
+}
+
+function replayHistoryForSave(history) {
+  if (!Array.isArray(history)) {
+    return [];
+  }
+
+  return history
+    .filter(entry => !isIntermediateJokerReplayEntry(entry))
+    .map(entry => JSON.parse(JSON.stringify(entry)));
+}
+
+module.exports = {
+  isIntermediateJokerReplayEntry,
+  replayHistoryForSave
+};

--- a/server/server.js
+++ b/server/server.js
@@ -7,6 +7,7 @@ const { nanoid } = require('nanoid/non-secure');
 const { Game } = require('./game');
 const BotManager = require('./bot_manager');
 const { logTurnState, logMoveDetails } = require('./log_utils');
+const { replayHistoryForSave } = require('./replay_utils');
 const fs = require('fs');
 
 const REPLAY_DIR = path.join(__dirname, '../replays');
@@ -100,7 +101,7 @@ function saveReplay(game) {
   const data = {
     roomId: game.roomId,
     players: game.players.map(p => p.name),
-    history: game.history
+    history: replayHistoryForSave(game.history)
   };
   fs.writeFileSync(file, JSON.stringify(data, null, 2));
 
@@ -741,6 +742,15 @@ socket.on('makeJokerMove', ({ roomId, pieceId, targetPieceId, cardIndex }) => {
       cards: currentPlayer.cards
     });
 
+    // Atualizar o estado salvo no histórico para refletir o jogo após todas as
+    // alterações do movimento Joker antes de qualquer replay ser salvo.
+    const snapState = game.getGameStateWithCards();
+    delete snapState.lastMove;
+    const snap = JSON.parse(JSON.stringify(snapState));
+    if (game.history.length > 0) {
+      game.history[game.history.length - 1].state = snap;
+    }
+
     if (game.checkWinCondition()) {
       saveReplay(game);
       io.to(roomId).emit('gameOver', {
@@ -756,15 +766,6 @@ socket.on('makeJokerMove', ({ roomId, pieceId, targetPieceId, cardIndex }) => {
     }
 
     scheduleNextTurn(game, updatedState.moveAnimations, updatedState.cardAnimation);
-
-    // Atualizar o estado salvo no histórico para refletir o jogo após todas as
-    // alterações do movimento Joker
-    const snapState = game.getGameStateWithCards();
-    delete snapState.lastMove;
-    const snap = JSON.parse(JSON.stringify(snapState));
-    if (game.history.length > 0) {
-      game.history[game.history.length - 1].state = snap;
-    }
   } catch (error) {
     console.error(`Erro ao processar movimento Joker:`, error);
     socket.emit('error', error.message);


### PR DESCRIPTION
### Motivation
- Fix two UI/replay bugs: the discard indicator (dashed outline) was incorrectly persisting on the central discard pile, and intermediate Joker moves produced noisy/incorrect snapshots in saved replays. 

### Description
- Restrict discard-only styling to the player hand by querying `cardsContainer` instead of the global document, and update `checkIfStuckInPenalty`/`isPlayerStuckInPenalty` to use `cardsContainer` in `public/js/game.js` so only hand cards get the `discard-only` marker. 
- Ensure the central discard card (`topDiscard`) clears any stale `discard-only` class when the discard pile is refreshed in `updateDeckInfo` in `public/js/game.js`. 
- Add `server/replay_utils.js` with `isIntermediateJokerReplayEntry` and `replayHistoryForSave` to detect and filter out intermediate Joker snapshots from `game.history`. 
- Use `replayHistoryForSave` when saving replays (`saveReplay`) in `server/server.js` so saved replay files omit intermediate Joker entries. 
- Update the human Joker flow in `server/server.js` (`makeJokerMove`) to update the last history snapshot to the final post-move snapshot before any replay save or win handling. 
- Add unit tests in `server/__tests__/replay_utils.test.js` that verify intermediate Joker snapshots are hidden while final Joker snapshots are preserved. 

### Testing
- Ran the full test suite with `npm test -- --runInBand`, and all test suites passed: 7 test suites, 76 tests passed. 
- Added and executed `server/__tests__/replay_utils.test.js`, which passed as part of the above test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a003cdf24832a97ad3de3209c7a36)