### PR TITLE
Fix move UI text/positioning and add split-move confirm button

### DIFF
--- a/public/css/game.css
+++ b/public/css/game.css
@@ -121,25 +121,16 @@
     border-radius: 10px;
     font-size: 0.75rem;
     text-align: center;
-    margin-bottom: 0.35rem;
+    margin-top: 0.35rem;
     pointer-events: none;
     color: #05060c;
     font-weight: 700;
     border: 1px solid rgba(255, 255, 255, 0.16);
     box-shadow: 0 10px 25px rgba(140, 246, 255, 0.2);
-}
-
-.game-info {
-    position: relative;
-}
-
-@media (min-width: 769px) {
-    #last-move {
-        position: absolute;
-        top: -1.6rem;
-        left: 50%;
-        transform: translateX(-50%);
-    }
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    width: 100%;
 }
 
 .hidden {
@@ -971,3 +962,14 @@
 }
 .piece-split-slider-wrap input[type="range"] { width: 70px; }
 .piece-split-slider-wrap.vertical { flex-direction: column; }
+.piece-split-confirm {
+  border: none;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 999px;
+  background: rgba(111, 255, 176, 0.25);
+  color: #dffaff;
+  font-weight: 800;
+  cursor: pointer;
+  line-height: 1;
+}

--- a/public/game.html
+++ b/public/game.html
@@ -18,8 +18,6 @@
                 </div>
             </div>
 
-            <div id="last-move" class="last-move-message hidden"></div>
-
             <div class="turn-info">
                 <h3>Turno: <span id="current-player"></span></h3>
                 <div id="turn-message"></div>
@@ -43,8 +41,9 @@
             </div>
             <div id="play-builder" class="play-builder hidden" aria-live="polite">
                 <button id="reset-play-builder" class="play-builder-reset" title="Reiniciar jogada" type="button">↻</button>
-                <span id="play-builder-text">Jogar X com Y</span>
+                <span id="play-builder-text">Jogar __ com __</span>
             </div>
+            <div id="last-move" class="last-move-message hidden"></div>
             <div id="stats-panel" class="stats-panel hidden"></div>
         </div>
         
@@ -119,4 +118,3 @@
     <script src="js/game.js"></script>
 </body>
 </html>
-

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -396,14 +396,21 @@ document.addEventListener('DOMContentLoaded', () => {
     function renderPlayBuilder() {
       if (!playBuilder || !playBuilderText) return;
       const selectedCard = selectedCardIndex !== null ? playerCards[selectedCardIndex] : null;
-      const cardValue = selectedCard ? getDisplayValue(selectedCard) : 'X';
+      const cardValue = selectedCard ? getDisplayValue(selectedCard) : '__';
       const pieceA = selectedPieceId ? gameState?.pieces?.find(p => p.id === selectedPieceId) : null;
       const pieceB = secondPieceId ? gameState?.pieces?.find(p => p.id === secondPieceId) : null;
-      const text = pieceB ? `Jogar ${cardValue} com ${pieceA ? pieceA.pieceId : 'Y'} e ${pieceB.pieceId}.` : `Jogar ${cardValue} com ${pieceA ? pieceA.pieceId : 'Y'}`;
+      const text = pieceB
+        ? `Jogar ${cardValue} com ${pieceA ? pieceA.pieceId : '__'} e ${pieceB.pieceId}.`
+        : `Jogar ${cardValue} com ${pieceA ? pieceA.pieceId : '__'}`;
       playBuilderText.textContent = text;
       if (isMyTurn || gameState?.lastMove) playBuilder.classList.remove('hidden');
       else playBuilder.classList.add('hidden');
-      if (!isMyTurn && gameState?.lastMove) playBuilderText.textContent = gameState.lastMove;
+      if (!isMyTurn && gameState?.lastMove) {
+        const lastMoveText = typeof gameState.lastMove === 'string'
+          ? gameState.lastMove
+          : gameState.lastMove.message;
+        if (lastMoveText) playBuilderText.textContent = lastMoveText;
+      }
     }
 
     function clearBoardSplitSliders() {
@@ -922,14 +929,38 @@ function checkIfStuckInPenalty(cards, canMoveFlag) {
         w.className = `piece-split-slider-wrap ${vertical ? 'vertical' : ''}`;
         const out = document.createElement('span');
         const input = document.createElement('input');
+        const confirm = document.createElement('button');
         input.type='range'; input.min=Math.min(...validSplits); input.max=Math.max(...validSplits); input.value=boardSplitValue;
         input.addEventListener('input',()=>{ let val=parseInt(input.value,10); if(validSplits.length && !validSplits.includes(val)){ val = validSplits.reduce((a,b)=> Math.abs(b-val) < Math.abs(a-val) ? b : a); input.value=val; } boardSplitValue=val; document.querySelectorAll('.piece-split-slider-wrap .val').forEach((el,i)=> el.textContent = i===0?boardSplitValue:7-boardSplitValue); });
+        confirm.type = 'button';
+        confirm.className = 'piece-split-confirm';
+        confirm.textContent = '✓';
+        confirm.title = 'Confirmar divisão';
+        confirm.addEventListener('click', submitSpecialSplit);
         out.className='val'; out.textContent = isLeft ? boardSplitValue : 7-boardSplitValue;
-        w.append(out,input);
+        w.append(out,input,confirm);
         target.appendChild(w);
       };
       mk(a,true); mk(b,false);
       boardSplitMode = true;
+    }
+
+    function submitSpecialSplit() {
+        const val = boardSplitMode ? boardSplitValue : parseInt(splitSlider.value, 10);
+        if (validSplits.length > 0 && !validSplits.includes(val)) {
+            showStatusMessage('Divisão inválida', 'error');
+            return;
+        }
+        pendingSpecialMove = { pieceAId: selectedPieceId, pieceBId: secondPieceId };
+        socket.emit('makeSpecialMove', {
+            roomId,
+            moves: [
+                { pieceId: selectedPieceId, steps: val },
+                { pieceId: secondPieceId, steps: 7 - val }
+            ],
+            cardIndex: specialMoveCard
+        });
+        finalizeSpecialMove();
     }
 
     // Funções de atualização da interface
@@ -1924,23 +1955,7 @@ function makeMove() {
 
         splitSlider.addEventListener('input', updateSliderValues);
 
-        confirmSplitBtn.addEventListener('click', () => {
-            const val = boardSplitMode ? boardSplitValue : parseInt(splitSlider.value, 10);
-            if (validSplits.length > 0 && !validSplits.includes(val)) {
-                showStatusMessage('Divisão inválida', 'error');
-                return;
-            }
-            pendingSpecialMove = { pieceAId: selectedPieceId, pieceBId: secondPieceId };
-            socket.emit('makeSpecialMove', {
-                roomId,
-                moves: [
-                    { pieceId: selectedPieceId, steps: val },
-                    { pieceId: secondPieceId, steps: 7 - val }
-                ],
-                cardIndex: specialMoveCard
-            });
-            finalizeSpecialMove();
-        });
+        confirmSplitBtn.addEventListener('click', submitSpecialSplit);
 
         cancelJokerMoveBtn.addEventListener('click', () => {
             jokerDialog.classList.add('hidden');
@@ -1987,4 +2002,3 @@ function makeMove() {
     // Inicializar o jogo
     init();
 });
-


### PR DESCRIPTION
### Motivation
- Make the "última jogada" banner render clearly below the deck/play-builder area and avoid it overlapping or expanding to multiple lines.
- Improve play-builder placeholder text to be visually consistent when no card/piece is selected.
- Fix cases where an opponent move was shown as `object Object` by handling both string and object `lastMove` payloads.
- Allow players to finalize a 7-card split move directly from the in-board sliders by adding an explicit confirm action.

### Description
- Moved the `#last-move` element in `public/game.html` to render under the deck/play-builder area and replaced the play-builder placeholder with `Jogar __ com __`.
- Updated `public/css/game.css` to make `#last-move` single-line with `white-space: nowrap`, `overflow: hidden`, `text-overflow: ellipsis`, changed its spacing (use `margin-top`) and added styles for a new `.piece-split-confirm` button.
- Modified `public/js/game.js` to use `__` placeholders in `renderPlayBuilder()`, to read `gameState.lastMove` or `gameState.lastMove.message` to avoid `object Object`, to inject a small check (`✓`) confirm button next to each board split slider in `renderBoardSplitSliders()`, and to refactor the split confirmation logic into a shared `submitSpecialSplit()` function used by both the dialog's confirm button and the new slider confirm buttons.
- Kept behavior server-side unchanged; frontend-only UI/interaction changes and small refactor of client-side split submission.

### Testing
- Ran the test suite with `npm test -- --runInBand` (Jest); all test suites passed (`7 passed`, `76 tests`), indicating no regressions in automated tests.
- Pretest install ran as part of the test pipeline but no backend protocol or API changes were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cec0af08c832a9ee977b3abab0dbe)