### PR TITLE
Ajusta posição flutuante da faixa de jogada e adiciona botão “Concluir” para carta 7 dividida

### DIFF
--- a/public/css/game.css
+++ b/public/css/game.css
@@ -929,16 +929,23 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  gap: 0.5rem;
-  margin-top: 0.55rem;
-  padding: 0.45rem 0.7rem;
-  border-radius: 10px;
-  background: rgba(140, 246, 255, 0.14);
-  border: 1px solid rgba(140, 246, 255, 0.3);
+  gap: 0.45rem;
+  margin: -0.45rem auto -0.2rem;
+  width: fit-content;
+  max-width: min(92vw, 860px);
+  padding: 0.3rem 0.55rem;
+  border-radius: 999px;
+  background: rgba(10, 14, 28, 0.76);
+  border: 1px solid rgba(140, 246, 255, 0.2);
   color: #dffaff;
-  font-weight: 700;
+  font-weight: 600;
+  font-size: 0.82rem;
+  backdrop-filter: blur(3px);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.28);
+  z-index: 4;
 }
 .play-builder-reset {
+  flex: 0 0 auto;
   border: none;
   width: 1.6rem;
   height: 1.6rem;
@@ -946,6 +953,21 @@
   background: rgba(255,255,255,0.15);
   color: #fff;
   cursor: pointer;
+}
+
+.play-builder-confirm {
+  border: 1px solid rgba(111, 255, 176, 0.45);
+  background: rgba(111, 255, 176, 0.18);
+  color: #d6ffe5;
+  border-radius: 999px;
+  padding: 0.18rem 0.55rem;
+  font-size: 0.74rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+#play-builder-text {
+  white-space: nowrap;
 }
 .piece-split-slider-wrap {
   position: absolute;

--- a/public/game.html
+++ b/public/game.html
@@ -39,14 +39,16 @@
                     <span id="discard-count">0</span>
                 </div>
             </div>
-            <div id="play-builder" class="play-builder hidden" aria-live="polite">
-                <button id="reset-play-builder" class="play-builder-reset" title="Reiniciar jogada" type="button">↻</button>
-                <span id="play-builder-text">Jogar __ com __</span>
-            </div>
             <div id="last-move" class="last-move-message hidden"></div>
             <div id="stats-panel" class="stats-panel hidden"></div>
         </div>
         
+        <div id="play-builder" class="play-builder hidden" aria-live="polite">
+            <button id="reset-play-builder" class="play-builder-reset" title="Reiniciar jogada" type="button">↻</button>
+            <span id="play-builder-text">Jogar __ com __</span>
+            <button id="confirm-play-builder" class="play-builder-confirm hidden" title="Concluir jogada da carta 7" type="button">Concluir</button>
+        </div>
+
         <div class="player-hand">
             <div id="cards-container"></div>
         </div>

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -21,6 +21,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const playBuilder = document.getElementById('play-builder');
     const playBuilderText = document.getElementById('play-builder-text');
     const resetPlayBuilderBtn = document.getElementById('reset-play-builder');
+    const confirmPlayBuilderBtn = document.getElementById('confirm-play-builder');
     
     // Elementos do diálogo de movimento especial (carta 7)
     const specialMoveChoice = document.getElementById('special-move-choice');
@@ -403,6 +404,16 @@ document.addEventListener('DOMContentLoaded', () => {
         ? `Jogar ${cardValue} com ${pieceA ? pieceA.pieceId : '__'} e ${pieceB.pieceId}.`
         : `Jogar ${cardValue} com ${pieceA ? pieceA.pieceId : '__'}`;
       playBuilderText.textContent = text;
+      const shouldShowConfirm = (
+        isMyTurn
+        && selectedCard?.value === '7'
+        && selectedPieceId
+        && secondPieceId
+        && validSplits.length > 0
+        && !awaitingSecondPiece
+      );
+      confirmPlayBuilderBtn?.classList.toggle('hidden', !shouldShowConfirm);
+
       if (isMyTurn || gameState?.lastMove) playBuilder.classList.remove('hidden');
       else playBuilder.classList.add('hidden');
       if (!isMyTurn && gameState?.lastMove) {
@@ -911,6 +922,7 @@ function checkIfStuckInPenalty(cards, canMoveFlag) {
         const mid = validSplits[Math.floor(validSplits.length / 2)];
         splitSlider.value = mid;
         updateSliderValues();
+        renderPlayBuilder();
         specialMoveDialog.classList.add('hidden');
         renderBoardSplitSliders();
     }
@@ -1639,6 +1651,7 @@ function handlePieceClick(pieceId) {
     }
     secondPieceId = pieceId;
     awaitingSecondPiece = false;
+    renderPlayBuilder();
     showSliderDialog();
     return;
   }
@@ -1973,6 +1986,7 @@ function makeMove() {
         window.addEventListener('resize', adjustBoardSize);
         window.addEventListener('orientationchange', adjustBoardSize);
         resetPlayBuilderBtn?.addEventListener('click', () => resetPlayBuilder(true));
+        confirmPlayBuilderBtn?.addEventListener('click', submitSpecialSplit);
     }
 
     function updateSliderValues() {


### PR DESCRIPTION
### Motivation
- Recuperar espaço útil no tabuleiro movendo a faixa de construção/indicação de jogada para entre o tabuleiro e a mão do jogador, com aparência discreta e flutuante para não aumentar a área do jogo.
- Resolver o fluxo confuso da carta `7` quando dividida entre duas peças, adicionando uma ação explícita para finalizar a jogada.

### Description
- Move a marcação HTML do `#play-builder` para ficar entre o `board` e a `player-hand` e adiciona um botão `#confirm-play-builder` para conclusão da divisão da carta `7` (`public/game.html`).
- Atualiza o estilo da faixa em `.play-builder` para um visual compacto/flutuante e adiciona estilos para `.play-builder-confirm` e `#play-builder-text` para melhorar legibilidade e comportamento responsivo (`public/css/game.css`).
- Em `public/js/game.js` passa a buscar `confirmPlayBuilderBtn`, exibe/esconde esse botão conforme as condições do fluxo da carta `7` (`selectedPieceId`, `secondPieceId`, `validSplits`, `awaitingSecondPiece`) e liga o clique do botão ao procedimento `submitSpecialSplit`; também chama `renderPlayBuilder()` quando chegam `validSplits` ou quando a segunda peça é selecionada para manter a faixa sincronizada.
- Mantém o botão de reset existente e preserva `submitSpecialSplit` como a ação que envia o movimento especial ao servidor.

### Testing
- Executei a suíte de testes automatizados com `npm test -- --runInBand` e todos os testes passaram (7 test suites, 76 tests) sem falhas.
- Nenhum teste automatizado precisou ser alterado; as mudanças são apenas de UI e integração de eventos no cliente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cf1188558832aa1879fcb8bfed8ed)