### PR TITLE
Remover faixa "última jogada" que quebrava o layout

### DIFF
--- a/public/css/game.css
+++ b/public/css/game.css
@@ -114,25 +114,6 @@
     box-shadow: 0 18px 45px rgba(0,0,0,0.4), inset 0 1px 0 rgba(255,255,255,0.03);
 }
 
-/* Mensagem da última jogada */
-#last-move {
-    background: linear-gradient(135deg, rgba(140, 246, 255, 0.22), rgba(255, 125, 255, 0.2));
-    padding: 4px 8px;
-    border-radius: 10px;
-    font-size: 0.75rem;
-    text-align: center;
-    margin-top: 0.35rem;
-    pointer-events: none;
-    color: #05060c;
-    font-weight: 700;
-    border: 1px solid rgba(255, 255, 255, 0.16);
-    box-shadow: 0 10px 25px rgba(140, 246, 255, 0.2);
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    width: 100%;
-}
-
 .hidden {
     display: none !important;
 }

--- a/public/game.html
+++ b/public/game.html
@@ -39,7 +39,6 @@
                     <span id="discard-count">0</span>
                 </div>
             </div>
-            <div id="last-move" class="last-move-message hidden"></div>
             <div id="stats-panel" class="stats-panel hidden"></div>
         </div>
         

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -16,7 +16,6 @@ document.addEventListener('DOMContentLoaded', () => {
     const gameOverDialog = document.getElementById('game-over');
     const winnersDiv = document.getElementById('winners');
     const finalStatsDiv = document.getElementById('final-stats');
-    const lastMoveDiv = document.getElementById('last-move');
     const playerHand = document.querySelector('.player-hand');
     const playBuilder = document.getElementById('play-builder');
     const playBuilderText = document.getElementById('play-builder-text');
@@ -428,15 +427,6 @@ document.addEventListener('DOMContentLoaded', () => {
       document.querySelectorAll('.piece-split-slider-wrap').forEach(el => el.remove());
       boardSplitMode = false;
     }
-
-    function showLastMove(message) {
-      if (!lastMoveDiv) return;
-      if (message) {
-        lastMoveDiv.textContent = message;
-        lastMoveDiv.classList.remove('hidden');
-      } else {
-        lastMoveDiv.classList.add('hidden');
-      }
     }
 
     function adjustBoardSize() {
@@ -627,9 +617,6 @@ function handleGameStarted(state) {
   updateTurnInfo();
   updateDeckInfo();
   updateStats(state.stats);
-  if (state.lastMove) {
-    showLastMove(state.lastMove);
-  }
   gameOverDialog.classList.add('hidden');
 }
 
@@ -690,9 +677,6 @@ function handlePlayerInfo(data) {
         updateTeams();
         updateDeckInfo(hasCardAnimation ? previousState : state);
         updateStats(state.stats);
-        if (state.lastMove) {
-            showLastMove(state.lastMove);
-        }
         renderPlayBuilder();
 
         await boardAnimationPromise;
@@ -906,9 +890,7 @@ function checkIfStuckInPenalty(cards, canMoveFlag) {
     }
 
     function handleLastMove(data) {
-        if (data && data.message) {
-            showLastMove(data.message);
-        }
+        return data;
     }
 
     function handleValidSplits(data) {


### PR DESCRIPTION
### Motivation
- A faixa que mostrava a última jogada estava exibindo valores inválidos (ex.: `object object`) e quebrando o layout do tabuleiro, e não é necessária para a experiência principal.

### Description
- Removido o elemento visual `#last-move` do layout em `public/game.html`.
- Eliminado o bloco de estilos CSS associado à mensagem da última jogada em `public/css/game.css`.
- Removida a função de renderização `showLastMove` e as chamadas que atualizavam a faixa no frontend, mantendo o handler de socket `handleLastMove` como no-op para preservar compatibilidade com eventos do backend em `public/js/game.js`.

### Testing
- Executado `npm test -- --runInBand` e todas as suítes de teste passaram (`Test Suites: 7 passed`, `Tests: 76 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cf3a4e010832abe9f1af8a9f33af3)