### PR TITLE
Fix syntax error that prevented game initialization

### DIFF
--- a/public/js/game.js
+++ b/public/js/game.js
@@ -427,7 +427,6 @@ document.addEventListener('DOMContentLoaded', () => {
       document.querySelectorAll('.piece-split-slider-wrap').forEach(el => el.remove());
       boardSplitMode = false;
     }
-    }
 
     function adjustBoardSize() {
       const info = document.querySelector('.game-info');


### PR DESCRIPTION
### Motivation
- Fix a JavaScript syntax error in `public/js/game.js` that caused `Uncaught SyntaxError: missing ) after argument list` and prevented the game from initializing.

### Description
- Removed an extraneous closing brace `}` in `public/js/game.js` within the play-builder/board helper area so the file now parses correctly.

### Testing
- Ran a syntax check with `node --check public/js/game.js` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cf93c391c832a8e1fe44074e25c78)