### PR TITLE
Fix card 7 split slider overlap with piece clicks

### DIFF
--- a/public/css/game.css
+++ b/public/css/game.css
@@ -951,8 +951,8 @@
   white-space: nowrap;
 }
 .piece-split-slider-wrap {
-  position: absolute;
-  z-index: 6;
+  position: fixed;
+  z-index: 30;
   display: flex;
   align-items: center;
   gap: 0.25rem;
@@ -962,6 +962,7 @@
   padding: 0.2rem 0.3rem;
   border-radius: 8px;
   border: 1px solid rgba(140, 246, 255, 0.25);
+  pointer-events: auto;
 }
 .piece-split-slider-wrap input[type="range"] { width: 70px; }
 .piece-split-slider-wrap.vertical { flex-direction: column; }

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -914,27 +914,72 @@ function checkIfStuckInPenalty(cards, canMoveFlag) {
       const a = document.querySelector(`.piece[data-id="${selectedPieceId}"]`);
       const b = document.querySelector(`.piece[data-id="${secondPieceId}"]`);
       if (!a || !b) return;
+
       const ra = a.getBoundingClientRect();
       const rb = b.getBoundingClientRect();
+      const boardRect = board.getBoundingClientRect();
       const vertical = Math.abs(ra.left - rb.left) < 40 || Math.abs(ra.top - rb.top) < 40;
-      const mk = (target, isLeft) => {
+
+      const placeWrap = (wrap, pieceRect, isRightSide) => {
+        const offset = 10;
+        const sliderWidth = vertical ? 44 : 150;
+        const sliderHeight = vertical ? 118 : 38;
+        const spaceRight = window.innerWidth - pieceRect.right;
+        const spaceLeft = pieceRect.left;
+
+        let left = pieceRect.left + (pieceRect.width - sliderWidth) / 2;
+        let top = pieceRect.bottom + offset;
+
+        if (top + sliderHeight > boardRect.bottom && !vertical) {
+          top = pieceRect.top - sliderHeight - offset;
+        }
+
+        if (vertical) {
+          if ((isRightSide && spaceRight > sliderWidth + offset) || spaceLeft < sliderWidth + offset) {
+            left = pieceRect.right + offset;
+          } else {
+            left = pieceRect.left - sliderWidth - offset;
+          }
+          top = pieceRect.top + (pieceRect.height - sliderHeight) / 2;
+        }
+
+        left = Math.max(6, Math.min(left, window.innerWidth - sliderWidth - 6));
+        top = Math.max(6, Math.min(top, window.innerHeight - sliderHeight - 6));
+
+        wrap.style.left = `${left}px`;
+        wrap.style.top = `${top}px`;
+      };
+
+      const mk = (pieceRect, isLeft, isRightSide) => {
         const w = document.createElement('div');
         w.className = `piece-split-slider-wrap ${vertical ? 'vertical' : ''}`;
         const out = document.createElement('span');
         const input = document.createElement('input');
         const confirm = document.createElement('button');
-        input.type='range'; input.min=Math.min(...validSplits); input.max=Math.max(...validSplits); input.value=boardSplitValue;
+
+        w.addEventListener('mousedown', (event) => event.stopPropagation());
+        w.addEventListener('click', (event) => event.stopPropagation());
+
+        input.type = 'range';
+        input.min = Math.min(...validSplits);
+        input.max = Math.max(...validSplits);
+        input.value = boardSplitValue;
         input.addEventListener('input',()=>{ let val=parseInt(input.value,10); if(validSplits.length && !validSplits.includes(val)){ val = validSplits.reduce((a,b)=> Math.abs(b-val) < Math.abs(a-val) ? b : a); input.value=val; } boardSplitValue=val; document.querySelectorAll('.piece-split-slider-wrap .val').forEach((el,i)=> el.textContent = i===0?boardSplitValue:7-boardSplitValue); });
+
         confirm.type = 'button';
         confirm.className = 'piece-split-confirm';
         confirm.textContent = '✓';
         confirm.title = 'Confirmar divisão';
         confirm.addEventListener('click', submitSpecialSplit);
+
         out.className='val'; out.textContent = isLeft ? boardSplitValue : 7-boardSplitValue;
         w.append(out,input,confirm);
-        target.appendChild(w);
+        placeWrap(w, pieceRect, isRightSide);
+        document.body.appendChild(w);
       };
-      mk(a,true); mk(b,false);
+
+      mk(ra, true, false);
+      mk(rb, false, true);
       boardSplitMode = true;
     }
 


### PR DESCRIPTION
### Motivation
- The split sliders shown when playing a card 7 were rendered over the pieces and were capturing/propagating pointer events, causing clicks/drags on sliders to be interpreted as clicks on pieces behind them. 
- Sliders must be positioned below or beside the pieces (never on top of the piece hit area) and should not forward clicks to board elements.

### Description
- Change CSS for ` .piece-split-slider-wrap` from `position: absolute` to `position: fixed`, raise `z-index` to `30`, and enable `pointer-events: auto` so the sliders become a dedicated interaction overlay (`public/css/game.css`).
- Rework `renderBoardSplitSliders()` to compute viewport-safe positions and place slider wrappers on `document.body` as fixed overlays that prefer below placement, flip above when there's no space, and place to the side for vertical layouts (`public/js/game.js`).
- Add `stopPropagation` handlers on slider wrappers for `mousedown` and `click` so interactions on sliders no longer trigger board or piece click handlers (`public/js/game.js`).
- Clamp overlay coordinates to the viewport to avoid rendering off-screen and keep existing slider input logic (`min`, `max`, `value`, and `input` handler) intact (`public/js/game.js`).

### Testing
- Ran the test suite with `npm test -- --runInBand`, which executed the project's Jest suites. 
- All automated tests passed: 7 test suites and 76 tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cfb502c68832ab6bbf1bf1de7b603)