### PR TITLE
Corrige slider de divisão da carta 7 que usava valor padrão antigo

### DIFF
--- a/public/js/game.js
+++ b/public/js/game.js
@@ -901,6 +901,7 @@ function checkIfStuckInPenalty(cards, canMoveFlag) {
         splitSlider.min = Math.min(...validSplits);
         splitSlider.max = Math.max(...validSplits);
         const mid = validSplits[Math.floor(validSplits.length / 2)];
+        boardSplitValue = mid;
         splitSlider.value = mid;
         updateSliderValues();
         renderPlayBuilder();


### PR DESCRIPTION
### Motivation
- Corrigir bug em que os controles de divisão da carta `7` exibiam e mantinham valores antigos (ex.: `3/4`) quando o servidor retornava um conjunto restrito de `validSplits`, deixando os sliders visualmente “zerados” e sem resposta.

### Description
- Ao processar a resposta `validSplits` no frontend, inicializar `boardSplitValue` com o ponto médio válido (`mid`) para manter a UI sincronizada, mudando `public/js/game.js` para atribuir `boardSplitValue = mid` em `handleValidSplits`.

### Testing
- Executado `npm test -- --runInBand` a partir da raiz do projeto; a suíte completa de testes passou (`7` suítes, `76` testes, todos aprovados).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cfe8ecd00832a856c3fb31c885d93)