### PR TITLE
Padroniza sliders da carta 7 e sincroniza sliders sobre peças

### DIFF
--- a/public/js/game.js
+++ b/public/js/game.js
@@ -898,8 +898,8 @@ function checkIfStuckInPenalty(cards, canMoveFlag) {
             showStatusMessage('Nenhuma divisão válida disponível', 'error');
             return;
         }
-        splitSlider.min = Math.min(...validSplits);
-        splitSlider.max = Math.max(...validSplits);
+        splitSlider.min = 1;
+        splitSlider.max = 6;
         const mid = validSplits[Math.floor(validSplits.length / 2)];
         boardSplitValue = mid;
         splitSlider.value = mid;
@@ -962,10 +962,20 @@ function checkIfStuckInPenalty(cards, canMoveFlag) {
         w.addEventListener('click', (event) => event.stopPropagation());
 
         input.type = 'range';
-        input.min = Math.min(...validSplits);
-        input.max = Math.max(...validSplits);
-        input.value = boardSplitValue;
-        input.addEventListener('input',()=>{ let val=parseInt(input.value,10); if(validSplits.length && !validSplits.includes(val)){ val = validSplits.reduce((a,b)=> Math.abs(b-val) < Math.abs(a-val) ? b : a); input.value=val; } boardSplitValue=val; document.querySelectorAll('.piece-split-slider-wrap .val').forEach((el,i)=> el.textContent = i===0?boardSplitValue:7-boardSplitValue); });
+        input.min = 1;
+        input.max = 6;
+        input.value = isLeft ? boardSplitValue : 7 - boardSplitValue;
+        input.dataset.side = isLeft ? 'left' : 'right';
+        input.addEventListener('input', () => {
+          let rawVal = parseInt(input.value, 10);
+          if (Number.isNaN(rawVal)) return;
+          let val = input.dataset.side === 'right' ? 7 - rawVal : rawVal;
+          if (validSplits.length && !validSplits.includes(val)) {
+            val = validSplits.reduce((a, b) => Math.abs(b - val) < Math.abs(a - val) ? b : a);
+          }
+          boardSplitValue = val;
+          syncBoardSplitControls();
+        });
 
         confirm.type = 'button';
         confirm.className = 'piece-split-confirm';
@@ -982,6 +992,24 @@ function checkIfStuckInPenalty(cards, canMoveFlag) {
       mk(ra, true, false);
       mk(rb, false, true);
       boardSplitMode = true;
+    }
+
+
+
+    function syncBoardSplitControls() {
+      const leftVal = boardSplitValue;
+      const rightVal = 7 - boardSplitValue;
+
+      document.querySelectorAll('.piece-split-slider-wrap').forEach((wrap) => {
+        const input = wrap.querySelector('input[type="range"]');
+        const out = wrap.querySelector('.val');
+        if (!input || !out) return;
+
+        const side = input.dataset.side || 'left';
+        const sliderVal = side === 'right' ? rightVal : leftVal;
+        input.value = sliderVal;
+        out.textContent = sliderVal;
+      });
     }
 
     function submitSpecialSplit() {


### PR DESCRIPTION
### Motivation
- Padronizar o comportamento do controle de divisão da carta 7 para que o slider represente sempre a escala de `1..6` (todo "percorrido" = 6, todo "zerado" = 1). 
- Garantir que os dois controles exibidos sobre as peças sejam espelhados logicamente e visualmente (quando um mostra `X`, o outro mostra `7 - X`) para evitar inconsistência entre números e progresso do slider.

### Description
- `handleValidSplits` agora fixa a faixa do slider principal com `splitSlider.min = 1` e `splitSlider.max = 6` e continua setando `splitSlider.value` ao valor médio válido. 
- Os sliders renderizados sobre cada peça agora usam faixa fixa `1..6`, armazenam o lado com `input.dataset.side = 'left'|'right'` e inicializam `input.value` com `left = boardSplitValue` e `right = 7 - boardSplitValue`.
- O listener dos sliders de peça converte corretamente o valor do lado direito para seu complementar (`7 - rawVal`), valida contra `validSplits` e atualiza o valor central `boardSplitValue` antes de sincronizar os controles. 
- Adicionada a função `syncBoardSplitControls()` que atualiza ambos os sliders e os rótulos numéricos para manter o espelhamento visual e lógico entre os dois controles.

### Testing
- Executei a checagem sintática de JavaScript com `node --check public/js/game.js` e ela passou sem erros.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d03e27ea8832aa6c418df28cb19c2)