### PR TITLE
Keep moving pieces visible as semi‑transparent before animations

### DIFF
--- a/public/css/game.css
+++ b/public/css/game.css
@@ -205,6 +205,10 @@
     --piece-shadow: #3da866;
 }
 
+.piece.pre-move-transparent {
+    opacity: 0.4;
+}
+
 .piece.moving {
     z-index: 12;
     box-shadow: 0 14px 24px rgba(0,0,0,0.45), 0 0 0 4px rgba(255,255,255,0.55), 0 0 32px rgba(255, 236, 122, 0.9);

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -1432,7 +1432,7 @@ function updatePlayerLabels() {
     if (moved) {
       cancelElementAnimations(pieceElement);
       pieceElement.style.transition = 'none';
-      pieceElement.style.visibility = 'hidden';
+      pieceElement.classList.add('pre-move-transparent');
     }
 
     cell.appendChild(pieceElement);
@@ -1457,7 +1457,7 @@ function updatePlayerLabels() {
       // Mantém a peça real invisível até o instante em que a animação do
       // tabuleiro começa. Assim, se o navegador pintar entre o append na célula
       // final e o início da WAAPI, ele nunca exibe um frame no destino.
-      pieceElement.style.visibility = 'hidden';
+      pieceElement.classList.add('pre-move-transparent');
       animations.push({
         element: pieceElement,
         from: moveDescriptor ? moveDescriptor.from : previousPiece.position,
@@ -1468,7 +1468,7 @@ function updatePlayerLabels() {
         finalTransform: `rotate(${-rotation}deg)`
       });
     } else {
-      pieceElement.style.visibility = '';
+      pieceElement.classList.remove('pre-move-transparent');
     }
   });
 
@@ -1504,7 +1504,7 @@ async function animatePieceMoves(animations) {
     animation.element.classList.add('moving');
     animation.element.style.transition = 'none';
     animation.element.style.transform = animation.initialTransform || animation.keyframes[0].transform;
-    animation.element.style.visibility = '';
+    animation.element.classList.remove('pre-move-transparent');
     await waitForNextFrame();
     const movement = animation.element.animate(animation.keyframes, {
       duration: MOVE_ANIMATION_DURATION_MS,
@@ -1518,7 +1518,7 @@ async function animatePieceMoves(animations) {
       // A animação pode ser cancelada por uma atualização mais nova do estado.
     } finally {
       animation.element.style.transform = animation.finalTransform;
-      animation.element.style.visibility = '';
+      animation.element.classList.remove('pre-move-transparent');
       movement.cancel();
       animation.element.classList.remove('moving');
     }


### PR DESCRIPTION
### Motivation
- Evitar o breve "apagão" das peças envolvidas numa jogada mostrando quais serão movidas ao deixá‑las semi‑transparentes antes da animação começar.

### Description
- Substitui o uso de `style.visibility = 'hidden'` por adicionar/remover a classe `pre-move-transparent` em `public/js/game.js` e adiciona a regra CSS `.piece.pre-move-transparent { opacity: 0.4; }` em `public/css/game.css` para manter as peças visíveis porém desbotadas enquanto aguardam a animação.

### Testing
- Executei `npm test -- --runInBand` e todos os testes automatizados passaram (7 test suites, 76 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0db6d5846c832aad038fc463c81a16)