### PR TITLE
Filter intermediate '7' replay snapshots so each player move is a single step

### DIFF
--- a/server/__tests__/replay_utils.test.js
+++ b/server/__tests__/replay_utils.test.js
@@ -37,4 +37,25 @@ describe('replayHistoryForSave', () => {
     expect(isIntermediateJokerReplayEntry(finalJoker)).toBe(false);
     expect(replayHistoryForSave([finalJoker])).toEqual([finalJoker]);
   });
+
+  test('hides intermediate snapshots for card 7 before the turn advances', () => {
+    const intermediateSeven = {
+      move: 'Alice jogou um 7',
+      state: {
+        players,
+        currentPlayerIndex: 0,
+        pieces: [{ id: 'p0_1', inHomeStretch: true }]
+      }
+    };
+    const finalSeven = {
+      move: 'Alice jogou um 7',
+      state: {
+        players,
+        currentPlayerIndex: 1,
+        discardPile: [{ value: '7' }]
+      }
+    };
+
+    expect(replayHistoryForSave([intermediateSeven, finalSeven])).toEqual([finalSeven]);
+  });
 });

--- a/server/replay_utils.js
+++ b/server/replay_utils.js
@@ -16,8 +16,15 @@ function isJokerMove(entry) {
   return /(?:\bC\b|JOKER|Joker)/.test(move);
 }
 
-function isIntermediateJokerReplayEntry(entry) {
-  if (!isJokerMove(entry)) {
+function isSevenMove(entry) {
+  const move = entry && entry.move;
+  if (!move) return false;
+
+  return /(?:\b7\b)/.test(move);
+}
+
+function isIntermediateSpecialReplayEntry(entry) {
+  if (!isJokerMove(entry) && !isSevenMove(entry)) {
     return false;
   }
 
@@ -32,13 +39,17 @@ function isIntermediateJokerReplayEntry(entry) {
   );
 }
 
+function isIntermediateJokerReplayEntry(entry) {
+  return isIntermediateSpecialReplayEntry(entry) && isJokerMove(entry);
+}
+
 function replayHistoryForSave(history) {
   if (!Array.isArray(history)) {
     return [];
   }
 
   return history
-    .filter(entry => !isIntermediateJokerReplayEntry(entry))
+    .filter(entry => !isIntermediateSpecialReplayEntry(entry))
     .map(entry => JSON.parse(JSON.stringify(entry)));
 }
 


### PR DESCRIPTION
### Motivation
- Replays were storing intermediate snapshots for card `7`, causing a single player move to appear as multiple steps and forcing multiple `next` clicks to advance a turn. 
- The intent is to make each `next` correspond to a single player turn regardless of internal piece submoves.

### Description
- Added `isSevenMove` and a shared `isIntermediateSpecialReplayEntry` predicate to detect intermediate snapshots for both Joker and `7` moves in `server/replay_utils.js`.
- Reworked `isIntermediateJokerReplayEntry` to reuse the shared predicate and changed `replayHistoryForSave` to filter out any intermediate special entries via `isIntermediateSpecialReplayEntry`.
- Added a regression test in `server/__tests__/replay_utils.test.js` that ensures intermediate `7` snapshots are removed and only the final state is kept.

### Testing
- Ran `npm test -- --runTestsByPath server/__tests__/replay_utils.test.js` and the test suite passed (3 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0df340275c832ab804e4f60bccb494)