### PR TITLE
Persist originalId and accept it for reconnection to avoid false "player not found" / "room full" errors

### DIFF
--- a/server/game.js
+++ b/server/game.js
@@ -84,6 +84,7 @@ class Game {
     
     this.players.push({
       id,
+      originalId: id,
       name,
       cards: [],
       position: this.players.length, // 0, 1, 2 ou 3
@@ -1670,4 +1671,3 @@ discardCard(cardIndex) {
 }
 
 module.exports = { Game };
-

--- a/server/server.js
+++ b/server/server.js
@@ -82,7 +82,9 @@ function validateReconnectionPlayer(game, playerName, originalId, originalPositi
     return -1;
   }
 
-  const byIdIndex = game.players.findIndex((player) => player.id === originalId);
+  const byIdIndex = game.players.findIndex(
+    (player) => player.id === originalId || player.originalId === originalId
+  );
   if (byIdIndex === -1) {
     return -1;
   }
@@ -400,7 +402,11 @@ socket.on('joinRoom', ({ roomId, playerName, originalPosition, originalId }) => 
     if (position >= 0 && position < game.players.length) {
       const player = game.players[position];
       
-      if (player && player.name === sanitizedPlayerName && player.id === originalId) {
+      if (
+        player &&
+        player.name === sanitizedPlayerName &&
+        (player.id === originalId || player.originalId === originalId)
+      ) {
         console.log(`Reconexão do jogador ${playerName} na posição ${position}`);
 
         // Cancelar limpeza da sala se estava agendada
@@ -693,7 +699,11 @@ socket.on('requestGameState', ({ roomId, playerName, originalId }) => {
   }
   
   // Encontrar o jogador pelo nome
-  const playerIndex = game.players.findIndex((p) => p.name === sanitizedPlayerName && p.id === originalId);
+  const playerIndex = game.players.findIndex(
+    (p) =>
+      p.name === sanitizedPlayerName &&
+      (p.id === originalId || p.originalId === originalId)
+  );
   
   if (playerIndex !== -1) {
     // Cancelar limpeza da sala se estava agendada
@@ -1355,4 +1365,3 @@ if (require.main === module) {
 }
 
 module.exports = { app, server };
-


### PR DESCRIPTION
### Motivation

- Reconexões falhavam quando o `socket.id` mudava, levando a erros "Jogador não encontrado na sala" e a caminhos que retornavam "Sala cheia" indevidamente.
- É necessário um identificador estável para reconhecer jogadores após refresh/rotinas de reconexão sem depender apenas de `socket.id`.

### Description

- Persisti um identificador estável `originalId` no objeto do jogador ao adicioná-lo em `server/game.js` inserindo `originalId: id` ao criar a entrada de `players`.
- Atualizei a função `validateReconnectionPlayer` em `server/server.js` para comparar tanto `player.id` quanto `player.originalId` ao localizar o jogador por id.
- Ajustei o fluxo de `joinRoom` em `server/server.js` para reconhecer reconexões verificando `player.id === originalId || player.originalId === originalId` antes de tratar como novo jogador.
- Apliquei a mesma regra de correspondência em `requestGameState` para evitar o erro "Jogador não encontrado na sala" durante sincronizações de estado.

### Testing

- Executei a suíte de testes com `npm test -- --runInBand` e todos os testes passaram; resultado: 7 test suites e 77 testes, todos `PASS`.
- Não houve testes automatizados falhando relacionados às mudanças introduzidas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e5c8d5618832a93add88938761342)