### PR TITLE
Fix split-7 suggestions to respect selected piece order

### DIFF
--- a/game-ai-training/game/game.js
+++ b/game-ai-training/game/game.js
@@ -1577,7 +1577,14 @@ class Game {
       ];
       const clone = this.cloneForSimulation();
       try {
-        clone.makeSpecialMove(moves);
+        // Validate split using the exact piece order selected in the UI.
+        // `makeSpecialMove` can auto-retry with reversed order after a failure,
+        // which is correct for execution but wrong for slider suggestions.
+        for (const move of moves) {
+          const piece = clone.pieces.find(p => p.id === move.pieceId);
+          if (!piece) throw new Error('Peça inválida');
+          clone.movePieceForward(piece, move.steps, null);
+        }
         valid.push(s);
       } catch (e) {
         continue;

--- a/server/game.js
+++ b/server/game.js
@@ -1607,7 +1607,14 @@ discardCard(cardIndex) {
       ];
       const clone = this.cloneForSimulation();
       try {
-        clone.makeSpecialMove(moves);
+        // Validate split using the exact piece order selected in the UI.
+        // `makeSpecialMove` can auto-retry with reversed order after a failure,
+        // which is correct for execution but wrong for slider suggestions.
+        for (const move of moves) {
+          const piece = clone.pieces.find(p => p.id === move.pieceId);
+          if (!piece) throw new Error('Peça inválida');
+          clone.movePieceForward(piece, move.steps, null);
+        }
         valid.push(s);
       } catch (e) {
         continue;


### PR DESCRIPTION
### Motivation
- The UI slider for splitting a `7` card showed invalid `s` values when a candidate only worked if the two-piece move order was reversed. 
- `makeSpecialMove` silently retries two-move splits in reversed order for execution robustness, which made `getValidSplits` report choices that were not valid for the specific piece order selected in the UI.

### Description
- Rewrote `getValidSplits` in `server/game.js` and `game-ai-training/game/game.js` to validate split candidates by simulating each move in the exact piece order selected instead of calling `makeSpecialMove`.
- The new validation uses `clone.movePieceForward(piece, steps, null)` for each move on a simulation clone and preserves order, preventing suggestions that rely on an internal reversed-order retry.
- Kept explanatory comments near the change so future readers understand why `makeSpecialMove` is not used for UI split validation.

### Testing
- Ran the targeted Jest tests with `npm test -- --runInBand game-ai-training/tests/game_wrapper.test.js`.
- Test suite passed: `15` tests in `game-ai-training/tests/game_wrapper.test.js` all succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11afd6ec7c832aa5214adc8cf39caf)