### PR TITLE
Fix forced-discard UI state on first turn

### DIFF
--- a/public/js/game.js
+++ b/public/js/game.js
@@ -852,13 +852,16 @@ function flushDeferredTurnEvents() {
 
 // Adicione esta função para verificar se o jogador está preso no castigo
 function checkIfStuckInPenalty(cards, canMoveFlag) {
-  if (!gameState || !gameState.pieces) return;
-
   const cardElements = cardsContainer.querySelectorAll('.card');
 
   if (canMoveFlag === false) {
     showStatusMessage('Você não tem jogadas possíveis. Selecione uma carta para descartar.', 'error');
     cardElements.forEach(card => card.classList.add('discard-only'));
+    return;
+  }
+
+  if (!gameState || !gameState.pieces) {
+    cardElements.forEach(card => card.classList.remove('discard-only'));
     return;
   }
 
@@ -872,7 +875,7 @@ function checkIfStuckInPenalty(cards, canMoveFlag) {
   } else {
     cardElements.forEach(card => card.classList.remove('discard-only'));
     showStatusMessage('É sua vez de jogar!', 'turn');
-  renderPlayBuilder();
+    renderPlayBuilder();
   }
 }
 


### PR DESCRIPTION
### Motivation
- Players could be stuck on the first round when forced to discard: the UI showed cards as playable and the `discard-only` state only appeared after a refresh because `gameState.pieces` was not yet available when the server sent `canMove: false`.

### Description
- Updated `public/js/game.js` in the `checkIfStuckInPenalty` function to apply forced-discard immediately when `canMove === false` so the discard UI is enabled even if `gameState.pieces` is not yet present.
- Added a safe fallback that clears any stale `discard-only` classes when `gameState` or `gameState.pieces` is temporarily unavailable to avoid inconsistent UI.
- Kept existing behavior that marks cards `discard-only` when all player pieces are in penalty and no exit card (`A,K,Q,J`) is present, and ensured `renderPlayBuilder()` is called after restoring normal state.

### Testing
- Ran the full Jest suite with `npm test -- --runInBand` and all test suites passed (`7` suites, `77` tests) successfully.
- Verified the change modifies only `public/js/game.js` and committed the fix as `Fix discard-only state on first forced-discard turn`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11bb71b084832aab17ba3e905a5f27)