### PR TITLE
Fix hover move preview to use live piece state

### DIFF
--- a/public/js/game.js
+++ b/public/js/game.js
@@ -1470,7 +1470,9 @@ function updatePlayerLabels() {
       });
       pieceElement.addEventListener('mouseenter', () => {
         if (selectedCardIndex === null || selectedPieceId) return;
-        showMovePreview(piece, playerCards[selectedCardIndex]);
+        const livePiece = gameState?.pieces?.find(currentPiece => currentPiece.id === piece.id);
+        if (!livePiece) return;
+        showMovePreview(livePiece, playerCards[selectedCardIndex]);
       });
       pieceElement.addEventListener('mouseleave', clearMovePreview);
       ensurePieceLabel(pieceElement, piece);


### PR DESCRIPTION
### Motivation
- Hover preview handlers captured the original `piece` snapshot when DOM elements were created, which caused destination previews to break for pieces that later changed state (for example, leaving the penalty zone).

### Description
- Change the `mouseenter` handler in `public/js/game.js` to resolve the current piece from `gameState` (via `gameState?.pieces?.find(...)`) and pass that live object to `showMovePreview`, leaving `mouseleave` and other logic unchanged.

### Testing
- Ran `node --check public/js/game.js` which completed successfully with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11bc344b94832ab1b81333ad26c626)