### PR TITLE
Fix hover preview ownership and restore 7-split preview

### DIFF
--- a/public/js/game.js
+++ b/public/js/game.js
@@ -1198,6 +1198,8 @@ function checkIfStuckInPenalty(cards, canMoveFlag) {
     function updateSplitMovePreview() {
       clearMovePreview();
       if (!boardSplitMode || !selectedPieceId || !secondPieceId) return;
+      const leftVal = boardSplitValue;
+      const rightVal = 7 - boardSplitValue;
       const pieceA = gameState?.pieces?.find((p) => p.id === selectedPieceId);
       const pieceB = gameState?.pieces?.find((p) => p.id === secondPieceId);
       if (!pieceA || !pieceB) return;
@@ -1556,9 +1558,9 @@ function updatePlayerLabels() {
         handlePieceClick(piece.id);
       });
       pieceElement.addEventListener('mouseenter', () => {
-        if (selectedCardIndex === null || selectedPieceId) return;
+        if (!isMyTurn || selectedCardIndex === null || selectedPieceId) return;
         const livePiece = gameState?.pieces?.find(currentPiece => currentPiece.id === piece.id);
-        if (!livePiece) return;
+        if (!livePiece || !canControlPiece(playerPosition, livePiece.playerId)) return;
         showMovePreview(livePiece, playerCards[selectedCardIndex]);
       });
       pieceElement.addEventListener('mouseleave', clearMovePreview);


### PR DESCRIPTION
### Motivation
- Corrigir o comportamento que mostrava previsões de movimento ao passar o mouse sobre peças adversárias e restaurar a visualização do split da carta `7` que não aparecia durante a abertura/ajuste dos sliders.

### Description
- Em `public/js/game.js` a `mouseenter` da peça agora verifica `isMyTurn` e `canControlPiece(playerPosition, livePiece.playerId)` antes de chamar `showMovePreview`, evitando prévias em peças que o jogador não controla; também foi reinserida a inicialização de `leftVal`/`rightVal` em `updateSplitMovePreview` para que o preview do split-7 seja calculado corretamente.

### Testing
- Executei os testes automatizados com `npm test -- --runInBand` e todas as suítes Jest passaram (`7` de `7`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a147ef9cf60832aaccb2182e6439986)