### PR TITLE
Allow tournament games to bypass forced action constraints

### DIFF
--- a/game-ai-training/ai/environment.py
+++ b/game-ai-training/ai/environment.py
@@ -86,7 +86,13 @@ def prioritize_home_entry_actions(valid_actions: List[int], home_entry_actions: 
 
 
 class GameEnvironment:
-    def __init__(self, env_id: int = 0, pieces_per_player: int = 5, turn_limit: int = 500):
+    def __init__(
+        self,
+        env_id: int = 0,
+        pieces_per_player: int = 5,
+        turn_limit: int = 500,
+        enforce_action_constraints: bool = True,
+    ):
         self.node_process = None
         self.game_state = None
         self.action_space_size = 80
@@ -95,6 +101,10 @@ class GameEnvironment:
 
         self.pieces_per_player = pieces_per_player
         self.turn_limit = turn_limit
+        # Training uses strict action constraints to shape policy behavior.
+        # Tournament evaluation can disable these constraints to let bots
+        # choose from the full legal action set.
+        self.enforce_action_constraints = enforce_action_constraints
 
         # identifier for logging when multiple environments are used
         self.env_id = env_id
@@ -851,7 +861,7 @@ class GameEnvironment:
             act for act in self.last_home_entry_actions.get(player_id, []) if act in valid_action_set
         ]
         self.last_home_entry_actions[player_id] = home_entry_actions
-        if home_entry_actions:
+        if home_entry_actions and self.enforce_action_constraints:
             # Homestretch entry is a rule-level priority for the training policy:
             # when any legal action can enter home, mask out every alternative so
             # the bot cannot learn to prefer captures, setup moves, or discards.
@@ -865,7 +875,7 @@ class GameEnvironment:
             act for act in self.last_home_stretch_move_actions.get(player_id, []) if act in valid_action_set
         ]
         self.last_home_stretch_move_actions[player_id] = home_stretch_move_actions
-        if home_stretch_move_actions:
+        if home_stretch_move_actions and self.enforce_action_constraints:
             # Once a piece is already in the homestretch, moving it deeper with
             # A/2/3/4 or a split 7 is mandatory so bots keep organizing pieces
             # instead of wasting winning positions on unrelated moves.

--- a/game-ai-training/tournament.py
+++ b/game-ai-training/tournament.py
@@ -166,7 +166,7 @@ def play_game(env: GameEnvironment, bots: List[GameBot]) -> List[int]:
 
 def run_single_game(game_index: int, seats: List[str], team0: str, team1: str) -> Dict[str, object]:
     """Run one tournament match in an isolated environment."""
-    env = GameEnvironment()
+    env = GameEnvironment(enforce_action_constraints=False)
     if not env.start_node_game():
         raise RuntimeError("Failed to start game process")
 


### PR DESCRIPTION
### Motivation
- Tournament runs should evaluate bots using the full legal action set instead of forcing homestretch/home-entry tactical moves that are useful for training but undesired for evaluation.
- Make the constraint opt-out so training behavior remains unchanged by default.

### Description
- Added an `enforce_action_constraints: bool = True` parameter to `GameEnvironment.__init__` to control whether the environment enforces forced action subsets during `get_valid_actions`.
- Conditioned the mandatory homestretch entry and home-stretch move filtering in `get_valid_actions` on `self.enforce_action_constraints` so the environment can return the full non-entry action set when disabled.
- Updated the tournament runner to instantiate the environment with `GameEnvironment(enforce_action_constraints=False)` so tournament matches use the full legal action set.
- Changes are limited to `game-ai-training/ai/environment.py` and `game-ai-training/tournament.py` and keep training defaults intact.

### Testing
- Ran `python3 -m py_compile game-ai-training/ai/environment.py game-ai-training/tournament.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14c89ce7c4832aa9742a17dc5b5af1)