### PR TITLE
Tune reward weights to emphasize home entry and tactical bonuses; minor whitespace cleanup

### DIFF
--- a/game-ai-training/ai/trainer.py
+++ b/game-ai-training/ai/trainer.py
@@ -176,7 +176,6 @@ class TrainingManager:
             limit += int(STAGE5_TURN_LIMIT_BOOST)
         return limit
 
-    
     def create_bots(self, num_bots=4):
         self.bots = []
         self.trainable_bots = []

--- a/game-ai-training/config.py
+++ b/game-ai-training/config.py
@@ -97,15 +97,15 @@ REWARD_WEIGHTS = {
     # before to reduce farming of intermediate rewards without closing games.
     'home_completion': 35.0,
     # Make homestretch entry overwhelmingly preferred whenever it is available.
-    'home_entry': 250.0,
+    'home_entry': 420.0,
     # Heavily punish rejecting or missing a valid home entry so bots learn this
     # is never an acceptable alternative to entering the homestretch.
-    'skip_home': -250.0,
-    'missed_home_entry': -250.0,
+    'skip_home': -420.0,
+    'missed_home_entry': -420.0,
     # Small tactical bonuses to improve credit assignment.
-    'home_entry_progress': 1.0,
-    'capture': 2.0,
-    'safe_move': 1.0,
+    'home_entry_progress': 2.5,
+    'capture': 3.0,
+    'safe_move': 1.5,
     # Team outcome signal.
     'win': 100.0,
     'loss': -80.0,


### PR DESCRIPTION
### Motivation
- Increase the learning signal for entering the homestretch and punish skipping/missed entries to drive stronger homestretch behavior.
- Amplify small tactical rewards to improve credit assignment for captures, progress and safe moves.
- Keep code tidy by removing a stray trailing whitespace in `trainer.py`.

### Description
- Adjusted `REWARD_WEIGHTS` in `game-ai-training/config.py` to increase `home_entry` from `250.0` to `420.0` and make `skip_home` and `missed_home_entry` stronger penalties from `-250.0` to `-420.0`.
- Increased tactical reward magnitudes: `home_entry_progress` `1.0` -> `2.5`, `capture` `2.0` -> `3.0`, and `safe_move` `1.0` -> `1.5`.
- Left other reward and curriculum constants unchanged to preserve existing training schedule behavior.
- Removed an extraneous trailing whitespace in `game-ai-training/ai/trainer.py`.

### Testing
- Ran the test suite with `pytest -q`, and all unit tests completed successfully.
- Ran static checks with `flake8` and no linting errors were reported.
- Verified that the modified `REWARD_WEIGHTS` load without parse errors by importing the config module in a quick smoke test.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14cc138598832a81c1071d80e15c84)