### PR TITLE
Detach rollout tensors to fix PPO autograd inplace error

### DIFF
--- a/game-ai-training/ai/bot.py
+++ b/game-ai-training/ai/bot.py
@@ -111,9 +111,11 @@ class GameBot:
             dist = torch.distributions.Categorical(probs)
             action = dist.sample()
 
-            self.last_log_prob = dist.log_prob(action)
+            # Store rollout statistics detached from the forward graph.
+            # PPO uses these as fixed "old policy/value" references during replay.
+            self.last_log_prob = dist.log_prob(action).detach()
             self.last_entropy = dist.entropy().item()
-            self.last_value = value.squeeze(0)
+            self.last_value = value.squeeze(0).detach()
             return int(action.item())
 
     def remember(self, state, action, reward, next_state, done, game_won=False, extra_advantage: float = 0.0):
@@ -125,8 +127,8 @@ class GameBot:
                     action,
                     reward,
                     done,
-                    self.last_log_prob,
-                    self.last_value,
+                    self.last_log_prob.detach(),
+                    self.last_value.detach(),
                     self.last_entropy,
                     game_won,
                     extra_advantage,


### PR DESCRIPTION
### Motivation
- Rollout tensors (`log_prob` and `value`) were being stored still attached to the autograd graph, which led to PyTorch version-counter/in-place errors during `loss.backward()` once model parameters changed between rollout and replay.

### Description
- Detach `log_prob` and `value` in `act()` so stored rollout statistics are graph-free old-policy/value references (`dist.log_prob(action).detach()` and `value.squeeze(0).detach()`).
- Also defensively call `.detach()` again when appending these tensors to memory to ensure replay uses immutable tensors.
- Change made in `game-ai-training/ai/bot.py` with a short explanatory comment above the detach calls.

### Testing
- Ran `pytest -q tests/test_bot.py tests/test_trainer.py` and all tests in those suites passed.
- Ran the full suite with `pytest -q` which reproduced one unrelated pre-existing failure in `tests/test_environment.py::test_eight_setup_rewards_reach_and_boosts_next_home_entry` (33 passed, 1 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14e2f6fe74832aaf5d3ede0531629d)