### PR TITLE
Centraliza sliders da carta 7 no mobile e adiciona rótulos de peça

### DIFF
--- a/public/css/game.css
+++ b/public/css/game.css
@@ -978,6 +978,21 @@
   border: 1px solid rgba(140, 246, 255, 0.25);
   pointer-events: auto;
 }
+
+.piece-split-piece-label {
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  opacity: 0.95;
+}
+.piece-split-slider-wrap .val {
+  min-width: 1.1rem;
+  text-align: center;
+  font-weight: 700;
+}
+.piece-split-slider-wrap.mobile-centered {
+  flex-direction: row;
+}
 .piece-split-slider-wrap input[type="range"] { width: 70px; }
 .piece-split-slider-wrap.vertical { flex-direction: column; }
 .piece-split-confirm {

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -1110,6 +1110,7 @@ function checkIfStuckInPenalty(cards, canMoveFlag) {
         return clampPosition({ left, top }, size);
       };
 
+      const isMobileSplitLayout = window.matchMedia('(max-width: 768px)').matches;
       const leftHorizontal = computePosition(ra, false, false, true);
       const rightHorizontal = computePosition(rb, true, false, false);
       const hSize = dims(false);
@@ -1131,10 +1132,32 @@ function checkIfStuckInPenalty(cards, canMoveFlag) {
         rightPosition = computeDiagonalPosition(rb, pairCenter, 'right');
       }
 
+      if (isMobileSplitLayout) {
+        const size = dims(false);
+        const boardCenterX = boardRect.left + (boardRect.width / 2);
+        const boardCenterY = boardRect.top + (boardRect.height / 2);
+        const horizontalGap = 12;
+        leftPosition = clampPosition({
+          left: boardCenterX - size.width - horizontalGap,
+          top: boardCenterY - (size.height / 2)
+        }, size);
+        rightPosition = clampPosition({
+          left: boardCenterX + horizontalGap,
+          top: boardCenterY - (size.height / 2)
+        }, size);
+      }
+
+      const pieceNumberFromId = (pieceId) => {
+        if (!pieceId) return '?';
+        const m = pieceId.match(/_(\d+)$/);
+        return m ? m[1] : pieceId;
+      };
+
       const mk = (isLeft, position) => {
         const w = document.createElement('div');
-        w.className = `piece-split-slider-wrap ${vertical ? 'vertical' : ''}`;
+        w.className = `piece-split-slider-wrap ${vertical ? 'vertical' : ''} ${isMobileSplitLayout ? 'mobile-centered' : ''}`;
         const out = document.createElement('span');
+        const label = document.createElement('span');
         const input = document.createElement('input');
         const confirm = document.createElement('button');
 
@@ -1163,8 +1186,10 @@ function checkIfStuckInPenalty(cards, canMoveFlag) {
         confirm.title = 'Confirmar divisão';
         confirm.addEventListener('click', submitSpecialSplit);
 
+        label.className = 'piece-split-piece-label';
+        label.textContent = `Peça ${pieceNumberFromId(isLeft ? selectedPieceId : secondPieceId)}`;
         out.className='val'; out.textContent = isLeft ? boardSplitValue : 7-boardSplitValue;
-        w.append(out,input,confirm);
+        w.append(label, out, input, confirm);
         w.style.left = `${position.left}px`;
         w.style.top = `${position.top}px`;
         document.body.appendChild(w);


### PR DESCRIPTION
### Motivation
- Evitar que os dois sliders da carta 7 se sobreponham em telas móveis ao posicioná-los de forma previsível no centro do tabuleiro.
- Tornar mais claro qual peça cada slider controla exibindo uma identificação textual do número da peça.

### Description
- Reposiciona os sliders flutuantes para layout mobile detectado com `window.matchMedia('(max-width: 768px)')` e ancora um slider à esquerda do centro do tabuleiro e outro à direita em `public/js/game.js`.
- Adiciona o helper `pieceNumberFromId` para extrair o número da peça a partir do `pieceId` e renderiza um rótulo `Peça N` em cada controle no DOM (`public/js/game.js`).
- Atualiza a classe do wrapper para incluir `mobile-centered` quando aplicável e insere o rótulo antes do valor/controle no markup (`public/js/game.js`).
- Insere estilos em `public/css/game.css` para `.piece-split-piece-label`, ajuste de `.val` e comportamento de `.piece-split-slider-wrap.mobile-centered` para acomodar o novo rótulo e manter legibilidade.

### Testing
- Executei a suíte de testes com `npm test -- --runInBand`, que passou com sucesso: 7 suites e 77 testes aprovados.
- Não foram introduzidos testes automatizados novos para a UI; alterações validadas por inspeção e execução dos testes existentes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1799b2e5c0832aadb92919b7c61084)