### PR TITLE
Fix card-7 split slider placement near board bottom

### DIFF
--- a/public/js/game.js
+++ b/public/js/game.js
@@ -1068,7 +1068,6 @@ function checkIfStuckInPenalty(cards, canMoveFlag) {
 
       const computeDiagonalPosition = (pieceRect, pairCenter, sideHint) => {
         const size = dims(false);
-        const boardCenterX = boardRect.left + boardRect.width / 2;
         const boardCenterY = boardRect.top + boardRect.height / 2;
         const isNearTop = pairCenter.y < boardCenterY;
         const horizontalSide = sideHint || (pieceRect.left + pieceRect.width / 2 < pairCenter.x ? 'left' : 'right');
@@ -1076,9 +1075,14 @@ function checkIfStuckInPenalty(cards, canMoveFlag) {
         const left = horizontalSide === 'left'
           ? pieceRect.left - size.width - offset
           : pieceRect.right + offset;
-        const top = isNearTop
+        let top = isNearTop
           ? pieceRect.bottom + offset
           : pieceRect.top - size.height - offset;
+
+        const overTop = top < boardRect.top;
+        const overBottom = top + size.height > boardRect.bottom;
+        if (overTop && !overBottom) top = pieceRect.bottom + offset;
+        if (overBottom && !overTop) top = pieceRect.top - size.height - offset;
 
         return clampPosition({ left, top }, size);
       };


### PR DESCRIPTION
### Motivation
- A posição diagonal dos sliders usados pela carta 7 podia extrapolar o limite inferior do tabuleiro quando as peças selecionadas estavam próximas, causando overlay inconsistente em relação à mesma lógica aplicada no topo.

### Description
- Atualiza `computeDiagonalPosition` em `public/js/game.js` para checar `overTop` e `overBottom` e inverter a posição vertical do slider quando a posição preferida extrapola os limites do tabuleiro antes de aplicar `clampPosition`.

### Testing
- Executei `npm test -- --runInBand` e todos os testes automatizados passaram (7 suítes, 77 testes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a179ca1a0fc832a90e3f5b82e0a8605)